### PR TITLE
Refine pre-alloc strategy

### DIFF
--- a/crates/driver/src/infra/solver/mod.rs
+++ b/crates/driver/src/infra/solver/mod.rs
@@ -566,10 +566,10 @@ fn serialize_body(auction_dto: solvers_dto::auction::Auction) -> Bytes {
         (true, true) => &AUCTION_WITH_LIQUIDITY,
     };
 
-    // pre-allocate biggest request size + 0.1% (to avoid re-allocations when
+    // pre-allocate biggest request size + 0.5% (to avoid re-allocations when
     // the request grows only slightly)
     let pre_alloc_size = memory_target.load(Ordering::Relaxed);
-    let pre_alloc_size = pre_alloc_size + pre_alloc_size / 1_000;
+    let pre_alloc_size = pre_alloc_size + pre_alloc_size * 5 / 1_000;
     let mut buffer = Vec::with_capacity(pre_alloc_size);
 
     serde_json::to_writer(&mut buffer, &auction_dto).unwrap();

--- a/crates/driver/src/infra/solver/mod.rs
+++ b/crates/driver/src/infra/solver/mod.rs
@@ -577,7 +577,7 @@ fn serialize_body(auction_dto: solvers_dto::auction::Auction) -> Bytes {
     // now that we now how much memory was actually needed we update the memory
     // targets
     memory_target.fetch_max(buffer.len(), Ordering::Relaxed);
-    tracing::debug!(pre_alloc_size, final_size = buffer.len(), "body allocation");
+    tracing::trace!(pre_alloc_size, final_size = buffer.len(), "body allocation");
 
     Bytes::from(buffer)
 }

--- a/crates/driver/src/infra/solver/mod.rs
+++ b/crates/driver/src/infra/solver/mod.rs
@@ -35,6 +35,7 @@ use {
     reqwest::header::HeaderName,
     std::{
         collections::HashMap,
+        sync::atomic::{AtomicUsize, Ordering},
         time::{Duration, Instant},
     },
     thiserror::Error,
@@ -376,26 +377,19 @@ impl Solver {
         // Fetch the solutions from the solver.
         let weth = self.eth.contracts().weth_address();
 
-        let body = {
-            let auction_dto = dto::auction::new(
-                auction,
-                liquidity,
-                weth,
-                self.config.fee_handler,
-                self.config.solver_native_token,
-                &flashloan_hints,
-                &wrappers,
-                auction.deadline(self.timeouts()).solvers(),
-                self.config.haircut_bps,
-            );
+        let auction_dto = dto::auction::new(
+            auction,
+            liquidity,
+            weth,
+            self.config.fee_handler,
+            self.config.solver_native_token,
+            &flashloan_hints,
+            &wrappers,
+            auction.deadline(self.timeouts()).solvers(),
+            self.config.haircut_bps,
+        );
 
-            // pre-allocate a big enough buffer to avoid re-allocating memory
-            // as the request gets serialized
-            const BYTES_PER_ORDER: usize = 1_300;
-            let mut buffer = Vec::with_capacity(auction.orders().len() * BYTES_PER_ORDER);
-            serde_json::to_writer(&mut buffer, &auction_dto).unwrap();
-            Bytes::from(buffer)
-        };
+        let body = serialize_body(auction_dto);
 
         if let Some(id) = auction.id() {
             // Only auctions with IDs are real auctions (/quote requests don't have an ID).
@@ -547,6 +541,45 @@ impl Solver {
     pub fn config(&self) -> &Config {
         &self.config
     }
+}
+
+/// Serializes the request body in a way that avoid re-allocations while not
+/// overallocating a lot of memory. It does that by keeping track of the biggest
+/// request seen for each kind of request (quote with/without liquidity, full
+/// auction with/without liquidity) and allocating the correct amount of memory
+/// based on the data in the auction.
+fn serialize_body(auction_dto: solvers_dto::auction::Auction) -> Bytes {
+    // these values store the biggest allocation we needed for each
+    // category of requests
+    static QUOTE_WITH_LIQUIDITY: AtomicUsize = AtomicUsize::new(1_000);
+    static QUOTE_WITHOUT_LIQUIDITY: AtomicUsize = AtomicUsize::new(1_000);
+    static AUCTION_WITH_LIQUIDITY: AtomicUsize = AtomicUsize::new(1_000);
+    static AUCTION_WITHOUT_LIQUIDITY: AtomicUsize = AtomicUsize::new(1_000);
+
+    // based on the "shape" of the auction we pick the allocation size
+    let multiple_orders = auction_dto.orders.len() > 1;
+    let with_liquidity = !auction_dto.liquidity.is_empty();
+    let memory_target = match (multiple_orders, with_liquidity) {
+        (false, false) => &QUOTE_WITHOUT_LIQUIDITY,
+        (false, true) => &QUOTE_WITH_LIQUIDITY,
+        (true, false) => &AUCTION_WITHOUT_LIQUIDITY,
+        (true, true) => &AUCTION_WITH_LIQUIDITY,
+    };
+
+    // pre-allocate biggest request size + 0.1% (to avoid re-allocations when
+    // the request grows only slightly)
+    let pre_alloc_size = memory_target.load(Ordering::Relaxed);
+    let pre_alloc_size = pre_alloc_size + pre_alloc_size / 1_000;
+    let mut buffer = Vec::with_capacity(pre_alloc_size);
+
+    serde_json::to_writer(&mut buffer, &auction_dto).unwrap();
+
+    // now that we now how much memory was actually needed we update the memory
+    // targets
+    memory_target.fetch_max(buffer.len(), Ordering::Relaxed);
+    tracing::debug!(pre_alloc_size, final_size = buffer.len(), "body allocation");
+
+    Bytes::from(buffer)
 }
 
 #[cfg(test)]

--- a/crates/driver/src/infra/solver/mod.rs
+++ b/crates/driver/src/infra/solver/mod.rs
@@ -543,7 +543,7 @@ impl Solver {
     }
 }
 
-/// Serializes the request body in a way that avoid re-allocations while not
+/// Serializes the request body in a way that avoid re-allocating while not
 /// overallocating a lot of memory. It does that by keeping track of the biggest
 /// request seen for each kind of request (quote with/without liquidity, full
 /// auction with/without liquidity) and allocating the correct amount of memory
@@ -557,9 +557,9 @@ fn serialize_body(auction_dto: solvers_dto::auction::Auction) -> Bytes {
     static AUCTION_WITHOUT_LIQUIDITY: AtomicUsize = AtomicUsize::new(1_000);
 
     // based on the "shape" of the auction we pick the allocation size
-    let multiple_orders = auction_dto.orders.len() > 1;
+    let is_auction = auction_dto.id.is_some();
     let with_liquidity = !auction_dto.liquidity.is_empty();
-    let memory_target = match (multiple_orders, with_liquidity) {
+    let memory_target = match (is_auction, with_liquidity) {
         (false, false) => &QUOTE_WITHOUT_LIQUIDITY,
         (false, true) => &QUOTE_WITH_LIQUIDITY,
         (true, false) => &AUCTION_WITHOUT_LIQUIDITY,
@@ -574,7 +574,7 @@ fn serialize_body(auction_dto: solvers_dto::auction::Auction) -> Bytes {
 
     serde_json::to_writer(&mut buffer, &auction_dto).unwrap();
 
-    // now that we now how much memory was actually needed we update the memory
+    // now that we know how much memory was actually needed we update the memory
     // targets
     memory_target.fetch_max(buffer.len(), Ordering::Relaxed);
     tracing::trace!(pre_alloc_size, final_size = buffer.len(), "body allocation");


### PR DESCRIPTION
# Description
The current logic of pre-allocating memory for the `/solve` request has a few downsides:
1. does not consider that requests can contain a significant amount of `liquidity` data
2. has no way of dynamically correcting the allocation size as we go. For example if our estimates how much memory orders and liquidity require is wrong it needs to be tweaked in the code (or a config parameter). 

# Changes
The new logic groups requests into 4 kinds which all have unique sizes on average and therefor memory requirements:
* quote without liquidity
* quote with liquidity
* auction without liquidity
* auction with liquidity

For each type we keep track of the biggest request we've seen so far. So when we have to allocate memory for a new request we first check what kind of requests it is and then allocate the memory for the biggest requests we've seen so far. We also overallocate a tiny amount since allocating not enough memory is quite expensive since the allocation will double in size.
After we know the size of the final allocation we update the counter accordingly.
Since the sizes of requests within each group don't vary significantly we are not overallocating much memory on averaged. Also keep in mind that overallocating by 100% is still better than slightly underallocating memory since vectors have a growth factor of 2.

## How to test
tested in the shadow competition
memory profiles went from indicating that extra memory had to be allocated for serializing orders and liquidity sources to not requiring any additional memory (while still being only slightly larger than the final bytes needed).
<img width="1024" height="834" alt="Screenshot 2026-06-17 at 11 34 14" src="https://github.com/user-attachments/assets/faa285c9-5e57-47a7-8c15-ea308b05c0ba" />
<img width="824" height="450" alt="Screenshot 2026-06-17 at 11 34 34" src="https://github.com/user-attachments/assets/f7eca423-389c-4c92-a486-0626c7ccc0f7" />

Also while it's still too early to tell for sure it looks like the more accurate allocations lead to more reasonable memory usage overall. Not sure if that insane linear growth is due to the allocator getting confused or what (I combed through the code and I couldn't find a memory leak and only the shadow arbitrum pod looks like this)
<img width="1902" height="385" alt="Screenshot 2026-06-17 at 11 36 41" src="https://github.com/user-attachments/assets/24aa6cb8-c4c2-42b2-a783-fbb2c40808de" />

The worst we over-allocated in a few hours was 2.5% so I think this is pretty good for such a simple solution.
<img width="1857" height="811" alt="Screenshot 2026-06-17 at 11 50 37" src="https://github.com/user-attachments/assets/037b52cd-5f40-4bd5-a9de-214d838f727a" />
