### PR TITLE
Do not check if the zero/burn address is banned

### DIFF
--- a/crates/order-validation/src/banned/mod.rs
+++ b/crates/order-validation/src/banned/mod.rs
@@ -66,7 +66,7 @@ impl Users {
         let need_lookup = addresses
             .into_iter()
             .filter(|address| {
-                if address == &Address::ZERO {
+                if address.is_zero() {
                     // We use the zero/burn address for some quotes, there's no point in checking if its banned
                     return false
                 }

--- a/crates/order-validation/src/banned/mod.rs
+++ b/crates/order-validation/src/banned/mod.rs
@@ -66,6 +66,10 @@ impl Users {
         let need_lookup = addresses
             .into_iter()
             .filter(|address| {
+                if address == &Address::ZERO {
+                    // We use the zero/burn address for some quotes, there's no point in checking if its banned
+                    return false
+                }
                 if self.list.contains(address) {
                     banned.insert(*address);
                     false


### PR DESCRIPTION
# Description
The Hermod team raised that we were querying the zero/burn address quite a bit, since it doesn't make any sense for us to check if that specific address is banned, we start bypassing it — less network requests after all.

# Changes

* Do not lookup if the zero/burn address is banned