### PR TITLE
Allow unfunded orders with approval

### DIFF
--- a/crates/account-balances/src/cached.rs
+++ b/crates/account-balances/src/cached.rs
@@ -1,10 +1,11 @@
 use {
     crate::{BalanceFetching, Query, TransferSimulationError},
-    alloy_primitives::U256,
+    alloy_primitives::{Address, U256},
     anyhow::Result,
     ethrpc::block_stream::{CurrentBlockWatcher, into_stream},
     futures::StreamExt,
     itertools::Itertools,
+    model::order::SellTokenSource,
     std::{
         collections::HashMap,
         sync::{Arc, Mutex},
@@ -194,6 +195,17 @@ impl BalanceFetching for Balances {
         // This only gets called when creating or replacing an order which doesn't
         // profit from caching.
         self.inner.can_transfer(query, amount).await
+    }
+
+    async fn allowance(
+        &self,
+        owner: Address,
+        token: Address,
+        source: SellTokenSource,
+    ) -> Result<U256> {
+        // This only gets called when creating or replacing an order which doesn't
+        // profit from caching.
+        self.inner.allowance(owner, token, source).await
     }
 }
 

--- a/crates/account-balances/src/lib.rs
+++ b/crates/account-balances/src/lib.rs
@@ -73,7 +73,7 @@ pub trait BalanceFetching: Send + Sync {
 
     /// Returns the owner's current on-chain allowance available to the protocol
     /// for the given sell token and source. This does **not** apply any order
-    /// pre-interactions or other actions that might affect allowance happen at
+    /// pre-interactions or other actions that might affect the allowance at
     /// settlement time.
     async fn allowance(
         &self,

--- a/crates/account-balances/src/lib.rs
+++ b/crates/account-balances/src/lib.rs
@@ -70,6 +70,17 @@ pub trait BalanceFetching: Send + Sync {
         query: &Query,
         amount: U256,
     ) -> Result<(), TransferSimulationError>;
+
+    /// Returns the owner's current on-chain allowance available to the protocol
+    /// for the given sell token and source. This does **not** apply any order
+    /// pre-interactions or other actions that might affect allowance happen at
+    /// settlement time.
+    async fn allowance(
+        &self,
+        owner: Address,
+        token: Address,
+        source: SellTokenSource,
+    ) -> anyhow::Result<U256>;
 }
 
 /// Create the default [`BalanceFetching`] instance.

--- a/crates/account-balances/src/simulation.rs
+++ b/crates/account-balances/src/simulation.rs
@@ -163,6 +163,44 @@ impl BalanceFetching for Balances {
 
         Ok(())
     }
+
+    #[instrument(skip(self))]
+    async fn allowance(
+        &self,
+        owner: Address,
+        token: Address,
+        source: SellTokenSource,
+    ) -> Result<U256> {
+        let token = ERC20::Instance::new(token, self.web3.provider.clone());
+        let allowance = match source {
+            SellTokenSource::Erc20 => token.allowance(owner, self.vault_relayer()).call().await?,
+            SellTokenSource::External => {
+                let vault = BalancerV2Vault::new(self.vault(), &self.web3.provider);
+                let approved = vault.hasApprovedRelayer(owner, self.vault_relayer());
+                let allowance = token.allowance(owner, self.vault());
+                let (approved, allowance) = futures::try_join!(
+                    approved.call().into_future(),
+                    allowance.call().into_future()
+                )?;
+                match approved {
+                    true => allowance,
+                    false => U256::ZERO,
+                }
+            }
+            SellTokenSource::Internal => {
+                let vault = BalancerV2Vault::new(self.vault(), &self.web3.provider);
+                match vault
+                    .hasApprovedRelayer(owner, self.vault_relayer())
+                    .call()
+                    .await?
+                {
+                    true => U256::MAX, // internal approvals are always U256::MAX
+                    false => U256::ZERO,
+                }
+            }
+        };
+        Ok(allowance)
+    }
 }
 
 #[cfg(test)]

--- a/crates/e2e/tests/e2e/uncovered_order.rs
+++ b/crates/e2e/tests/e2e/uncovered_order.rs
@@ -21,9 +21,11 @@ async fn local_node_full_balance_check() {
     run_test(test_full_balance_check).await;
 }
 
-/// Tests that a user can already create an order if they only have
-/// 1 wei of the sell token and later fund their account to get the
-/// order executed.
+/// Tests that a user can create an order without holding any sell-token balance
+/// as long as they have already set a sufficient on-chain approval to the vault
+/// relayer, and that the order executes once the account is funded.
+///
+/// Without such a pre-existing approval a zero-balance order is still rejected.
 async fn test(web3: Web3) {
     tracing::info!("Setting up chain state.");
     let mut onchain = OnchainComponents::deploy(web3).await;
@@ -35,17 +37,10 @@ async fn test(web3: Web3) {
         .await;
     let weth = &onchain.contracts().weth;
 
-    weth.approve(onchain.contracts().allowance, 3u64.eth())
-        .from(trader.address())
-        .send_and_watch()
-        .await
-        .unwrap();
-
     tracing::info!("Starting services.");
     let services = Services::new(&onchain).await;
     services.start_protocol(solver).await;
 
-    tracing::info!("Placing order with 0 sell tokens");
     let order = OrderCreation {
         sell_token: *weth.address(),
         sell_amount: 2u64.eth(),
@@ -62,19 +57,29 @@ async fn test(web3: Web3) {
         &onchain.contracts().domain_separator,
         &trader.signer,
     );
-    // This order can't be created because we require the trader
-    // to have at least 1 wei of sell tokens.
-    services.create_order(&order).await.unwrap_err();
 
-    tracing::info!("Placing order with 1 wei of sell_tokens");
-    weth.deposit()
+    tracing::info!("Placing zero-balance order without a pre-existing approval");
+    // With neither balance nor allowance the order is rejected: we require some
+    // on-chain proof of intent before accepting an order that cannot be filled.
+    assert!(
+        services
+            .create_order(&order)
+            .await
+            .unwrap_err()
+            .1
+            .contains("InsufficientBalance")
+    );
+
+    tracing::info!("Approving the vault relayer for the full sell amount");
+    weth.approve(onchain.contracts().allowance, 2u64.eth())
         .from(trader.address())
-        .value(::alloy::primitives::U256::ONE)
         .send_and_watch()
         .await
         .unwrap();
-    // Now that the trader has some funds they are able to create
-    // an order (even if it exceeds their current balance).
+
+    tracing::info!("Placing zero-balance order backed by the existing approval");
+    // The account still holds no sell tokens, but the pre-existing approval now
+    // covers the order, so it is accepted (it stays unfillable until funded).
     services.create_order(&order).await.unwrap();
 
     tracing::info!("Deposit ETH to make order executable");
@@ -87,8 +92,8 @@ async fn test(web3: Web3) {
 
     tracing::info!("Waiting for trade.");
     wait_for_condition(TIMEOUT, || async {
-        let balance_after = weth.balanceOf(trader.address()).call().await.unwrap();
-        !balance_after.is_zero()
+        let buy_balance = token.balanceOf(trader.address()).call().await.unwrap();
+        !buy_balance.is_zero()
     })
     .await
     .unwrap();

--- a/crates/e2e/tests/e2e/uncovered_order.rs
+++ b/crates/e2e/tests/e2e/uncovered_order.rs
@@ -59,8 +59,6 @@ async fn test(web3: Web3) {
     );
 
     tracing::info!("Placing zero-balance order without a pre-existing approval");
-    // With neither balance nor allowance the order is rejected: we require some
-    // on-chain proof of intent before accepting an order that cannot be filled.
     assert!(
         services
             .create_order(&order)
@@ -78,8 +76,6 @@ async fn test(web3: Web3) {
         .unwrap();
 
     tracing::info!("Placing zero-balance order backed by the existing approval");
-    // The account still holds no sell tokens, but the pre-existing approval now
-    // covers the order, so it is accepted (it stays unfillable until funded).
     services.create_order(&order).await.unwrap();
 
     tracing::info!("Deposit ETH to make order executable");

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -622,7 +622,24 @@ impl OrderValidator {
             // To cover both cases we simulate multiple small transfers. As soon as one
             // passes we consider the token transferable. If all transfers fail we return
             // the last error.
-            simulate_transfers([1, 10, 100].map(U256::from).as_slice()).await
+            match simulate_transfers([1, 10, 100].map(U256::from).as_slice()).await {
+                // A zero/low balance is acceptable as long as the owner has already set a
+                // real on-chain approval that covers the order (spam-protectiion).
+                Err(ValidationError::InsufficientBalance) => {
+                    let data = order.data();
+                    let approval = self
+                        .balance_fetcher
+                        .allowance(owner, data.sell_token, data.sell_token_balance)
+                        .await
+                        .unwrap_or(U256::ZERO);
+                    if approval >= data.sell_amount {
+                        Ok(())
+                    } else {
+                        Err(ValidationError::InsufficientBalance)
+                    }
+                }
+                other => other,
+            }
         }
     }
 }
@@ -2264,6 +2281,10 @@ mod tests {
         balance_fetcher
             .expect_can_transfer()
             .returning(|_, _| Err(TransferSimulationError::InsufficientBalance));
+        // No pre-existing approval, so a zero balance is still rejected.
+        balance_fetcher
+            .expect_allowance()
+            .returning(|_, _, _| Ok(alloy::primitives::U256::ZERO));
         let mut limit_order_counter = MockLimitOrderCounting::new();
         limit_order_counter.expect_count().returning(|_| Ok(0u64));
         let native_token = WETH9::Instance::new([0xef; 20].into(), ethrpc::mock::web3().provider);
@@ -2308,6 +2329,67 @@ mod tests {
             .await;
         dbg!(&result);
         assert!(matches!(result, Err(ValidationError::InsufficientBalance)));
+    }
+
+    #[tokio::test]
+    async fn accepts_zero_balance_order_with_sufficient_existing_approval() {
+        let mut order_quoter = MockOrderQuoting::new();
+        let mut balance_fetcher = MockBalanceFetching::new();
+        order_quoter
+            .expect_find_quote()
+            .returning(|_, _| Ok(Default::default()));
+        // The account holds no balance ...
+        balance_fetcher
+            .expect_can_transfer()
+            .returning(|_, _| Err(TransferSimulationError::InsufficientBalance));
+        // ... but a pre-existing on-chain approval already covers the sell amount,
+        // so the order is accepted (it stays unfillable until the account is funded).
+        balance_fetcher
+            .expect_allowance()
+            .returning(|_, _, _| Ok(alloy::primitives::U256::from(1)));
+        let mut limit_order_counter = MockLimitOrderCounting::new();
+        limit_order_counter.expect_count().returning(|_| Ok(0u64));
+        let native_token = WETH9::Instance::new([0xef; 20].into(), ethrpc::mock::web3().provider);
+        let validator = OrderValidator::new(
+            native_token,
+            Arc::new(order_validation::banned::Users::none()),
+            OrderValidPeriodConfiguration::any(),
+            false,
+            Default::default(),
+            HooksTrampoline::Instance::new(
+                Address::repeat_byte(0xcf),
+                ProviderBuilder::new()
+                    .connect_mocked_client(Asserter::new())
+                    .erased(),
+            ),
+            Arc::new(order_quoter),
+            Arc::new(balance_fetcher),
+            Arc::new(MockSignatureValidating::new()),
+            None,
+            Arc::new(limit_order_counter),
+            1,
+            Default::default(),
+            u64::MAX,
+            SameTokensPolicy::Disallow,
+        );
+
+        let order = OrderCreation {
+            valid_to: time::now_in_epoch_seconds() + 2,
+            sell_token: Address::with_last_byte(1),
+            buy_token: Address::with_last_byte(2),
+            buy_amount: alloy::primitives::U256::from(1),
+            sell_amount: alloy::primitives::U256::from(1),
+            fee_amount: alloy::primitives::U256::from(0),
+            signature: Signature::Eip712(EcdsaSignature::non_zero()),
+            app_data: OrderCreationAppData::Full {
+                full: "{}".to_string(),
+            },
+            ..Default::default()
+        };
+        validator
+            .validate_and_construct_order(order, &Default::default(), Default::default(), None)
+            .await
+            .unwrap();
     }
 
     #[tokio::test]
@@ -2390,6 +2472,11 @@ mod tests {
             balance_fetcher
                 .expect_can_transfer()
                 .returning(move |_, _| Err(create_error()));
+            // No pre-existing approval, so the insufficient-balance case is not
+            // relaxed (only relevant for the InsufficientBalance variant).
+            balance_fetcher
+                .expect_allowance()
+                .returning(|_, _, _| Ok(alloy::primitives::U256::ZERO));
             let mut limit_order_counter = MockLimitOrderCounting::new();
             limit_order_counter.expect_count().returning(|_| Ok(0u64));
             let native_token =
@@ -2482,6 +2569,11 @@ mod tests {
         balance_fetcher
             .expect_can_transfer()
             .returning(|_, _| Err(TransferSimulationError::InsufficientBalance));
+        // No pre-existing approval, so balance is not waived for the non-flashloan,
+        // non-presign orders below.
+        balance_fetcher
+            .expect_allowance()
+            .returning(|_, _, _| Ok(alloy::primitives::U256::ZERO));
         let mut limit_order_counter = MockLimitOrderCounting::new();
         limit_order_counter.expect_count().returning(|_| Ok(0u64));
         let native_token = WETH9::Instance::new([0xef; 20].into(), ethrpc::mock::web3().provider);

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -631,7 +631,7 @@ impl OrderValidator {
                         .balance_fetcher
                         .allowance(owner, data.sell_token, data.sell_token_balance)
                         .await
-                        .unwrap_or(U256::ZERO);
+                        .map_err(ValidationError::Other)?;
                     if approval >= data.sell_amount {
                         Ok(())
                     } else {

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -2281,7 +2281,6 @@ mod tests {
         balance_fetcher
             .expect_can_transfer()
             .returning(|_, _| Err(TransferSimulationError::InsufficientBalance));
-        // No pre-existing approval, so a zero balance is still rejected.
         balance_fetcher
             .expect_allowance()
             .returning(|_, _, _| Ok(alloy::primitives::U256::ZERO));
@@ -2338,6 +2337,7 @@ mod tests {
         order_quoter
             .expect_find_quote()
             .returning(|_, _| Ok(Default::default()));
+
         // The account holds no balance ...
         balance_fetcher
             .expect_can_transfer()
@@ -2347,6 +2347,7 @@ mod tests {
         balance_fetcher
             .expect_allowance()
             .returning(|_, _, _| Ok(alloy::primitives::U256::from(1)));
+
         let mut limit_order_counter = MockLimitOrderCounting::new();
         limit_order_counter.expect_count().returning(|_| Ok(0u64));
         let native_token = WETH9::Instance::new([0xef; 20].into(), ethrpc::mock::web3().provider);
@@ -2472,8 +2473,6 @@ mod tests {
             balance_fetcher
                 .expect_can_transfer()
                 .returning(move |_, _| Err(create_error()));
-            // No pre-existing approval, so the insufficient-balance case is not
-            // relaxed (only relevant for the InsufficientBalance variant).
             balance_fetcher
                 .expect_allowance()
                 .returning(|_, _, _| Ok(alloy::primitives::U256::ZERO));
@@ -2569,8 +2568,6 @@ mod tests {
         balance_fetcher
             .expect_can_transfer()
             .returning(|_, _| Err(TransferSimulationError::InsufficientBalance));
-        // No pre-existing approval, so balance is not waived for the non-flashloan,
-        // non-presign orders below.
         balance_fetcher
             .expect_allowance()
             .returning(|_, _, _| Ok(alloy::primitives::U256::ZERO));

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -2475,7 +2475,7 @@ mod tests {
                 .returning(move |_, _| Err(create_error()));
             balance_fetcher
                 .expect_allowance()
-                .returning(|_, _, _| Ok(alloy::primitives::U256::ZERO));
+                .returning(|_, _, _| Ok(U256::ZERO));
             let mut limit_order_counter = MockLimitOrderCounting::new();
             limit_order_counter.expect_count().returning(|_| Ok(0u64));
             let native_token =

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -624,7 +624,7 @@ impl OrderValidator {
             // the last error.
             match simulate_transfers([1, 10, 100].map(U256::from).as_slice()).await {
                 // A zero/low balance is acceptable as long as the owner has already set a
-                // real on-chain approval that covers the order (spam-protectiion).
+                // real on-chain approval that covers the order (spam protection).
                 Err(ValidationError::InsufficientBalance) => {
                     let data = order.data();
                     let approval = self

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -2570,7 +2570,7 @@ mod tests {
             .returning(|_, _| Err(TransferSimulationError::InsufficientBalance));
         balance_fetcher
             .expect_allowance()
-            .returning(|_, _, _| Ok(alloy::primitives::U256::ZERO));
+            .returning(|_, _, _| Ok(U256::ZERO));
         let mut limit_order_counter = MockLimitOrderCounting::new();
         limit_order_counter.expect_count().returning(|_| Ok(0u64));
         let native_token = WETH9::Instance::new([0xef; 20].into(), ethrpc::mock::web3().provider);

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -2378,9 +2378,9 @@ mod tests {
             valid_to: time::now_in_epoch_seconds() + 2,
             sell_token: Address::with_last_byte(1),
             buy_token: Address::with_last_byte(2),
-            buy_amount: alloy::primitives::U256::from(1),
-            sell_amount: alloy::primitives::U256::from(1),
-            fee_amount: alloy::primitives::U256::from(0),
+            buy_amount: U256::ONE,
+            sell_amount: U256::ONE,
+            fee_amount: U256::ZERO,
             signature: Signature::Eip712(EcdsaSignature::non_zero()),
             app_data: OrderCreationAppData::Full {
                 full: "{}".to_string(),


### PR DESCRIPTION
# Description

There are use cases in which we want to allow limit order placement even if no funds are available yet. The existing logic requires the user to have at least 1 wei of balance. Reason for this is spam protection (funding a wallet requires a transaction and thus someone to spend gas). However, the same applies to setting an on-chain allowance.

This PR adds logic to allow completely unfunded accounts to place limit orders as long as they have set an onchain approval. Note that the cost of doing this is roughly equivalent to transferring 1 wei of token into an account (and then using a free permit pre-hook to set allowance, which would pass today's test). Therefore, I don't expect the spam surface to increase.

# Changes
* When validating an order and not using a full balance check, we now have a branch if transfer fails with insufficient balance, which checks if there exists on-chain approval (without evaluating any pre hooks or wrappers)
* Add and implement `allowance` method on the balance fetcher
* Adjust and add a test covering this path

## How to test
Added unit test and adapted e2e test

## Additional Context
Context: https://nomevlabs.slack.com/archives/C0A9GFVLLD6/p1781605451078769
