### PR TITLE
Generate report from simulation

### DIFF
--- a/crates/simulator/src/encoding.rs
+++ b/crates/simulator/src/encoding.rs
@@ -636,30 +636,24 @@ async fn build_final_state_overrides(
             AccountOverrideRequest::Custom { account, state } => Some((*account, state.clone())),
         };
 
-        match state_override {
-            Some(value) => Either::Left(value),
-            None => {
-                tracing::debug!(?request, "failed to compute state override");
-                Either::Right(request)
-            }
+        if state_override.is_none() {
+            tracing::debug!(?request, "failed to compute state override");
         }
+        (request, state_override)
     });
 
     let mut state_overrides = StateOverride::default();
     let mut errors = vec![];
 
-    for res in futures::future::join_all(futures).await.into_iter() {
-        match res {
-            Either::Left((address, account_override)) => {
-                if let Err(err) =
-                    apply_account_override(&mut state_overrides, address, account_override)
-                {
-                    tracing::warn!(?err, %address, "conflicting state overrides for address, skipping");
-                }
-            }
-            Either::Right(error) => {
-                errors.push(error);
-            }
+    for (request, state_override) in futures::future::join_all(futures).await.into_iter() {
+        let Some((address, account_override)) = state_override else {
+            errors.push(request);
+            continue;
+        };
+
+        if let Err(err) = apply_account_override(&mut state_overrides, address, account_override) {
+            tracing::warn!(?err, ?request, %address, "conflicting state overrides, skipping");
+            errors.push(request);
         }
     }
     (state_overrides, errors)

--- a/crates/simulator/src/encoding.rs
+++ b/crates/simulator/src/encoding.rs
@@ -19,6 +19,7 @@ use {
     balance_overrides::{ApprovalOverrideRequest, BalanceOverrideRequest, StateOverriding},
     contracts::GPv2Settlement,
     derive_more::Debug,
+    futures::future::Either,
     model::{
         interaction::InteractionData,
         order::{BuyTokenDestination, OrderData, OrderKind, SellTokenSource},
@@ -490,7 +491,7 @@ pub(crate) async fn finish_simulation_builder(
         }
         None => return Err(BuildError::NoSolver),
     };
-    let state_overrides = build_final_state_overrides(
+    let (state_overrides, state_override_errors) = build_final_state_overrides(
         builder.account_override_requests,
         builder.simulator.0.state_overrides.as_ref(),
         builder.simulator.0.authenticator,
@@ -505,6 +506,7 @@ pub(crate) async fn finish_simulation_builder(
         state_overrides,
         block,
         simulator: builder.simulator,
+        failed_state_overrides: state_override_errors,
     })
 }
 
@@ -545,18 +547,18 @@ async fn executed_amount(
 }
 
 /// Resolves all [`AccountOverrideRequest`]s concurrently on a best-effort
-/// basis. Failures are logged and the corresponding override is skipped rather
-/// than aborting the whole build.
+/// basis. Returns the fully resolved state overrides and
+/// [`AccountOverrideRequest`]s that failed to resolve.
 async fn build_final_state_overrides(
     requests: Vec<AccountOverrideRequest>,
     state_overrides: &dyn StateOverriding,
     authenticator: Address,
     settlement_contract: Address,
-) -> StateOverride {
+) -> (StateOverride, Vec<AccountOverrideRequest>) {
     let futures = requests.into_iter().map(|request| async move {
-        match request {
+        let state_override = match &request {
             AccountOverrideRequest::SufficientEthBalance(addr) => Some((
-                addr,
+                *addr,
                 AccountOverride::default().with_balance(U256::MAX / U256::from(2)),
             )),
             AccountOverrideRequest::AuthenticateAsSolver(addr) => {
@@ -579,22 +581,18 @@ async fn build_final_state_overrides(
                 token,
                 amount,
             } => {
-                let result = state_overrides
+                state_overrides
                     .balance_override(BalanceOverrideRequest {
-                        token,
-                        holder,
-                        amount,
+                        token: *token,
+                        holder: *holder,
+                        amount: *amount,
                     })
-                    .await;
-                if result.is_none() {
-                    tracing::warn!(%token, %holder, "failed to compute balance state override, skipping");
-                }
-                result
+                    .await
             }
             AccountOverrideRequest::Code { account, code } => Some((
-                account,
+                *account,
                 AccountOverride {
-                    code: Some(code),
+                    code: Some(code.clone()),
                     ..Default::default()
                 },
             )),
@@ -605,13 +603,15 @@ async fn build_final_state_overrides(
                 // <https://github.com/cowprotocol/contracts/blob/c6b61ce75841ce4c25ab126def9cc981c568e6c6/src/contracts/mixins/GPv2Signing.sol#L57>
                 let mut buf = [0u8; 56 + 32];
                 buf[0..56].copy_from_slice(order.0.as_slice());
-                // no need to copy anything for storage slot 0 since the array gets 0 initialized.
+                // no need to copy anything for storage slot 0 since the array gets 0
+                // initialized.
                 let slot = keccak256(buf);
 
                 // Sentinel value expected by the settlement contract to indicate that the order
                 // was pre-signed by the user.
                 // See <https://github.com/cowprotocol/contracts/blob/c6b61ce75841ce4c25ab126def9cc981c568e6c6/src/contracts/mixins/GPv2Signing.sol#L44-L46>
-                const PRE_SIGN_SENTINEL: B256 = b256!("f59c009283ff87aa78203fc4d9c2df025ee851130fb69cc3e068941f6b5e2d6f");
+                const PRE_SIGN_SENTINEL: B256 =
+                    b256!("f59c009283ff87aa78203fc4d9c2df025ee851130fb69cc3e068941f6b5e2d6f");
                 Some((
                     settlement_contract,
                     AccountOverride::default()
@@ -624,34 +624,45 @@ async fn build_final_state_overrides(
                 spender,
                 amount,
             } => {
-                let result = state_overrides
+                state_overrides
                     .approval_override(ApprovalOverrideRequest {
-                        token,
-                        owner,
-                        spender,
-                        amount,
+                        token: *token,
+                        owner: *owner,
+                        spender: *spender,
+                        amount: *amount,
                     })
-                    .await;
-                if result.is_none() {
-                    tracing::warn!(%token, %owner, %spender, "failed to compute approval state override, skipping");
-                }
-                result
+                    .await
             }
-            AccountOverrideRequest::Custom { account, state } => Some((account, state)),
+            AccountOverrideRequest::Custom { account, state } => Some((*account, state.clone())),
+        };
+
+        match state_override {
+            Some(value) => Either::Left(value),
+            None => {
+                tracing::debug!(?request, "failed to compute state override");
+                Either::Right(request)
+            }
         }
     });
 
     let mut state_overrides = StateOverride::default();
-    for (address, account_override) in futures::future::join_all(futures)
-        .await
-        .into_iter()
-        .flatten()
-    {
-        if let Err(err) = apply_account_override(&mut state_overrides, address, account_override) {
-            tracing::warn!(?err, %address, "conflicting state overrides for address, skipping");
+    let mut errors = vec![];
+
+    for res in futures::future::join_all(futures).await.into_iter() {
+        match res {
+            Either::Left((address, account_override)) => {
+                if let Err(err) =
+                    apply_account_override(&mut state_overrides, address, account_override)
+                {
+                    tracing::warn!(?err, %address, "conflicting state overrides for address, skipping");
+                }
+            }
+            Either::Right(error) => {
+                errors.push(error);
+            }
         }
     }
-    state_overrides
+    (state_overrides, errors)
 }
 
 /// Merges `new` into `existing` field by field.

--- a/crates/simulator/src/encoding.rs
+++ b/crates/simulator/src/encoding.rs
@@ -19,7 +19,6 @@ use {
     balance_overrides::{ApprovalOverrideRequest, BalanceOverrideRequest, StateOverriding},
     contracts::GPv2Settlement,
     derive_more::Debug,
-    futures::future::Either,
     model::{
         interaction::InteractionData,
         order::{BuyTokenDestination, OrderData, OrderKind, SellTokenSource},

--- a/crates/simulator/src/simulation_builder.rs
+++ b/crates/simulator/src/simulation_builder.rs
@@ -1,14 +1,15 @@
 use {
-    crate::{encoding::WrapperCall, tenderly},
+    crate::{encoding::WrapperCall, report, tenderly},
     alloy_primitives::{Address, B256, Bytes, U256, address, b256, keccak256},
-    alloy_provider::{DynProvider, Provider},
+    alloy_provider::{DynProvider, Provider, ext::DebugApi},
     alloy_rpc_types::{
         TransactionRequest,
         state::{AccountOverride, StateOverride},
+        trace::geth::{CallConfig, GethDebugTracingCallOptions, GethDebugTracingOptions},
     },
     alloy_sol_types::SolCall,
     alloy_transport::RpcError,
-    anyhow::{Context, Result},
+    anyhow::{Context as AnyhowContext, Result},
     balance_overrides::StateOverriding,
     ethrpc::block_stream::CurrentBlockWatcher,
     model::{
@@ -437,6 +438,7 @@ pub struct EthCallInputs {
     pub state_overrides: StateOverride,
     pub simulator: SettlementSimulator,
     pub block: u64,
+    pub failed_state_overrides: Vec<AccountOverrideRequest>,
 }
 
 impl EthCallInputs {
@@ -452,15 +454,46 @@ impl EthCallInputs {
 
     /// Runs the generated simulation using an `eth_call` and returns the
     /// response bytes if there are any.
-    pub async fn simulate(self) -> Result<Bytes, RpcError<alloy_transport::TransportErrorKind>> {
+    pub async fn simulate(&self) -> Result<Bytes, RpcError<alloy_transport::TransportErrorKind>> {
         self.simulator
             .0
             .provider
             .clone()
             .call(self.as_transaction_request())
-            .overrides(self.state_overrides)
+            .overrides(self.state_overrides.clone())
             .block(self.block.into())
             .await
+    }
+
+    /// Runs the simulation together with a call tracer. Afterwards the call
+    /// trace gets analyzed to generate a high level report of the simulation
+    /// with information to help the caller understand what went wrong during
+    /// the simulation.
+    pub async fn simulation_report(
+        &self,
+    ) -> Result<report::SimulationReport, RpcError<alloy_transport::TransportErrorKind>> {
+        let trace = self
+            .simulator
+            .0
+            .provider
+            .clone()
+            .debug_trace_call_callframe(
+                self.as_transaction_request(),
+                self.block.into(),
+                GethDebugTracingCallOptions::default()
+                    .with_tracing_options(GethDebugTracingOptions::call_tracer(
+                        CallConfig::default(),
+                    ))
+                    .with_state_overrides(self.state_overrides.clone()),
+            )
+            .await?;
+
+        let context = report::Context {
+            settlement: self.simulator.0.settlement.address(),
+            vault_relayer: &self.simulator.0.vault_relayer,
+            trampoline: &self.simulator.0.hooks_trampoline,
+        };
+        Ok(report::generate_settlement_report(context, trace))
     }
 
     /// Same as [`EthCallInputs::simulate`] but also generates a tenderly


### PR DESCRIPTION
# Description
Follow up to #4537. In order to understand whether our simulation or the order is at fault we also need to know what went wrong while building the simulation. The most likely issue with our simulation will be that we fail to compute the necessary state overrides for the buy token balance.

# Changes
Instead of surfacing those issues as a hard error we simply return our best effort simulation inputs together with the state override errors. This is because a simulation can theoretically still work without the override and now that we can generate a simulation report for reverting simulations we can still get **some** important information (setup of wrappers, pre-hooks, signature check).

## How to test
Rather than adding a unit test for this this logic together with the other PRs of this stack will be covered by an e2e tests asserting that orders which trigger the specific limitations of the simulation approach can still be placed.