### PR TITLE
Fixes for new simulation check

### DIFF
--- a/crates/shared/src/order_creation_simulation.rs
+++ b/crates/shared/src/order_creation_simulation.rs
@@ -80,6 +80,14 @@ impl OrderSimulating for OrderCreationSimulator {
         let inputs = self
             .prepare_simulation(order, full_app_data, full_balance_check)
             .await?;
+
+        // Fast path for "well behaved" orders which make up the majority.
+        // We only run the more involved analysis logic when something is
+        // actually wrong with the order.
+        if inputs.simulate().await.is_ok() {
+            return Ok(());
+        }
+
         analyze_simulation(order, inputs).await
     }
 }

--- a/crates/shared/src/order_creation_simulation.rs
+++ b/crates/shared/src/order_creation_simulation.rs
@@ -116,7 +116,8 @@ impl OrderCreationSimulator {
                     OrderKind::Buy => clamped_sell_amount
                         .checked_mul(order.data.buy_amount)
                         .and_then(|val| val.checked_div(order.data.sell_amount))
-                        .unwrap_or(U256::ONE),
+                        .unwrap_or(U256::ONE)
+                        .max(U256::ONE),
                 };
                 ExecutionAmount::Explicit(final_amount)
             }

--- a/crates/shared/src/order_creation_simulation.rs
+++ b/crates/shared/src/order_creation_simulation.rs
@@ -230,13 +230,19 @@ fn allow_failed_buy_token_transfer(
     failed_state_overrides: &[AccountOverrideRequest],
     report: &SimulationReport,
 ) -> bool {
+    let receiver = match &order.data.receiver {
+        None => &order.metadata.owner,
+        Some(r) if r.is_zero() => &order.metadata.owner,
+        Some(receiver) => receiver,
+    };
     let buy_token_transfer_failed = report.events.iter().any(|e| {
         matches!(e,
             Event::Transfer { from, token, to, revert, .. }
                 if revert.is_some()
                 && from == &settlement
                 && token == &order.data.buy_token
-                && to == &order.data.receiver.unwrap_or(order.metadata.owner))
+                && to == receiver
+        )
     });
     let buy_token_override_failed = failed_state_overrides.iter().any(|o| {
         matches!(o,

--- a/crates/shared/src/order_creation_simulation.rs
+++ b/crates/shared/src/order_creation_simulation.rs
@@ -100,12 +100,17 @@ impl OrderCreationSimulator {
                     .call()
                     .await
                     .unwrap_or_default();
-                let executable_amount = match order.data.kind {
-                    OrderKind::Sell => order.data.sell_amount,
-                    OrderKind::Buy => order.data.buy_amount,
+                let clamped_sell_amount =
+                    sell_token_balance.clamp(U256::ONE, order.data.sell_amount);
+                let final_amount = match order.data.kind {
+                    OrderKind::Sell => clamped_sell_amount,
+                    // convert maxium sell amount to buy tokens
+                    OrderKind::Buy => clamped_sell_amount
+                        .checked_mul(order.data.buy_amount)
+                        .and_then(|val| val.checked_div(order.data.sell_amount))
+                        .unwrap_or(U256::ONE),
                 };
-                let clamped_sell_amount = sell_token_balance.clamp(U256::ONE, executable_amount);
-                ExecutionAmount::Explicit(clamped_sell_amount)
+                ExecutionAmount::Explicit(final_amount)
             }
         };
         let sim_order = simulation_builder::Order::new(order.data)

--- a/crates/shared/src/order_creation_simulation.rs
+++ b/crates/shared/src/order_creation_simulation.rs
@@ -1,11 +1,19 @@
 use {
+    alloy::primitives::{Address, U256},
     anyhow::anyhow,
     async_trait::async_trait,
-    model::order::Order,
+    contracts::ERC20::ERC20,
+    model::{
+        order::{Order, OrderKind},
+        signature::SigningScheme,
+    },
     simulator::{
+        report::{Event, SimulationReport},
         simulation_builder::{
             self,
+            AccountOverrideRequest,
             Block,
+            EthCallInputs,
             ExecutionAmount,
             PriceEncoding,
             SettlementSimulator,
@@ -27,6 +35,7 @@ pub enum OrderSimulationError {
     /// would blow up `Result<(), OrderSimulationError>`'s stack footprint.
     Reverted {
         reason: String,
+        summary: Vec<Event>,
         tenderly_url: Option<String>,
         tenderly_request: Option<Box<tenderly::dto::Request>>,
     },
@@ -43,6 +52,7 @@ pub trait OrderSimulating: Send + Sync {
         &self,
         order: &Order,
         full_app_data: &str,
+        full_balance_check: bool,
     ) -> Result<(), OrderSimulationError>;
 }
 
@@ -65,13 +75,44 @@ impl OrderSimulating for OrderCreationSimulator {
         &self,
         order: &Order,
         full_app_data: &str,
+        full_balance_check: bool,
     ) -> Result<(), OrderSimulationError> {
+        let inputs = self
+            .prepare_simulation(order, full_app_data, full_balance_check)
+            .await?;
+        analyze_simulation(order, inputs).await
+    }
+}
+
+impl OrderCreationSimulator {
+    async fn prepare_simulation(
+        &self,
+        order: &Order,
+        full_app_data: &str,
+        full_balance_check: bool,
+    ) -> Result<EthCallInputs, OrderSimulationError> {
+        let amount_to_fill = match !order.data.partially_fillable || full_balance_check {
+            true => ExecutionAmount::Full,
+            false => {
+                let sell_token = ERC20::new(order.data.sell_token, self.inner.provider());
+                let sell_token_balance = sell_token
+                    .balanceOf(order.metadata.owner)
+                    .call()
+                    .await
+                    .unwrap_or_default();
+                let executable_amount = match order.data.kind {
+                    OrderKind::Sell => order.data.sell_amount,
+                    OrderKind::Buy => order.data.buy_amount,
+                };
+                let clamped_sell_amount = sell_token_balance.clamp(U256::ONE, executable_amount);
+                ExecutionAmount::Explicit(clamped_sell_amount)
+            }
+        };
         let sim_order = simulation_builder::Order::new(order.data)
             .with_signature(order.metadata.owner, order.signature.clone())
-            .fill_at(ExecutionAmount::Full, PriceEncoding::LimitPrice);
+            .fill_at(amount_to_fill, PriceEncoding::LimitPrice);
 
-        let inputs = self
-            .inner
+        self.inner
             .new_simulation_builder()
             .with_orders([sim_order])
             .parameters_from_app_data(full_app_data)
@@ -82,26 +123,288 @@ impl OrderSimulating for OrderCreationSimulator {
             .at_block(Block::Latest)
             .build()
             .await
-            .map_err(|err| OrderSimulationError::Infra(anyhow!(err).context("build")))?;
+            .map_err(|err| OrderSimulationError::Infra(anyhow!(err).context("build")))
+    }
+}
 
-        // Capture the Tenderly handle and the diagnostic request before
-        // consuming `inputs` with `simulate()`. The Tenderly call is only
-        // dispatched on revert, since the URL is only useful for diagnostics
-        // and most simulations succeed.
-        let tenderly = inputs.simulator.tenderly();
-        let tenderly_request = inputs.to_tenderly_request().ok();
+/// Runs the simulation, handles errors caused by fundamental limitations of
+/// the simulation approach and returns a comprehensive report in case of an
+/// error.
+async fn analyze_simulation(
+    order: &Order,
+    inputs: EthCallInputs,
+) -> Result<(), OrderSimulationError> {
+    let report = inputs
+        .simulation_report()
+        .await
+        .map_err(|err| OrderSimulationError::Infra(anyhow!(err).context("simulate")))?;
 
-        let Err(err) = inputs.simulate().await else {
-            return Ok(());
+    let revert_reason = match extract_critical_revert(
+        order,
+        inputs.simulator.settlement_address(),
+        &inputs.failed_state_overrides,
+        &report,
+    ) {
+        Some(revert) => revert,
+        None => return Ok(()),
+    };
+
+    let tenderly = inputs.simulator.tenderly();
+    let tenderly_request = inputs.to_tenderly_request().ok();
+    let tenderly_url = match (tenderly, tenderly_request.as_ref()) {
+        (Some(api), Some(req)) => api.simulate_and_share(req.clone()).await.ok(),
+        _ => None,
+    };
+    Err(OrderSimulationError::Reverted {
+        reason: revert_reason,
+        summary: report.events,
+        tenderly_url,
+        tenderly_request: tenderly_request.map(Box::new),
+    })
+}
+
+/// Analyzes the simulation and only surfaces a revert if it was critical
+/// (as opposed to being caused by limitations of the simulation
+/// approach).
+fn extract_critical_revert(
+    order: &Order,
+    settlement: Address,
+    failed_state_overrides: &[AccountOverrideRequest],
+    report: &SimulationReport,
+) -> Option<String> {
+    let Some(revert) = &report.revert else {
+        return None;
+    };
+
+    if disallow_broken_hook(report) {
+        return Some(revert.clone());
+    }
+
+    if allow_failed_buy_token_transfer(order, settlement, failed_state_overrides, report) {
+        tracing::debug!(
+            summary = ?report.events,
+            ?failed_state_overrides,
+            "allow reverting order: buy token balance override failed"
+        );
+        return None;
+    }
+
+    if allow_unfunded_presign_order(order, settlement, report) {
+        tracing::debug!(
+            summary = ?report.events,
+            "allow reverting order: unfunded presign order"
+        );
+        return None;
+    }
+
+    Some(revert.clone())
+}
+
+/// Because the trampoline contract catches reverts of hooks they will not
+/// cause the settlement to revert outright. However, usually hooks are
+/// required for an order to work so the revert that's ultimately caused by
+/// the broken hook will only in a settlement revert later (e.g. when
+/// flashloan can't be paid back correctly). Let's assume all hooks are
+/// required and reject orders with broken ones.
+fn disallow_broken_hook(report: &SimulationReport) -> bool {
+    report
+        .events
+        .iter()
+        .any(|e| matches!(e, Event::Hook { caught_error, .. } if caught_error.is_some()))
+}
+
+/// The simulation requires the settlement contract to have enough buy
+/// tokens to pay out the order directly. But it's also possible that
+/// we fail to compute the necessary state overrides for that.
+/// To not prevent the creation of reasonable orders we allow placing
+/// orders where ONLY the buy token transfer reverted AND we failed to
+/// compute the required overrides.
+fn allow_failed_buy_token_transfer(
+    order: &Order,
+    settlement: Address,
+    failed_state_overrides: &[AccountOverrideRequest],
+    report: &SimulationReport,
+) -> bool {
+    let buy_token_transfer_failed = report.events.iter().any(|e| {
+        matches!(e,
+            Event::Transfer { from, token, to, revert, .. }
+                if revert.is_some()
+                && from == &settlement
+                && token == &order.data.buy_token
+                && to == &order.data.receiver.unwrap_or(order.metadata.owner))
+    });
+    let buy_token_override_failed = failed_state_overrides.iter().any(|o| {
+        matches!(o,
+            AccountOverrideRequest::Balance { token, holder, .. }
+                if token == &order.data.buy_token
+                && holder == &settlement
+        )
+    });
+
+    buy_token_transfer_failed && buy_token_override_failed
+}
+
+/// PreSign orders are currently the only ones that are allowed to be placed
+/// without any balance at all. If we detect a revert of the sell token
+/// transfer we allow it when it's a pre-sign order.
+fn allow_unfunded_presign_order(
+    order: &Order,
+    settlement: Address,
+    report: &SimulationReport,
+) -> bool {
+    let sell_token_transfer_failed = report.events.iter().any(|e| {
+        matches!(e,
+            Event::Transfer { from, token, to, revert, .. }
+                if revert.is_some()
+                && to == &settlement
+                && token == &order.data.sell_token
+                && from == &order.metadata.owner)
+    });
+
+    sell_token_transfer_failed && order.signature.scheme() == SigningScheme::PreSign
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        model::order::OrderBuilder,
+        simulator::{
+            report::{Event, SimulationReport},
+            simulation_builder::AccountOverrideRequest,
+        },
+    };
+
+    const SETTLEMENT: Address = Address::repeat_byte(0x11);
+    const SELL_TOKEN: Address = Address::repeat_byte(0xaa);
+    const BUY_TOKEN: Address = Address::repeat_byte(0xbb);
+    const OWNER: Address = Address::repeat_byte(0xcc);
+
+    fn report_with_revert(events: Vec<Event>) -> SimulationReport {
+        SimulationReport {
+            events,
+            returned_bytes: None,
+            revert: Some("revert".to_owned()),
+        }
+    }
+
+    fn ok_report() -> SimulationReport {
+        SimulationReport {
+            events: vec![],
+            returned_bytes: None,
+            revert: None,
+        }
+    }
+
+    fn buy_token_transfer_failed() -> Event {
+        Event::Transfer {
+            token: BUY_TOKEN,
+            from: SETTLEMENT,
+            to: OWNER,
+            amount: U256::from(100),
+            revert: Some("transfer failed".to_owned()),
+        }
+    }
+
+    fn sell_token_transfer_failed() -> Event {
+        Event::Transfer {
+            token: SELL_TOKEN,
+            from: OWNER,
+            to: SETTLEMENT,
+            amount: U256::from(100),
+            revert: Some("transfer failed".to_owned()),
+        }
+    }
+
+    fn buy_token_override_failed() -> AccountOverrideRequest {
+        AccountOverrideRequest::Balance {
+            token: BUY_TOKEN,
+            holder: SETTLEMENT,
+            amount: U256::from(100),
+        }
+    }
+
+    fn check(
+        order: &Order,
+        failed_overrides: &[AccountOverrideRequest],
+        report: &SimulationReport,
+    ) -> Option<String> {
+        extract_critical_revert(order, SETTLEMENT, failed_overrides, report)
+    }
+
+    #[test]
+    fn no_revert_in_report_is_ok() {
+        let order = OrderBuilder::default()
+            .with_sell_token(SELL_TOKEN)
+            .with_buy_token(BUY_TOKEN)
+            .build();
+
+        assert!(check(&order, &[], &ok_report()).is_none());
+    }
+
+    #[test]
+    fn detects_unjust_buy_token_transfer_revert() {
+        let mut order = OrderBuilder::default()
+            .with_sell_token(SELL_TOKEN)
+            .with_buy_token(BUY_TOKEN)
+            .build();
+        order.metadata.owner = OWNER;
+        let report = report_with_revert(vec![buy_token_transfer_failed()]);
+
+        assert!(check(&order, &[buy_token_override_failed()], &report).is_none());
+    }
+
+    #[test]
+    fn surfaces_hook_revert_despite_buy_transfer_exception() {
+        let mut order = OrderBuilder::default()
+            .with_sell_token(SELL_TOKEN)
+            .with_buy_token(BUY_TOKEN)
+            .build();
+        order.metadata.owner = OWNER;
+        let broken_hook = Event::Hook {
+            target: Address::repeat_byte(0x00),
+            caught_error: Some("hook failed".to_owned()),
         };
-        let tenderly_url = match (tenderly, tenderly_request.as_ref()) {
-            (Some(api), Some(req)) => api.simulate_and_share(req.clone()).await.ok(),
-            _ => None,
-        };
-        Err(OrderSimulationError::Reverted {
-            reason: err.to_string(),
-            tenderly_url,
-            tenderly_request: tenderly_request.map(Box::new),
-        })
+        let report = report_with_revert(vec![broken_hook, buy_token_transfer_failed()]);
+
+        assert!(check(&order, &[buy_token_override_failed()], &report).is_some());
+    }
+
+    #[test]
+    fn allows_presign_sell_transfer_revert() {
+        let order = OrderBuilder::default()
+            .with_sell_token(SELL_TOKEN)
+            .with_buy_token(BUY_TOKEN)
+            .with_presign(OWNER)
+            .build();
+        let report = report_with_revert(vec![sell_token_transfer_failed()]);
+
+        assert!(check(&order, &[], &report).is_none());
+    }
+
+    #[test]
+    fn rejects_sell_transfer_revert_for_all_other_orders() {
+        // EIP-712 order (default) — same failure must surface as a critical revert.
+        let order = OrderBuilder::default()
+            .with_sell_token(SELL_TOKEN)
+            .with_buy_token(BUY_TOKEN)
+            .build();
+        let report = report_with_revert(vec![sell_token_transfer_failed()]);
+
+        assert!(check(&order, &[], &report).is_some());
+    }
+
+    #[test]
+    fn buy_token_transfer_revert_is_critical_without_state_override_error() {
+        // The transfer reverted but we *did* manage to set the balance override,
+        // so this is a genuine problem and should not be silenced.
+        let mut order = OrderBuilder::default()
+            .with_sell_token(SELL_TOKEN)
+            .with_buy_token(BUY_TOKEN)
+            .build();
+        order.metadata.owner = OWNER;
+        let report = report_with_revert(vec![buy_token_transfer_failed()]);
+
+        assert!(check(&order, &[], &report).is_some());
     }
 }

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -79,22 +79,26 @@ impl OrderSimulator {
         &self,
         order: &Order,
         full_app_data: &str,
+        full_balance_check: bool,
     ) -> Result<(), OrderSimulationError> {
         let start = Instant::now();
-        let (outcome, result) =
-            match tokio::time::timeout(self.timeout, self.simulator.simulate(order, full_app_data))
-                .await
-            {
-                Ok(r @ Ok(())) => ("ok", r),
-                Ok(r @ Err(OrderSimulationError::Reverted { .. })) => ("reverted", r),
-                Ok(r @ Err(OrderSimulationError::Infra(_))) => ("infra", r),
-                Err(_) => (
-                    "timeout",
-                    Err(OrderSimulationError::Infra(anyhow!(
-                        "order simulation timeout"
-                    ))),
-                ),
-            };
+        let (outcome, result) = match tokio::time::timeout(
+            self.timeout,
+            self.simulator
+                .simulate(order, full_app_data, full_balance_check),
+        )
+        .await
+        {
+            Ok(r @ Ok(())) => ("ok", r),
+            Ok(r @ Err(OrderSimulationError::Reverted { .. })) => ("reverted", r),
+            Ok(r @ Err(OrderSimulationError::Infra(_))) => ("infra", r),
+            Err(_) => (
+                "timeout",
+                Err(OrderSimulationError::Infra(anyhow!(
+                    "order simulation timeout"
+                ))),
+            ),
+        };
 
         Metrics::get()
             .duration_seconds
@@ -124,6 +128,7 @@ fn log_simulation_outcome(
                 reason,
                 tenderly_url,
                 tenderly_request,
+                summary,
             }),
         ) => {
             let tenderly_request_json = tenderly_request
@@ -137,6 +142,7 @@ fn log_simulation_outcome(
                 full_app_data,
                 ?order_signature,
                 ?reason,
+                ?summary,
                 ?tenderly_url,
                 tenderly_request = %tenderly_request_json,
                 "order simulation disagreement: signature passed, simulation reverted",
@@ -819,11 +825,9 @@ impl OrderValidating for OrderValidator {
             None
         };
 
-        let simulation_fut = OptionFuture::from(
-            self.order_simulator
-                .as_ref()
-                .map(|c| c.simulate_with_timeout(&preview_order, &full_app_data)),
-        );
+        let simulation_fut = OptionFuture::from(self.order_simulator.as_ref().map(|c| {
+            c.simulate_with_timeout(&preview_order, &full_app_data, order.full_balance_check)
+        }));
         let transfer_fut = self.ensure_token_is_transferable(&order, owner, &app_data);
 
         let verification_gas_limit = match eip1271_check {
@@ -3056,12 +3060,13 @@ mod tests {
             let mut sim = MockOrderSimulating::new();
             sim.expect_simulate()
                 .times(1)
-                .returning(move |_, _| match simulation {
+                .returning(move |_, _, _| match simulation {
                     Sim::Pass => Ok(()),
                     Sim::Reverted => Err(OrderSimulationError::Reverted {
                         reason: "hook reverted".into(),
                         tenderly_url: None,
                         tenderly_request: None,
+                        summary: vec![],
                     }),
                 });
             let validator =
@@ -3092,7 +3097,7 @@ mod tests {
             .returning(|_| Ok(0u64));
         let mut sim = MockOrderSimulating::new();
         sim.expect_simulate()
-            .returning(|_, _| Err(OrderSimulationError::Infra(anyhow!("RPC down"))));
+            .returning(|_, _, _| Err(OrderSimulationError::Infra(anyhow!("RPC down"))));
         let validator =
             build_1271_validator(signature_validator, Some(order_simulator(sim)), false);
         let result = validator
@@ -3115,11 +3120,12 @@ mod tests {
             .expect_validate_signature_and_get_additional_gas()
             .times(0);
         let mut sim = MockOrderSimulating::new();
-        sim.expect_simulate().returning(|_, _| {
+        sim.expect_simulate().returning(|_, _, _| {
             Err(OrderSimulationError::Reverted {
                 reason: "x".into(),
                 tenderly_url: None,
                 tenderly_request: None,
+                summary: vec![],
             })
         });
         let validator = build_1271_validator(signature_validator, Some(order_simulator(sim)), true);
@@ -3143,7 +3149,7 @@ mod tests {
             .expect_validate_signature_and_get_additional_gas()
             .times(0);
         let mut sim = MockOrderSimulating::new();
-        sim.expect_simulate().times(1).returning(|_, _| Ok(()));
+        sim.expect_simulate().times(1).returning(|_, _, _| Ok(()));
         let validator =
             build_1271_validator(signature_validator, Some(order_simulator(sim)), false);
 


### PR DESCRIPTION
# Description
Follow up to #4538. This PR finally makes use of the features introduces in the previous 2 PRs to address the limitations of the simulation approach. It also addresses 2 other smaller issues with the current code.

# Changes
1. We now use the state override errors and the simulation report to infer whether our state override errors caused the simulation to fail. If everything worked fine until the simulation hits the buy token transfer AND we previously failed to compute the necessary state overrides we now err on the side of allowing the order to be placed. The most relevant examples of this would be orders buying `stETH` or `xStocks` tokens as those are relatively popular and are currently not supported by our balance override code.
2. Most of the simulation disagreements I saw were caused by the new simulation filling the order more than possible. The currently active logic tries to send only 1, 10, and 100 wei of the sell token into the settlement contract (for partially fillable orders). To allow the same partially funded orders to be placed via the new logic we now chose the fill amount as `clamp(1 wei, sellToken.balanceOf(trader), full order amount)`.
3. Lastly we now also pipe the `full_balance_check` into the simulation setup which the user can opt-in to when they only want fully funded orders to be placed.

Additionally this PR also starts logging the order simulation report to help us debug the remaining cases of disagreements faster.

## How to test
Added a unit test for detecting and handling those edge cases of our simulation.
