### PR TITLE
Log orders filtered by driver

### DIFF
--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -19,7 +19,7 @@ use {
             self,
             blockchain::Ethereum,
             notify,
-            observe::{self, metrics},
+            observe::{self, OrderExcludedFromAuctionReason, metrics},
             solver::{self, Account, SolutionMerging, Solver},
         },
         util::math,
@@ -675,7 +675,7 @@ impl Competition {
         let mut balances = balances.as_ref().clone();
         let cow_amms: HashSet<_> = cow_amm_orders.iter().map(|o| o.uid).collect();
 
-        let mut discarded_orders = BTreeMap::<&'static str, Vec<Uid>>::new();
+        let mut discarded_orders = BTreeMap::<OrderExcludedFromAuctionReason, Vec<Uid>>::new();
 
         // The auction that we receive from the `autopilot` assumes that there
         // is sufficient balance to completely cover all the orders. **This is
@@ -719,7 +719,7 @@ impl Competition {
                 Some(balance) => balance,
                 None => {
                     discarded_orders
-                        .entry("could not fetch balance")
+                        .entry(OrderExcludedFromAuctionReason::CouldNotFetchBalance)
                         .or_default()
                         .push(order.uid);
                     return false;
@@ -735,7 +735,7 @@ impl Competition {
             };
             if allocated_balance.0.is_zero() {
                 discarded_orders
-                    .entry("allocated balance is 0")
+                    .entry(OrderExcludedFromAuctionReason::InsufficientBalance)
                     .or_default()
                     .push(order.uid);
                 return false;
@@ -761,7 +761,7 @@ impl Competition {
             }
             if order.available().is_zero() {
                 discarded_orders
-                    .entry("available balance scaled down to 0")
+                    .entry(OrderExcludedFromAuctionReason::OrderWithZeroAmountRemaining)
                     .or_default()
                     .push(order.uid);
                 return false;

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -674,6 +674,8 @@ impl Competition {
         let mut balances = balances.as_ref().clone();
         let cow_amms: HashSet<_> = cow_amm_orders.iter().map(|o| o.uid).collect();
 
+        let mut discarded_orders = vec![];
+
         // The auction that we receive from the `autopilot` assumes that there
         // is sufficient balance to completely cover all the orders. **This is
         // not the case** (as the protocol should not chose which limit orders
@@ -715,8 +717,7 @@ impl Competition {
             )) {
                 Some(balance) => balance,
                 None => {
-                    let reason = observe::OrderExcludedFromAuctionReason::CouldNotFetchBalance;
-                    observe::order_excluded_from_auction(order, reason);
+                    discarded_orders.push((order.uid, "could not fetch balance"));
                     return false;
                 }
             };
@@ -729,10 +730,7 @@ impl Competition {
                 _ => order::SellAmount::default(),
             };
             if allocated_balance.0.is_zero() {
-                observe::order_excluded_from_auction(
-                    order,
-                    observe::OrderExcludedFromAuctionReason::InsufficientBalance,
-                );
+                discarded_orders.push((order.uid, "allocated balance is 0"));
                 return false;
             }
 
@@ -755,10 +753,7 @@ impl Competition {
                 );
             }
             if order.available().is_zero() {
-                observe::order_excluded_from_auction(
-                    order,
-                    observe::OrderExcludedFromAuctionReason::OrderWithZeroAmountRemaining,
-                );
+                discarded_orders.push((order.uid, "available balance is 0"));
                 return false;
             }
 
@@ -766,6 +761,13 @@ impl Competition {
 
             true
         });
+
+        if !discarded_orders.is_empty() {
+            tracing::debug!(
+                ?discarded_orders,
+                "filtered orders during solver specific prioritization logic"
+            );
+        }
 
         auction
     }

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -772,9 +772,10 @@ impl Competition {
             true
         });
 
-        if !discarded_orders.is_empty() {
+        let discarded_total = discarded_orders.values().map(Vec::len).sum::<usize>();
+        if discarded_total > 0 {
             tracing::debug!(
-                total = discarded_orders.values().map(Vec::len).sum::<usize>(),
+                total = discarded_total,
                 ?discarded_orders,
                 "filtered orders during solver specific prioritization logic"
             );

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -764,6 +764,7 @@ impl Competition {
 
         if !discarded_orders.is_empty() {
             tracing::debug!(
+                count = discarded_orders.len(),
                 ?discarded_orders,
                 "filtered orders during solver specific prioritization logic"
             );

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -753,7 +753,7 @@ impl Competition {
                 );
             }
             if order.available().is_zero() {
-                discarded_orders.push((order.uid, "available balance is 0"));
+                discarded_orders.push((order.uid, "available balance scaled down to 0"));
                 return false;
             }
 

--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -8,6 +8,7 @@ use {
     crate::{
         domain::{
             competition::{
+                order::Uid,
                 pre_processing::DataFetchingTasks,
                 solution::Settlement,
                 sorting::SortingStrategy,
@@ -32,7 +33,7 @@ use {
     simulator::{RevertError, Simulator, SimulatorError},
     std::{
         cmp::Reverse,
-        collections::{HashMap, HashSet, VecDeque},
+        collections::{BTreeMap, HashMap, HashSet, VecDeque},
         sync::{Arc, Mutex},
         time::Instant,
     },
@@ -674,7 +675,7 @@ impl Competition {
         let mut balances = balances.as_ref().clone();
         let cow_amms: HashSet<_> = cow_amm_orders.iter().map(|o| o.uid).collect();
 
-        let mut discarded_orders = vec![];
+        let mut discarded_orders = BTreeMap::<&'static str, Vec<Uid>>::new();
 
         // The auction that we receive from the `autopilot` assumes that there
         // is sufficient balance to completely cover all the orders. **This is
@@ -717,7 +718,10 @@ impl Competition {
             )) {
                 Some(balance) => balance,
                 None => {
-                    discarded_orders.push((order.uid, "could not fetch balance"));
+                    discarded_orders
+                        .entry("could not fetch balance")
+                        .or_default()
+                        .push(order.uid);
                     return false;
                 }
             };
@@ -730,7 +734,10 @@ impl Competition {
                 _ => order::SellAmount::default(),
             };
             if allocated_balance.0.is_zero() {
-                discarded_orders.push((order.uid, "allocated balance is 0"));
+                discarded_orders
+                    .entry("allocated balance is 0")
+                    .or_default()
+                    .push(order.uid);
                 return false;
             }
 
@@ -753,7 +760,10 @@ impl Competition {
                 );
             }
             if order.available().is_zero() {
-                discarded_orders.push((order.uid, "available balance scaled down to 0"));
+                discarded_orders
+                    .entry("available balance scaled down to 0")
+                    .or_default()
+                    .push(order.uid);
                 return false;
             }
 
@@ -764,7 +774,7 @@ impl Competition {
 
         if !discarded_orders.is_empty() {
             tracing::debug!(
-                count = discarded_orders.len(),
+                total = discarded_orders.values().map(Vec::len).sum::<usize>(),
                 ?discarded_orders,
                 "filtered orders during solver specific prioritization logic"
             );

--- a/crates/driver/src/infra/observe/mod.rs
+++ b/crates/driver/src/infra/observe/mod.rs
@@ -444,3 +444,10 @@ pub fn sending_solve_request(solver: &str, remaining_time: Duration, is_quote_re
         .with_label_values(&[solver, kind])
         .observe(remaining_time.as_secs_f64());
 }
+
+#[derive(Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub enum OrderExcludedFromAuctionReason {
+    CouldNotFetchBalance,
+    InsufficientBalance,
+    OrderWithZeroAmountRemaining,
+}

--- a/crates/driver/src/infra/observe/mod.rs
+++ b/crates/driver/src/infra/observe/mod.rs
@@ -444,17 +444,3 @@ pub fn sending_solve_request(solver: &str, remaining_time: Duration, is_quote_re
         .with_label_values(&[solver, kind])
         .observe(remaining_time.as_secs_f64());
 }
-
-#[derive(Debug)]
-pub enum OrderExcludedFromAuctionReason {
-    CouldNotFetchBalance,
-    InsufficientBalance,
-    OrderWithZeroAmountRemaining,
-}
-
-pub fn order_excluded_from_auction(
-    order: &competition::Order,
-    reason: OrderExcludedFromAuctionReason,
-) {
-    tracing::trace!(uid=?order.uid, ?reason, "order excluded from auction");
-}


### PR DESCRIPTION
# Description
There are some solver specific order prioritization options which can lead to the driver discarding different orders for different solvers. Figuring out whether a solver got a specific order is therefor not easily possible.
There were already some logs for this but they had the default log level of `trace` (effectively always disabled) and we emitted 1 log per filtered order.

# Changes
Collects all discarded orders and logs them with `debug` level if at least 1 order was discarded.
I chose a `BTreeMap<&'static str, Uid>` since it had the advantages of most containers with minimal downsides:
* naturally grouped which leads to leaner logs
* finding the correct bucket should be basically 0 overhead since no hashing is required
* good cache locality

Also using `&'static str` (instead of `String`) specifically means we can use the entry API without having to create a new string every time.