### PR TITLE
Downsize v3 pool big ints into specific integers

### DIFF
--- a/crates/driver/src/boundary/liquidity/uniswap/v3.rs
+++ b/crates/driver/src/boundary/liquidity/uniswap/v3.rs
@@ -30,7 +30,7 @@ use {
         },
         liquidity_collector::{BackgroundInitLiquiditySource, LiquidityCollecting},
     },
-    std::{collections::BTreeMap, sync::Arc},
+    std::sync::Arc,
 };
 
 pub fn to_domain(id: liquidity::Id, pool: ConcentratedLiquidity) -> Result<liquidity::Liquidity> {
@@ -57,16 +57,14 @@ pub fn to_domain(id: liquidity::Id, pool: ConcentratedLiquidity) -> Result<liqui
             )?,
             sqrt_price: SqrtPrice(pool.pool.state.sqrt_price),
             liquidity: Liquidity(u128::try_from(pool.pool.state.liquidity)?),
-            tick: Tick(pool.pool.state.tick.clone().try_into()?),
+            tick: Tick(pool.pool.state.tick),
             liquidity_net: pool
                 .pool
                 .state
                 .liquidity_net
                 .iter()
-                .map(|(key, value)| -> Result<_> {
-                    Ok((Tick(key.try_into()?), LiquidityNet(value.try_into()?)))
-                })
-                .collect::<Result<BTreeMap<_, _>>>()?,
+                .map(|(key, value)| (Tick(*key), LiquidityNet(*value)))
+                .collect(),
             fee: Fee(pool.pool.state.fee),
         }),
     })

--- a/crates/liquidity-sources/src/uniswap_v3/graph_api.rs
+++ b/crates/liquidity-sources/src/uniswap_v3/graph_api.rs
@@ -11,7 +11,6 @@ use {
     anyhow::Result,
     async_trait::async_trait,
     event_indexing::event_handler::MAX_REORG_BLOCK_COUNT,
-    num::BigInt,
     number::serialization::HexOrDecimalU256,
     reqwest::{Client, Url},
     serde::{Deserialize, Serialize},
@@ -332,7 +331,7 @@ pub struct PoolData {
     #[serde_as(as = "HexOrDecimalU256")]
     pub sqrt_price: U256,
     #[serde_as(as = "DisplayFromStr")]
-    pub tick: BigInt,
+    pub tick: i32,
     pub ticks: Option<Vec<TickData>>,
     /// Not serialised — sources populate this after deserialisation. See
     /// the struct doc for why.
@@ -352,9 +351,9 @@ impl ContainsId for PoolData {
 #[serde(rename_all = "camelCase")]
 pub struct TickData {
     #[serde_as(as = "DisplayFromStr")]
-    pub tick_idx: BigInt,
+    pub tick_idx: i32,
     #[serde_as(as = "DisplayFromStr")]
-    pub liquidity_net: BigInt,
+    pub liquidity_net: i128,
     pub pool_address: Address,
 }
 
@@ -463,7 +462,7 @@ mod tests {
                         fee_tier: U256::from(10000),
                         liquidity: U256::from(303015134493562686441_u128),
                         sqrt_price: U256::from(792216481398733702759960397_u128),
-                        tick: BigInt::from(-92110),
+                        tick: -92110,
                         ticks: None,
                         block_number: 0,
                     },
@@ -480,7 +479,7 @@ mod tests {
                         fee_tier: U256::from(3000),
                         liquidity: U256::from(3125586395511534995_u128),
                         sqrt_price: U256::from(5986323062404391218190509_u128),
-                        tick: BigInt::from(-189822),
+                        tick: -189822,
                         ticks: None,
                         block_number: 0,
                     },
@@ -512,13 +511,13 @@ mod tests {
             Data {
                 inner: vec![
                     TickData {
-                        tick_idx: BigInt::from(0),
-                        liquidity_net: BigInt::from(-303015134493562686441i128),
+                        tick_idx: 0,
+                        liquidity_net: -303015134493562686441i128,
                         pool_address: address!("0x0001fcbba8eb491c3ccfeddc5a5caba1a98c4c28")
                     },
                     TickData {
-                        tick_idx: BigInt::from(-92200),
-                        liquidity_net: BigInt::from(303015134493562686441i128),
+                        tick_idx: -92200,
+                        liquidity_net: 303015134493562686441i128,
                         pool_address: address!("0x0001fcbba8eb491c3ccfeddc5a5caba1a98c4c28")
                     },
                 ],

--- a/crates/liquidity-sources/src/uniswap_v3/pool_fetching.rs
+++ b/crates/liquidity-sources/src/uniswap_v3/pool_fetching.rs
@@ -21,13 +21,12 @@ use {
         maintenance::Maintaining,
     },
     model::TokenPair,
-    num::{BigInt, Zero, rational::Ratio},
+    num::rational::Ratio,
     number::serialization::HexOrDecimalU256,
     serde::Serialize,
     serde_with::{DisplayFromStr, serde_as},
     std::{
         collections::{BTreeMap, HashMap, HashSet},
-        ops::Neg,
         sync::{Arc, Mutex},
     },
     tracing::instrument,
@@ -63,10 +62,10 @@ pub struct PoolState {
     #[serde_as(as = "HexOrDecimalU256")]
     pub liquidity: U256,
     #[serde_as(as = "DisplayFromStr")]
-    pub tick: BigInt,
+    pub tick: i32,
     // (tick_idx, liquidity_net)
     #[serde_as(as = "BTreeMap<DisplayFromStr, DisplayFromStr>")]
-    pub liquidity_net: BTreeMap<BigInt, BigInt>,
+    pub liquidity_net: BTreeMap<i32, i128>,
     #[serde(skip_serializing)]
     pub fee: Ratio<u32>,
 }
@@ -96,7 +95,7 @@ impl TryFrom<PoolData> for PoolInfo {
                     .context("no ticks")?
                     .into_iter()
                     .filter_map(|tick| {
-                        if tick.liquidity_net.is_zero() {
+                        if tick.liquidity_net == 0 {
                             None
                         } else {
                             Some((tick.tick_idx, tick.liquidity_net))
@@ -447,8 +446,17 @@ fn append_events(
             let pool = &mut pool.state;
             match event.inner() {
                 UniswapV3PoolEvents::Burn(burn) => {
-                    let tick_lower = BigInt::from(burn.tickLower.as_i32());
-                    let tick_upper = BigInt::from(burn.tickUpper.as_i32());
+                    let tick_lower = burn.tickLower.as_i32();
+                    let tick_upper = burn.tickUpper.as_i32();
+                    // `amount` is the position's `uint128` liquidity and always fits
+                    // `i128`: it's capped on-chain by `maxLiquidityPerTick` (~1.9e32) which
+                    // is far below `i128::MAX` (~1.7e38), so this branch is unreachable for
+                    // any valid event. We skip the whole event (not just the tick deltas)
+                    // so `liquidity` and `liquidity_net` can't desync.
+                    let Ok(amount) = i128::try_from(burn.amount) else {
+                        tracing::warn!(amount = %burn.amount, "burn liquidity exceeds i128; skipping event");
+                        continue;
+                    };
 
                     // liquidity tracks the liquidity on recent tick,
                     // only need to update it if the new position includes the recent tick.
@@ -456,28 +464,19 @@ fn append_events(
                         pool.liquidity -= U256::from(burn.amount);
                     }
 
-                    pool.liquidity_net
-                        .entry(tick_lower.clone())
-                        .and_modify(|tick| *tick -= BigInt::from(burn.amount))
-                        .or_insert_with(|| BigInt::from(burn.amount).neg());
-
-                    pool.liquidity_net
-                        .entry(tick_upper.clone())
-                        .and_modify(|tick| *tick += BigInt::from(burn.amount))
-                        .or_insert_with(|| BigInt::from(burn.amount));
-
-                    // remove 0 entries to save bandwidth
-                    if pool.liquidity_net[&tick_lower].is_zero() {
-                        pool.liquidity_net.remove(&tick_lower);
-                    }
-
-                    if pool.liquidity_net[&tick_upper].is_zero() {
-                        pool.liquidity_net.remove(&tick_upper);
-                    }
+                    update_liquidity_net(&mut pool.liquidity_net, tick_lower, -amount);
+                    update_liquidity_net(&mut pool.liquidity_net, tick_upper, amount);
                 }
                 UniswapV3PoolEvents::Mint(mint) => {
-                    let tick_lower = BigInt::from(mint.tickLower.as_i32());
-                    let tick_upper = BigInt::from(mint.tickUpper.as_i32());
+                    let tick_lower = mint.tickLower.as_i32();
+                    let tick_upper = mint.tickUpper.as_i32();
+                    // Unreachable for the same reason as the `Burn` arm (per-position
+                    // liquidity is capped well below `i128::MAX`); skip the whole event to
+                    // avoid desyncing `liquidity` from `liquidity_net`.
+                    let Ok(amount) = i128::try_from(mint.amount) else {
+                        tracing::warn!(amount = %mint.amount, "mint liquidity exceeds i128; skipping event");
+                        continue;
+                    };
 
                     // liquidity tracks the liquidity on recent tick,
                     // only need to update it if the new position includes the recent tick.
@@ -485,33 +484,29 @@ fn append_events(
                         pool.liquidity += U256::from(mint.amount);
                     }
 
-                    pool.liquidity_net
-                        .entry(tick_lower.clone())
-                        .and_modify(|tick| *tick += BigInt::from(mint.amount))
-                        .or_insert_with(|| BigInt::from(mint.amount));
-
-                    pool.liquidity_net
-                        .entry(tick_upper.clone())
-                        .and_modify(|tick| *tick -= BigInt::from(mint.amount))
-                        .or_insert_with(|| BigInt::from(mint.amount).neg());
-
-                    // remove 0 entries to save bandwidth
-                    if pool.liquidity_net[&tick_lower].is_zero() {
-                        pool.liquidity_net.remove(&tick_lower);
-                    }
-
-                    if pool.liquidity_net[&tick_upper].is_zero() {
-                        pool.liquidity_net.remove(&tick_upper);
-                    }
+                    update_liquidity_net(&mut pool.liquidity_net, tick_lower, amount);
+                    update_liquidity_net(&mut pool.liquidity_net, tick_upper, -amount);
                 }
                 UniswapV3PoolEvents::Swap(swap) => {
-                    pool.tick = BigInt::from(swap.tick.as_i32());
+                    pool.tick = swap.tick.as_i32();
                     pool.liquidity = U256::from(swap.liquidity);
                     pool.sqrt_price = U256::from(swap.sqrtPriceX96);
                 }
                 _ => continue,
             }
         }
+    }
+}
+
+/// Applies a signed `delta` to a tick's net liquidity, dropping the entry when
+/// it cancels out to zero. The accumulated value mirrors the pool's on-chain
+/// `int128` `liquidityNet`, so a real overflow is impossible; `saturating_add`
+/// just keeps us panic-free against malformed event data.
+fn update_liquidity_net(liquidity_net: &mut BTreeMap<i32, i128>, tick: i32, delta: i128) {
+    let entry = liquidity_net.entry(tick).or_insert(0);
+    *entry = entry.saturating_add(delta);
+    if *entry == 0 {
+        liquidity_net.remove(&tick);
     }
 }
 
@@ -547,7 +542,6 @@ mod tests {
         alloy::primitives::{U160, address, aliases::I24},
         contracts::UniswapV3Pool::UniswapV3Pool::{Burn, Mint, Swap},
         serde_json::json,
-        std::str::FromStr,
         testlib::assert_json_matches,
     };
 
@@ -596,20 +590,11 @@ mod tests {
             state: PoolState {
                 sqrt_price: U256::from(792216481398733702759960397_u128),
                 liquidity: U256::from(303015134493562686441_u128),
-                tick: BigInt::from_str("-92110").unwrap(),
+                tick: -92110,
                 liquidity_net: BTreeMap::from([
-                    (
-                        BigInt::from_str("-122070").unwrap(),
-                        BigInt::from_str("104713649338178916454").unwrap(),
-                    ),
-                    (
-                        BigInt::from_str("-77030").unwrap(),
-                        BigInt::from_str("1182024318125220460617").unwrap(),
-                    ),
-                    (
-                        BigInt::from_str("67260").unwrap(),
-                        BigInt::from_str("5812623076452005012674").unwrap(),
-                    ),
+                    (-122070, 104713649338178916454i128),
+                    (-77030, 1182024318125220460617i128),
+                    (67260, 5812623076452005012674i128),
                 ]),
                 fee: Ratio::new(10_000u32, 1_000_000u32),
             },
@@ -654,7 +639,7 @@ mod tests {
         );
         append_events(&mut pools, vec![event]);
 
-        assert_eq!(pools[&address].state.tick, BigInt::from(3));
+        assert_eq!(pools[&address].state.tick, 3);
         assert_eq!(pools[&address].state.liquidity, U256::from(2));
         assert_eq!(pools[&address].state.sqrt_price, U256::from(1));
     }
@@ -683,10 +668,7 @@ mod tests {
         append_events(&mut pools, vec![event]);
         assert_eq!(
             pools[&address].state.liquidity_net,
-            BTreeMap::from([
-                (BigInt::from(100_000), BigInt::from(-12345)),
-                (BigInt::from(110_000), BigInt::from(12345))
-            ])
+            BTreeMap::from([(100_000, -12345i128), (110_000, 12345i128)])
         );
 
         // add second burn event
@@ -705,9 +687,9 @@ mod tests {
         assert_eq!(
             pools[&address].state.liquidity_net,
             BTreeMap::from([
-                (BigInt::from(100_000), BigInt::from(-12345)),
-                (BigInt::from(105_000), BigInt::from(-54321)),
-                (BigInt::from(110_000), BigInt::from(66666))
+                (100_000, -12345i128),
+                (105_000, -54321i128),
+                (110_000, 66666i128)
             ])
         );
     }
@@ -737,10 +719,7 @@ mod tests {
         append_events(&mut pools, vec![event]);
         assert_eq!(
             pools[&address].state.liquidity_net,
-            BTreeMap::from([
-                (BigInt::from(100_000), BigInt::from(12345)),
-                (BigInt::from(110_000), BigInt::from(-12345))
-            ])
+            BTreeMap::from([(100_000, 12345i128), (110_000, -12345i128)])
         );
 
         // add second burn event
@@ -760,9 +739,9 @@ mod tests {
         assert_eq!(
             pools[&address].state.liquidity_net,
             BTreeMap::from([
-                (BigInt::from(100_000), BigInt::from(12345)),
-                (BigInt::from(105_000), BigInt::from(54321)),
-                (BigInt::from(110_000), BigInt::from(-66666))
+                (100_000, 12345i128),
+                (105_000, 54321i128),
+                (110_000, -66666i128)
             ])
         );
     }

--- a/crates/liquidity-sources/src/uniswap_v3/pool_indexer.rs
+++ b/crates/liquidity-sources/src/uniswap_v3/pool_indexer.rs
@@ -20,7 +20,6 @@ use {
     async_trait::async_trait,
     chain::Chain,
     itertools::Itertools,
-    num::BigInt,
     number::serialization::HexOrDecimalU256,
     reqwest::{Client, Url},
     serde::{Deserialize, Deserializer, de},
@@ -146,7 +145,7 @@ fn deserialize_ticks_by_pool<'de, D: Deserializer<'de>>(
 struct IndexerTick {
     tick_idx: i32,
     #[serde_as(as = "DisplayFromStr")]
-    liquidity_net: BigInt,
+    liquidity_net: i128,
 }
 
 /// Drops pools missing either token's `decimals`. Treating missing as `0`
@@ -196,7 +195,7 @@ impl IndexerPool {
             fee_tier: self.fee_tier,
             liquidity: self.liquidity,
             sqrt_price: self.sqrt_price,
-            tick: BigInt::from(self.tick),
+            tick: self.tick,
             ticks: None,
             block_number,
         })
@@ -206,7 +205,7 @@ impl IndexerPool {
 impl IndexerTick {
     fn into_tick_data(self, pool_address: Address) -> TickData {
         TickData {
-            tick_idx: BigInt::from(self.tick_idx),
+            tick_idx: self.tick_idx,
             liquidity_net: self.liquidity_net,
             pool_address,
         }


### PR DESCRIPTION
# Description
Uniswap v3 pool's ticks are i24 and liquidity_nets are i128, using BigInt incurs quite a bit of overhead, especially for i24:

BigInts are (put very simply) a Vec of u64, so for each i24, we're paying 2x as much just for the number plus the vec pointer and length field, for i128 this is not *as* bad, but since we know the numbers are bounded we can do away with all this overhead.

# Changes

* Ticks -> i32 (we could even use alloy's I24 but i32 is simpler and more ergonomic)
* Liquidity Net -> i128

## How to test

This shows before and after applying this on staging mainnet

<img width="2008" height="806" alt="image" src="https://github.com/user-attachments/assets/3b309188-ec0c-4445-9fd8-2970631460e5" />

The gap between the averages is around ~10MB

<img width="1023" height="399" alt="Screenshot 2026-06-23 at 15 24 17" src="https://github.com/user-attachments/assets/038a5709-a41f-44dc-b246-d8d2989bc42a" />
