### PR TITLE
Return EIP 1271 verification cost from new simulation logic

### DIFF
--- a/crates/shared/src/order_creation_simulation.rs
+++ b/crates/shared/src/order_creation_simulation.rs
@@ -5,7 +5,7 @@ use {
     contracts::ERC20::ERC20,
     model::{
         order::{Order, OrderKind},
-        signature::SigningScheme,
+        signature::{Signature, SigningScheme},
     },
     simulator::{
         report::{Event, SimulationReport},
@@ -44,6 +44,12 @@ pub enum OrderSimulationError {
     Infra(anyhow::Error),
 }
 
+pub struct SimulationSuccess {
+    /// Returns how much gas was needed to verify the order's EIP 1271
+    /// signature (if it had any).
+    pub eip1271_signature_verification_gas: u64,
+}
+
 /// Simulates an order's pre-hooks, swap, and post-hooks against the chain.
 #[cfg_attr(any(test, feature = "test-util"), mockall::automock)]
 #[async_trait]
@@ -53,7 +59,7 @@ pub trait OrderSimulating: Send + Sync {
         order: &Order,
         full_app_data: &str,
         full_balance_check: bool,
-    ) -> Result<(), OrderSimulationError>;
+    ) -> Result<SimulationSuccess, OrderSimulationError>;
 }
 
 /// Drives [`SettlementSimulator`] to run a full-order simulation at order
@@ -76,16 +82,20 @@ impl OrderSimulating for OrderCreationSimulator {
         order: &Order,
         full_app_data: &str,
         full_balance_check: bool,
-    ) -> Result<(), OrderSimulationError> {
+    ) -> Result<SimulationSuccess, OrderSimulationError> {
         let inputs = self
             .prepare_simulation(order, full_app_data, full_balance_check)
             .await?;
 
-        // Fast path for "well behaved" orders which make up the majority.
-        // We only run the more involved analysis logic when something is
-        // actually wrong with the order.
-        if inputs.simulate().await.is_ok() {
-            return Ok(());
+        // Generating a failure report is more costly than a standard simulation.
+        // To avoid unnecessary overhead in the happy path we assume orders are
+        // well behaved and do a regular simulation by default. Except when it's
+        // an EIP 1271 order in which case we always have to run the more complex
+        // code to figure out how much gas the signature check needs.
+        if !matches!(order.signature, Signature::Eip1271(_)) && inputs.simulate().await.is_ok() {
+            return Ok(SimulationSuccess {
+                eip1271_signature_verification_gas: 0,
+            });
         }
 
         analyze_simulation(order, inputs).await
@@ -147,7 +157,7 @@ impl OrderCreationSimulator {
 async fn analyze_simulation(
     order: &Order,
     inputs: EthCallInputs,
-) -> Result<(), OrderSimulationError> {
+) -> Result<SimulationSuccess, OrderSimulationError> {
     let report = inputs
         .simulation_report()
         .await
@@ -160,7 +170,19 @@ async fn analyze_simulation(
         &report,
     ) {
         Some(revert) => revert,
-        None => return Ok(()),
+        None => {
+            let gas = if matches!(order.signature, Signature::Eip1271(_)) {
+                report
+                    .eip1271_gas_cost(&order.metadata.owner)
+                    .map_err(OrderSimulationError::Infra)?
+            } else {
+                0
+            };
+
+            return Ok(SimulationSuccess {
+                eip1271_signature_verification_gas: gas,
+            });
+        }
     };
 
     let tenderly = inputs.simulator.tenderly();

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -80,6 +80,9 @@ impl OrderSimulator {
         order: &Order,
         full_app_data: &str,
         full_balance_check: bool,
+        // todo this should really return a Result<Report, InfraError>
+        // the caller can then try to read as much as possible from the
+        // report and react accordingly
     ) -> Result<(), OrderSimulationError> {
         let start = Instant::now();
         let (outcome, result) = match tokio::time::timeout(

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        order_creation_simulation::{OrderSimulating, OrderSimulationError},
+        order_creation_simulation::{OrderSimulating, OrderSimulationError, SimulationSuccess},
         order_quoting::{
             CalculateQuoteError,
             OrderQuoting,
@@ -80,10 +80,7 @@ impl OrderSimulator {
         order: &Order,
         full_app_data: &str,
         full_balance_check: bool,
-        // todo this should really return a Result<Report, InfraError>
-        // the caller can then try to read as much as possible from the
-        // report and react accordingly
-    ) -> Result<(), OrderSimulationError> {
+    ) -> Result<SimulationSuccess, OrderSimulationError> {
         let start = Instant::now();
         let (outcome, result) = match tokio::time::timeout(
             self.timeout,
@@ -92,7 +89,7 @@ impl OrderSimulator {
         )
         .await
         {
-            Ok(r @ Ok(())) => ("ok", r),
+            Ok(Ok(r)) => ("ok", Ok(r)),
             Ok(r @ Err(OrderSimulationError::Reverted { .. })) => ("reverted", r),
             Ok(r @ Err(OrderSimulationError::Infra(_))) => ("infra", r),
             Err(_) => (
@@ -116,7 +113,7 @@ impl OrderSimulator {
 /// and infra errors as warnings. Agreement is silent.
 fn log_simulation_outcome(
     signature: &Result<u64, SignatureValidationError>,
-    simulation: &Result<(), OrderSimulationError>,
+    simulation: &Result<SimulationSuccess, OrderSimulationError>,
     preview_order: &Order,
     full_app_data: &str,
 ) {
@@ -151,7 +148,7 @@ fn log_simulation_outcome(
                 "order simulation disagreement: signature passed, simulation reverted",
             );
         }
-        (Err(SignatureValidationError::Invalid), Ok(())) => tracing::warn!(
+        (Err(SignatureValidationError::Invalid), Ok(_)) => tracing::warn!(
             ?order_uid,
             ?owner,
             ?order_data,
@@ -3153,7 +3150,9 @@ mod tests {
             sim.expect_simulate()
                 .times(1)
                 .returning(move |_, _, _| match simulation {
-                    Sim::Pass => Ok(()),
+                    Sim::Pass => Ok(SimulationSuccess {
+                        eip1271_signature_verification_gas: 0,
+                    }),
                     Sim::Reverted => Err(OrderSimulationError::Reverted {
                         reason: "hook reverted".into(),
                         tenderly_url: None,
@@ -3241,7 +3240,11 @@ mod tests {
             .expect_validate_signature_and_get_additional_gas()
             .times(0);
         let mut sim = MockOrderSimulating::new();
-        sim.expect_simulate().times(1).returning(|_, _, _| Ok(()));
+        sim.expect_simulate().times(1).returning(|_, _, _| {
+            Ok(SimulationSuccess {
+                eip1271_signature_verification_gas: 0,
+            })
+        });
         let validator =
             build_1271_validator(signature_validator, Some(order_simulator(sim)), false);
 

--- a/crates/simulator/src/report.rs
+++ b/crates/simulator/src/report.rs
@@ -4,6 +4,7 @@ use {
     alloy_sol_types::SolCall,
     contracts::{
         ERC20::ERC20,
+        ERC1271SignatureValidator::ERC1271SignatureValidator,
         FlashLoanRouter::FlashLoanRouter,
         GPv2Settlement::GPv2Settlement,
         ICowWrapper::ICowWrapper,
@@ -33,8 +34,13 @@ pub enum Event {
         target: Address,
         caught_error: Option<String>,
     },
+    Eip1271SignatureCheck {
+        revert: Option<String>,
+        gas: U256,
+        owner: Address,
+    },
     /// All orders had valid signatures.
-    SignatureCheck,
+    AllSignatureChecksSuccessful,
     /// ERC20 token transfer into or from the settlement contract.
     Transfer {
         token: Address,
@@ -143,7 +149,7 @@ fn process_settle_frame(frame: &CallFrame, ctx: &Context, events: &mut Vec<Event
         // the settlement contract. Since this happens AFTER the signature check
         // and signature checks don't always require `CALL`s we use this checkpoint
         // to also signal that the `SignatureCheck` was successful.
-        events.push(Event::SignatureCheck);
+        events.push(Event::AllSignatureChecksSuccessful);
 
         for child_call in &frame.calls {
             if let Ok(call) = ERC20::transferFromCall::abi_decode(&child_call.input) {
@@ -163,6 +169,12 @@ fn process_settle_frame(frame: &CallFrame, ctx: &Context, events: &mut Vec<Event
             to: call.recipient,
             amount: call.amount,
             revert: revert_message(frame),
+        });
+    } else if ERC1271SignatureValidator::isValidSignatureCall::abi_decode(&frame.input).is_ok() {
+        events.push(Event::Eip1271SignatureCheck {
+            gas: frame.gas_used,
+            revert: frame.revert_reason.clone(),
+            owner: to,
         });
     }
 }
@@ -215,7 +227,12 @@ mod tests {
                         wrapper: address!("0x531636e6e18f3a52c283accda39d7185e4597a37"),
                     },
                     Event::SettlementEntered,
-                    Event::SignatureCheck,
+                    Event::Eip1271SignatureCheck {
+                        revert: None,
+                        gas: uint!(7703_U256),
+                        owner: address!("0xcbf50aa2d442548aed93915da99d827e71473dd1"),
+                    },
+                    Event::AllSignatureChecksSuccessful,
                     Event::Transfer {
                         token: address!("0xe91d153e0b41518a2ce8dd3d7944fa863463a97d"),
                         from: address!("0xcbf50aa2d442548aed93915da99d827e71473dd1"),
@@ -281,7 +298,7 @@ mod tests {
                         target: address!("0xc139190f447e929f090edeb554d95abb8b18ac1c"),
                         caught_error: Some("ERC20Permit: invalid signature".to_string()),
                     },
-                    Event::SignatureCheck,
+                    Event::AllSignatureChecksSuccessful,
                     Event::Transfer {
                         token: address!("0xc139190f447e929f090edeb554d95abb8b18ac1c"),
                         from: address!("0x255a1804125356422354f0252b182b8efad1b329"),

--- a/crates/simulator/src/report.rs
+++ b/crates/simulator/src/report.rs
@@ -2,6 +2,7 @@ use {
     alloy_primitives::{Address, Bytes, U256},
     alloy_rpc_types::trace::geth::CallFrame,
     alloy_sol_types::SolCall,
+    anyhow::Context as _,
     contracts::{
         ERC20::ERC20,
         ERC1271SignatureValidator::ERC1271SignatureValidator,
@@ -16,6 +17,24 @@ pub struct SimulationReport {
     pub events: Vec<Event>,
     pub returned_bytes: Option<Bytes>,
     pub revert: Option<String>,
+}
+
+impl SimulationReport {
+    pub fn eip1271_gas_cost(&self, target: &Address) -> Result<u64, anyhow::Error> {
+        for event in &self.events {
+            let Event::Eip1271SignatureCheck { owner, gas, .. } = event else {
+                continue;
+            };
+            if target != owner {
+                continue;
+            }
+            // in reality this overflow can't actually happen
+            return u64::try_from(gas).context("gas cost overflowed u64");
+        }
+        Err(anyhow::anyhow!(
+            "could not find eip1271 signature check for target"
+        ))
+    }
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -34,6 +53,8 @@ pub enum Event {
         target: Address,
         caught_error: Option<String>,
     },
+    /// Information about the `isValidSignature()` call required for EIP 1271
+    /// signatures.
     Eip1271SignatureCheck {
         revert: Option<String>,
         gas: U256,
@@ -216,6 +237,14 @@ mod tests {
             trampoline: &address!("0xd496f9fcfba14d7bd1e45e4840d38ad85ded14dd"),
         };
         let report = generate_settlement_report(context, trace);
+
+        assert_eq!(
+            report
+                .eip1271_gas_cost(&address!("0xcbf50aa2d442548aed93915da99d827e71473dd1"))
+                .unwrap(),
+            7703
+        );
+        assert!(report.eip1271_gas_cost(&Address::ZERO).is_err());
         assert_eq!(
             report,
             SimulationReport {
@@ -298,6 +327,9 @@ mod tests {
                         target: address!("0xc139190f447e929f090edeb554d95abb8b18ac1c"),
                         caught_error: Some("ERC20Permit: invalid signature".to_string()),
                     },
+                    // no additional information about the signature check is available
+                    // as we can only recover that for eip 1271 signatures and the
+                    // order used a different signing scheme
                     Event::AllSignatureChecksSuccessful,
                     Event::Transfer {
                         token: address!("0xc139190f447e929f090edeb554d95abb8b18ac1c"),


### PR DESCRIPTION
# Description
The current eip 1271 verification logic returns the gas cost of the `isValidSignature()` call which gets used [here](https://github.com/cowprotocol/services/blob/f57acbaa73391dac3d27466985952c3ec7d27a5a/crates/shared/src/order_validation.rs#L850). To completely switch to the new simulation logic it also needs to support this.

# Changes
* added a new `Eip1271SignatureCheck` event variant which can just copy the gas cost of the function trace
* adjusted the fast path to not trigger when we need to return the gas cost - otherwise we just return a gas cost of 0

## How to test
Updated the existing xdai test to now expect the new event variant and verified the gas costs are correct with tenderly