### PR TITLE
Drop the pool-indexer wait-until-timeout config

### DIFF
--- a/crates/driver/example.toml
+++ b/crates/driver/example.toml
@@ -98,7 +98,7 @@ max-order-age = "1m"
 
 # [[liquidity.uniswap-v3]] # Uniswap V3 configuration (pool-indexer as data source)
 # preset = "uniswap-v3"
-# indexer-config = { pool-indexer = { url = "http://pool-indexer/", wait-until-timeout = "5m" } }
+# indexer-config = { pool-indexer = { url = "http://pool-indexer/" } }
 # max_pools_to_initialize = 100
 
 # [[liquidity.uniswap-v3]] # Custom Uniswap V3 configuration

--- a/crates/driver/src/boundary/liquidity/uniswap/v3.rs
+++ b/crates/driver/src/boundary/liquidity/uniswap/v3.rs
@@ -151,14 +151,12 @@ async fn build_pool_data_source(
         UniswapV3PoolSource::PoolIndexer(indexer) => {
             tracing::info!(
                 url = %indexer.url,
-                wait_until_timeout = ?indexer.wait_until_timeout,
                 "uniswap v3: using pool-indexer as data source",
             );
             Ok(Arc::new(PoolIndexerClient::new(
                 indexer.url.clone(),
                 eth.chain(),
                 http,
-                indexer.wait_until_timeout,
             )))
         }
         UniswapV3PoolSource::Subgraph(subgraph) => {

--- a/crates/driver/src/infra/config/file/load.rs
+++ b/crates/driver/src/infra/config/file/load.rs
@@ -380,15 +380,11 @@ fn uniswap_v3_pool_source(
                 max_pools_per_tick_query,
             })
         }
-        file::IndexerConfig::PoolIndexer {
-            url,
-            wait_until_timeout,
-        } => liquidity::config::UniswapV3PoolSource::PoolIndexer(
-            liquidity::config::UniswapV3PoolIndexer {
-                url,
-                wait_until_timeout,
-            },
-        ),
+        file::IndexerConfig::PoolIndexer { url } => {
+            liquidity::config::UniswapV3PoolSource::PoolIndexer(
+                liquidity::config::UniswapV3PoolIndexer { url },
+            )
+        }
     }
 }
 

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -637,16 +637,7 @@ enum IndexerConfig {
         max_pools_per_tick_query: usize,
     },
     #[serde(rename_all = "kebab-case")]
-    PoolIndexer {
-        url: Url,
-        /// Upper bound on a single `wait_until` call. Size per-network to
-        /// comfortably exceed the worst-case first-deploy seed time.
-        #[serde(
-            with = "humantime_serde",
-            default = "uniswap_v3::default_pool_indexer_wait_until_timeout"
-        )]
-        wait_until_timeout: Duration,
-    },
+    PoolIndexer { url: Url },
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -656,18 +647,12 @@ enum UniswapV3Preset {
 }
 
 mod uniswap_v3 {
-    use std::time::Duration;
-
     pub fn default_max_pools_to_initialize() -> usize {
         100
     }
 
     pub fn default_max_pools_per_tick_query() -> usize {
         usize::MAX
-    }
-
-    pub fn default_pool_indexer_wait_until_timeout() -> Duration {
-        Duration::from_secs(300)
     }
 }
 
@@ -1203,6 +1188,24 @@ mod tests {
         .unwrap_err();
 
         assert!(err.to_string().contains("must be signers"));
+    }
+
+    #[test]
+    fn pool_indexer_config_needs_only_a_url() {
+        let config: IndexerConfig =
+            toml::from_str(r#"pool-indexer = { url = "http://pool-indexer/" }"#).unwrap();
+        assert!(matches!(config, IndexerConfig::PoolIndexer { .. }));
+    }
+
+    #[test]
+    fn pool_indexer_config_rejects_wait_until_timeout() {
+        // The field was dropped (bootstrap is its own initContainer now); a
+        // stale config still carrying it should fail loudly, not be ignored.
+        let err = toml::from_str::<IndexerConfig>(
+            r#"pool-indexer = { url = "http://pool-indexer/", wait-until-timeout = "5m" }"#,
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("wait-until-timeout"));
     }
 
     #[test]

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -1191,24 +1191,6 @@ mod tests {
     }
 
     #[test]
-    fn pool_indexer_config_needs_only_a_url() {
-        let config: IndexerConfig =
-            toml::from_str(r#"pool-indexer = { url = "http://pool-indexer/" }"#).unwrap();
-        assert!(matches!(config, IndexerConfig::PoolIndexer { .. }));
-    }
-
-    #[test]
-    fn pool_indexer_config_rejects_wait_until_timeout() {
-        // The field was dropped (bootstrap is its own initContainer now); a
-        // stale config still carrying it should fail loudly, not be ignored.
-        let err = toml::from_str::<IndexerConfig>(
-            r#"pool-indexer = { url = "http://pool-indexer/", wait-until-timeout = "5m" }"#,
-        )
-        .unwrap_err();
-        assert!(err.to_string().contains("wait-until-timeout"));
-    }
-
-    #[test]
     fn submission_accounts_new_accepts_signers() {
         let signer = Account::PrivateKey(
             "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"

--- a/crates/driver/src/infra/liquidity/config.rs
+++ b/crates/driver/src/infra/liquidity/config.rs
@@ -175,11 +175,6 @@ pub struct UniswapV3PoolIndexer {
     /// Service root, e.g. `http://pool-indexer/` exposing
     /// `/api/v1/{network}/uniswap/v3/`.
     pub url: Url,
-
-    /// Upper bound on a single `wait_until` call. Size per-network to
-    /// comfortably exceed the worst-case first-deploy seed time (~13 min
-    /// for mainnet's ~60k pools; tens of seconds for smaller chains).
-    pub wait_until_timeout: Duration,
 }
 
 /// Where Uniswap V3 pool definitions and tick data are fetched from. Exactly

--- a/crates/liquidity-sources/src/uniswap_v3/pool_indexer.rs
+++ b/crates/liquidity-sources/src/uniswap_v3/pool_indexer.rs
@@ -31,6 +31,11 @@ use {
 /// Poll interval for [`PoolIndexerClient::wait_until`].
 const WAIT_UNTIL_POLL_INTERVAL: Duration = Duration::from_millis(500);
 
+/// Cap on a single `wait_until` call. Bootstrap now runs as a separate
+/// initContainer, so the serve container is up within seconds — this only
+/// covers the indexer coming up at startup, not the old cold-bootstrap time.
+const WAIT_UNTIL_TIMEOUT: Duration = Duration::from_secs(60);
+
 /// Matches the server-side `MAX_POOL_IDS_PER_REQUEST`.
 const POOL_IDS_PER_REQUEST: usize = 500;
 
@@ -40,20 +45,13 @@ const LIST_PAGE_SIZE: u64 = 5000;
 pub struct PoolIndexerClient {
     base_url: Url,
     http: Client,
-    /// Cap on a single `wait_until` call. Pick per network to exceed the
-    /// worst-case fresh-deploy seed time.
-    wait_until_timeout: Duration,
 }
 
 impl PoolIndexerClient {
-    pub fn new(base_url: Url, chain: Chain, http: Client, wait_until_timeout: Duration) -> Self {
+    pub fn new(base_url: Url, chain: Chain, http: Client) -> Self {
         let prefix = format!("api/v1/{}/uniswap/v3/", chain.as_str());
         let base_url = url_join(&base_url, &prefix);
-        Self {
-            base_url,
-            http,
-            wait_until_timeout,
-        }
+        Self { base_url, http }
     }
 
     fn path(&self, suffix: &str) -> Url {
@@ -216,7 +214,7 @@ impl IndexerTick {
 impl PoolIndexerClient {
     /// Polls `/pools?limit=1` every [`WAIT_UNTIL_POLL_INTERVAL`] until the
     /// envelope reports `block_number >= target_block`. Returns
-    /// immediately if already there; bails after [`Self::wait_until_timeout`].
+    /// immediately if already there; bails after [`WAIT_UNTIL_TIMEOUT`].
     /// [`BlockTarget::Latest`] serves at-head without waiting.
     ///
     /// `503` is treated as "still bootstrapping" and the loop keeps
@@ -226,7 +224,7 @@ impl PoolIndexerClient {
             BlockTarget::Latest => return Ok(()),
             BlockTarget::Number(n) => n,
         };
-        let deadline = std::time::Instant::now() + self.wait_until_timeout;
+        let deadline = std::time::Instant::now() + WAIT_UNTIL_TIMEOUT;
         let mut last_observed: Option<u64> = None;
         let mut interval = tokio::time::interval(WAIT_UNTIL_POLL_INTERVAL);
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
@@ -253,7 +251,7 @@ impl PoolIndexerClient {
                 anyhow::bail!(
                     "pool-indexer wait_until exceeded {:?} waiting for block {target_block}; last \
                      observed indexer block: {last_observed:?}",
-                    self.wait_until_timeout,
+                    WAIT_UNTIL_TIMEOUT,
                 );
             }
         }


### PR DESCRIPTION
# Description

`wait-until-timeout` on the pool-indexer liquidity config was sized (15m default) to cover a cold mainnet bootstrap back when bootstrap ran inside the serve container. Since the bootstrap-split (#4559) bootstrap runs as a separate initContainer, so the serve container is ready within seconds and the driver never waits on a cold bootstrap. The value was obsolete, and the long timeout was actively harmful as it hides a misconfigured or unreachable indexer for up to 15 mins (or hte configured timeout for that network), and the maintenance loop spends the full timeout each cycle waiting for a block the finalized-serving indexer never reaches.

# Changes

* Removed `wait_until_timeout` from the driver's V3 pool-indexer config: the file config (`IndexerConfig::PoolIndexer`) and its default, the domain config (`UniswapV3PoolIndexer`), the config mapping, and the client constructor.