### PR TITLE
Pick median native price

### DIFF
--- a/crates/configs/src/native_price.rs
+++ b/crates/configs/src/native_price.rs
@@ -13,7 +13,7 @@ const fn default_cache_concurrent_requests() -> NonZeroUsize {
 }
 
 const fn default_results_required() -> NonZeroUsize {
-    NonZeroUsize::new(2).expect("value should not be zero")
+    NonZeroUsize::new(3).expect("value should not be zero")
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/crates/price-estimation/src/competition/mod.rs
+++ b/crates/price-estimation/src/competition/mod.rs
@@ -42,10 +42,7 @@ pub struct CompetitionEstimator<T> {
 }
 
 impl<T: Send + Sync + 'static> CompetitionEstimator<T> {
-    pub fn new(
-        stages: Vec<PriceEstimationStage<T>>,
-        quote_context_mode: QuoteContextMode,
-    ) -> Self {
+    pub fn new(stages: Vec<PriceEstimationStage<T>>, quote_context_mode: QuoteContextMode) -> Self {
         assert!(!stages.is_empty());
         assert!(stages.iter().all(|stage| !stage.is_empty()));
         Self {

--- a/crates/price-estimation/src/competition/mod.rs
+++ b/crates/price-estimation/src/competition/mod.rs
@@ -37,18 +37,21 @@ type ResultWithIndex<O> = (EstimatorIndex, Result<O, PriceEstimationError>);
 pub struct CompetitionEstimator<T> {
     stages: Vec<PriceEstimationStage<T>>,
     usable_results_for_early_return: NonZeroUsize,
-    ranking: PriceRanking,
+    quote_context_mode: QuoteContextMode,
     verification_mode: QuoteVerificationMode,
 }
 
 impl<T: Send + Sync + 'static> CompetitionEstimator<T> {
-    pub fn new(stages: Vec<PriceEstimationStage<T>>, ranking: PriceRanking) -> Self {
+    pub fn new(
+        stages: Vec<PriceEstimationStage<T>>,
+        quote_context_mode: QuoteContextMode,
+    ) -> Self {
         assert!(!stages.is_empty());
         assert!(stages.iter().all(|stage| !stage.is_empty()));
         Self {
             stages,
             usable_results_for_early_return: NonZeroUsize::MAX,
-            ranking,
+            quote_context_mode,
             verification_mode: QuoteVerificationMode::Unverified,
         }
     }
@@ -231,14 +234,14 @@ fn metrics() -> &'static Metrics {
         .expect("unexpected error getting metrics instance")
 }
 
-/// The metric which decides the winning price estimate.
+/// Controls which data will be provided in addition to the
+/// quote to determine which quote is better.
 #[derive(Clone)]
-pub enum PriceRanking {
-    /// The highest quoted `out_amount` gets picked regardless of trade
-    /// complexity.
-    MaxOutAmount,
-    /// Returns the estimate where `out_amount - fees` is highest.
-    BestBangForBuck {
+pub enum QuoteContextMode {
+    /// No additional data will be provided.
+    None,
+    /// Returns information to determine the gas cost of a quote.
+    GasCost {
         native: Arc<dyn NativePriceEstimating>,
         gas: Arc<dyn GasPriceEstimating>,
     },
@@ -361,7 +364,7 @@ mod tests {
                 ("first".to_owned(), Arc::new(first)),
                 ("second".to_owned(), Arc::new(second)),
             ]],
-            PriceRanking::MaxOutAmount,
+            QuoteContextMode::None,
         );
 
         let result = priority.estimate(queries[0].clone()).await;
@@ -444,7 +447,7 @@ mod tests {
                 ("second".to_owned(), Arc::new(second)),
                 ("third".to_owned(), Arc::new(third)),
             ]],
-            PriceRanking::MaxOutAmount,
+            QuoteContextMode::None,
         );
         let racing = racing.with_early_return(1.try_into().unwrap());
 
@@ -521,7 +524,7 @@ mod tests {
                     ("fourth".to_owned(), Arc::new(fourth)),
                 ],
             ],
-            PriceRanking::MaxOutAmount,
+            QuoteContextMode::None,
         );
         let racing = racing.with_early_return(2.try_into().unwrap());
 
@@ -591,7 +594,7 @@ mod tests {
                 vec![("fourth".to_owned(), Arc::new(fourth))],
             ],
             usable_results_for_early_return: NonZeroUsize::new(2).unwrap(),
-            ranking: PriceRanking::MaxOutAmount,
+            quote_context_mode: QuoteContextMode::None,
             verification_mode: QuoteVerificationMode::Unverified,
         };
 

--- a/crates/price-estimation/src/competition/native.rs
+++ b/crates/price-estimation/src/competition/native.rs
@@ -51,34 +51,34 @@ impl NativePriceEstimating for CompetitionEstimator<Arc<dyn NativePriceEstimatin
                     .boxed()
                 })
                 .await;
-            let winner = pick_median_price(results)
-                .context("could not get any native price")?;
+            let winner = pick_median_price(results).context("could not get any native price")?;
             self.report_winner(&token, OrderKind::Buy, winner)
         }
         .boxed()
     }
 }
 
-/// There are no rewards or penalties for providing native prices which means there
-/// are very little incentives for solvers to provide accurate prices. This can lead
-/// to wildly inaccurate prices. Because native prices don't have to be super competitive
-/// we pick the median price instead of the very best one.
+/// There are no rewards or penalties for providing native prices which means
+/// there are very little incentives for solvers to provide accurate prices.
+/// This can lead to wildly inaccurate prices. Because native prices don't have
+/// to be super competitive we pick the median price instead of the very best
+/// one.
 fn pick_median_price(
     results: Vec<super::ResultWithIndex<f64>>,
 ) -> Option<super::ResultWithIndex<f64>> {
     let (mut prices, errs): (Vec<_>, Vec<_>) =
-        results
-            .into_iter()
-            .partition_map(|(idx, r)| match r {
-                Ok(price) => Either::Left((idx, price)),
-                Err(e) => Either::Right((idx, e)),
-            });
+        results.into_iter().partition_map(|(idx, r)| match r {
+            Ok(price) => Either::Left((idx, price)),
+            Err(e) => Either::Right((idx, e)),
+        });
     if prices.is_empty() {
         errs.into_iter()
             .max_by(|(_, a), (_, b)| compare_error(a, b))
             .map(|(idx, e)| (idx, Err(e)))
     } else {
-        prices.sort_by(|(_, a), (_, b)| a.total_cmp(b));
+        // we sort prices from best to worst so that `len / 2` skews
+        // in favour of worse prices as high prices have worse consequences
+        prices.sort_by(|(_, a), (_, b)| b.total_cmp(a));
         let (idx, price) = prices.remove(prices.len() / 2);
         Some((idx, Ok(price)))
     }
@@ -144,6 +144,17 @@ mod tests {
         )
         .await;
         assert_eq!(best, Ok(2.));
+    }
+
+    #[tokio::test]
+    async fn median_price_skews_towards_worse_price() {
+        // With 2 estimates, we chose the worse price
+        let best = best_response(
+            PriceRanking::MaxOutAmount,
+            vec![async { Ok(1.) }.boxed(), async { Ok(2.) }.boxed()],
+        )
+        .await;
+        assert_eq!(best, Ok(1.));
     }
 
     /// If all estimators returned an error we return the one with the highest

--- a/crates/price-estimation/src/competition/native.rs
+++ b/crates/price-estimation/src/competition/native.rs
@@ -99,8 +99,10 @@ mod tests {
     type NativePriceFuture =
         Pin<Box<dyn Future<Output = Result<f64, PriceEstimationError>> + Send>>;
 
+    /// Returns the best native estimate with respect to the provided ranking
+    /// and order kind.
     async fn best_response(
-        quote_context_mode: QuoteContextMode,
+        ranking: QuoteContextMode,
         estimates: Vec<NativePriceFuture>,
     ) -> Result<f64, PriceEstimationError> {
         fn estimator(estimate: NativePriceFuture) -> Arc<dyn NativePriceEstimating> {
@@ -121,7 +123,7 @@ mod tests {
                         .map(|(i, e)| (format!("estimator_{i}"), estimator(e)))
                         .collect(),
                 ],
-                quote_context_mode.clone(),
+                ranking.clone(),
             );
 
         priority

--- a/crates/price-estimation/src/competition/native.rs
+++ b/crates/price-estimation/src/competition/native.rs
@@ -99,10 +99,8 @@ mod tests {
     type NativePriceFuture =
         Pin<Box<dyn Future<Output = Result<f64, PriceEstimationError>> + Send>>;
 
-    /// Returns the best native estimate with respect to the provided ranking
-    /// and order kind.
     async fn best_response(
-        ranking: QuoteContextMode,
+        quote_context_mode: QuoteContextMode,
         estimates: Vec<NativePriceFuture>,
     ) -> Result<f64, PriceEstimationError> {
         fn estimator(estimate: NativePriceFuture) -> Arc<dyn NativePriceEstimating> {
@@ -123,7 +121,7 @@ mod tests {
                         .map(|(i, e)| (format!("estimator_{i}"), estimator(e)))
                         .collect(),
                 ],
-                ranking.clone(),
+                quote_context_mode.clone(),
             );
 
         priority

--- a/crates/price-estimation/src/competition/native.rs
+++ b/crates/price-estimation/src/competition/native.rs
@@ -7,8 +7,9 @@ use {
     alloy::primitives::Address,
     anyhow::Context,
     futures::{FutureExt, future::BoxFuture},
+    itertools::{Either, Itertools},
     model::order::OrderKind,
-    std::{cmp::Ordering, sync::Arc, time::Duration},
+    std::{sync::Arc, time::Duration},
     tracing::instrument,
 };
 
@@ -50,9 +51,7 @@ impl NativePriceEstimating for CompetitionEstimator<Arc<dyn NativePriceEstimatin
                     .boxed()
                 })
                 .await;
-            let winner = results
-                .into_iter()
-                .max_by(|a, b| compare_native_result(&a.1, &b.1))
+            let winner = pick_median_price(results)
                 .context("could not get any native price")?;
             self.report_winner(&token, OrderKind::Buy, winner)
         }
@@ -60,15 +59,28 @@ impl NativePriceEstimating for CompetitionEstimator<Arc<dyn NativePriceEstimatin
     }
 }
 
-fn compare_native_result(
-    a: &Result<f64, PriceEstimationError>,
-    b: &Result<f64, PriceEstimationError>,
-) -> Ordering {
-    match (a, b) {
-        (Ok(a), Ok(b)) => a.total_cmp(b),
-        (Ok(_), Err(_)) => Ordering::Greater,
-        (Err(_), Ok(_)) => Ordering::Less,
-        (Err(a), Err(b)) => compare_error(a, b),
+/// There are no rewards or penalties for providing native prices which means there
+/// are very little incentives for solvers to provide accurate prices. This can lead
+/// to wildly inaccurate prices. Because native prices don't have to be super competitive
+/// we pick the median price instead of the very best one.
+fn pick_median_price(
+    results: Vec<super::ResultWithIndex<f64>>,
+) -> Option<super::ResultWithIndex<f64>> {
+    let (mut prices, errs): (Vec<_>, Vec<_>) =
+        results
+            .into_iter()
+            .partition_map(|(idx, r)| match r {
+                Ok(price) => Either::Left((idx, price)),
+                Err(e) => Either::Right((idx, e)),
+            });
+    if prices.is_empty() {
+        errs.into_iter()
+            .max_by(|(_, a), (_, b)| compare_error(a, b))
+            .map(|(idx, e)| (idx, Err(e)))
+    } else {
+        prices.sort_by(|(_, a), (_, b)| a.total_cmp(b));
+        let (idx, price) = prices.remove(prices.len() / 2);
+        Some((idx, Ok(price)))
     }
 }
 
@@ -119,14 +131,16 @@ mod tests {
             .await
     }
 
-    /// If all estimators returned an error we return the one with the highest
-    /// priority.
     #[tokio::test]
-    async fn returns_highest_native_price() {
-        // Returns errors with highest priority.
+    async fn returns_median_native_price() {
+        // With 3 estimates, the median (middle value) is returned, ignoring outliers.
         let best = best_response(
             PriceRanking::MaxOutAmount,
-            vec![async { Ok(1.) }.boxed(), async { Ok(2.) }.boxed()],
+            vec![
+                async { Ok(1.) }.boxed(),
+                async { Ok(100.) }.boxed(),
+                async { Ok(2.) }.boxed(),
+            ],
         )
         .await;
         assert_eq!(best, Ok(2.));

--- a/crates/price-estimation/src/competition/native.rs
+++ b/crates/price-estimation/src/competition/native.rs
@@ -90,7 +90,7 @@ mod tests {
         super::*,
         crate::{
             HEALTHY_PRICE_ESTIMATION_TIME,
-            competition::PriceRanking,
+            competition::QuoteContextMode,
             native::MockNativePriceEstimating,
         },
         std::pin::Pin,
@@ -102,7 +102,7 @@ mod tests {
     /// Returns the best native estimate with respect to the provided ranking
     /// and order kind.
     async fn best_response(
-        ranking: PriceRanking,
+        ranking: QuoteContextMode,
         estimates: Vec<NativePriceFuture>,
     ) -> Result<f64, PriceEstimationError> {
         fn estimator(estimate: NativePriceFuture) -> Arc<dyn NativePriceEstimating> {
@@ -133,9 +133,10 @@ mod tests {
 
     #[tokio::test]
     async fn returns_median_native_price() {
-        // With 3 estimates, the median (middle value) is returned, ignoring outliers.
+        // with 3 or more estimates, the median (middle value) is returned, protecting
+        // us against outliers
         let best = best_response(
-            PriceRanking::MaxOutAmount,
+            QuoteContextMode::None,
             vec![
                 async { Ok(1.) }.boxed(),
                 async { Ok(100.) }.boxed(),
@@ -148,9 +149,10 @@ mod tests {
 
     #[tokio::test]
     async fn median_price_skews_towards_worse_price() {
-        // With 2 estimates, we chose the worse price
+        // with 2 estimates, we chose the worse price as unreasonably high prices
+        // cause more issues than low prices
         let best = best_response(
-            PriceRanking::MaxOutAmount,
+            QuoteContextMode::None,
             vec![async { Ok(1.) }.boxed(), async { Ok(2.) }.boxed()],
         )
         .await;
@@ -163,7 +165,7 @@ mod tests {
     async fn returns_highest_priority_error_native() {
         // Returns errors with highest priority.
         let best = best_response(
-            PriceRanking::MaxOutAmount,
+            QuoteContextMode::None,
             vec![
                 async { Err(PriceEstimationError::RateLimited) }.boxed(),
                 async { Err(PriceEstimationError::ProtocolInternal(anyhow::anyhow!("!"))) }.boxed(),
@@ -178,7 +180,7 @@ mod tests {
     #[tokio::test]
     async fn prefer_estimate_over_error_native() {
         let best = best_response(
-            PriceRanking::MaxOutAmount,
+            QuoteContextMode::None,
             vec![
                 async { Ok(1.) }.boxed(),
                 async { Err(PriceEstimationError::RateLimited) }.boxed(),
@@ -196,7 +198,7 @@ mod tests {
 
         for price in [f64::NEG_INFINITY, -1., 0., f64::INFINITY, subnormal] {
             let best = best_response(
-                PriceRanking::MaxOutAmount,
+                QuoteContextMode::None,
                 vec![async move { Ok(price) }.boxed()],
             )
             .await;
@@ -270,7 +272,7 @@ mod tests {
                         ),
                     )],
                 ],
-                PriceRanking::MaxOutAmount,
+                QuoteContextMode::None,
             )
             // allow bailing out after 1 successful result to prevent both
             // stages to be kicked-off at the same time (if we have too few stages

--- a/crates/price-estimation/src/competition/quote.rs
+++ b/crates/price-estimation/src/competition/quote.rs
@@ -144,8 +144,7 @@ enum QuoteContext {
     /// would be lost due to paying for the gas cost.
     /// If an extremely complex trade route would only result
     /// in slightly more `out_amount` than a simple trade route the simple
-    /// trade route would report a higher `effective_out_amount`. This is also
-    /// referred to as "bang-for-buck" and what matters most to traders.
+    /// trade route would report a higher effective out_amount.
     GasCost {
         native_price: f64,
         gas_price: f64,
@@ -165,13 +164,13 @@ impl QuoteContext {
             } => {
                 let eth_out = f64::from(estimate.out_amount) * native_price;
                 let fees = estimate.gas as f64 * gas_price;
-                let effective_eth_out = match kind {
+                let effective_out = match kind {
                     // High fees mean receiving less `buy_token` from your sell order.
                     OrderKind::Sell => eth_out - fees,
                     // High fees mean paying more `sell_token` for your buy order.
                     OrderKind::Buy => eth_out + fees,
                 };
-                match effective_eth_out {
+                match effective_out {
                     // converts `NaN` and `(-∞, 0]` to `0`
                     v if v.is_sign_negative() || v.is_nan() => U256::ZERO,
                     // Previous case already covered negative infinity
@@ -331,11 +330,11 @@ mod tests {
         Err(err)
     }
 
-    /// Builds a `BestBangForBuck` setup where every token is estimated
+    /// Builds a `GasCost` setup where every token is estimated
     /// to be half as valuable as ETH and the gas price is 2.
     /// That effectively means every unit of `gas` in an estimate worth
     /// 4 units of `out_amount`.
-    fn bang_for_buck_ranking() -> QuoteContextMode {
+    fn gas_cost_mode() -> QuoteContextMode {
         // Make `out_token` half as valuable as `ETH` and set gas price to 2.
         // That means 1 unit of `gas` is equal to 4 units of `out_token`.
         let mut native = MockNativePriceEstimating::new();
@@ -352,10 +351,10 @@ mod tests {
         }
     }
 
-    /// Returns the best estimate with respect to the provided ranking and order
-    /// kind.
+    /// Returns the best estimate with respect to the provided quote context
+    /// mode and order kind.
     async fn best_response(
-        ranking: QuoteContextMode,
+        quote_context_mode: QuoteContextMode,
         kind: OrderKind,
         estimates: Vec<PriceEstimateResult>,
         verification: QuoteVerificationMode,
@@ -377,7 +376,7 @@ mod tests {
                     .map(|(i, e)| (format!("estimator_{i}"), estimator(e)))
                     .collect(),
             ],
-            ranking.clone(),
+            quote_context_mode.clone(),
         )
         .with_verification(verification);
 
@@ -389,15 +388,15 @@ mod tests {
             .await
     }
 
-    /// Verifies that `PriceRanking::BestBangForBuck` correctly adjusts
+    /// Verifies that `QuoteContextMode::GasCost` correctly adjusts
     /// `out_amount` of quotes based on the `gas` used for the quote. E.g.
     /// if a quote requires a significantly more complex execution but does
     /// not provide a significantly better `out_amount` than a simpler quote
     /// the simpler quote will be preferred.
     #[tokio::test]
-    async fn best_bang_for_buck_adjusts_for_complexity() {
+    async fn gas_cost_adjusts_for_complexity() {
         let best = best_response(
-            bang_for_buck_ranking(),
+            gas_cost_mode(),
             OrderKind::Sell,
             vec![
                 // User effectively receives `100_000` `buy_token`.
@@ -411,7 +410,7 @@ mod tests {
         assert_eq!(best, price(104_000, 1_000));
 
         let best = best_response(
-            bang_for_buck_ranking(),
+            gas_cost_mode(),
             OrderKind::Buy,
             vec![
                 // User effectively pays `100_000` `sell_token`.
@@ -432,7 +431,7 @@ mod tests {
     #[tokio::test]
     async fn discards_low_gas_cost_estimates() {
         let best = best_response(
-            bang_for_buck_ranking(),
+            gas_cost_mode(),
             OrderKind::Sell,
             vec![
                 // User effectively receives `100_000` `buy_token`.
@@ -449,7 +448,7 @@ mod tests {
         assert_eq!(best, price(104_000, 1_000));
 
         let best = best_response(
-            bang_for_buck_ranking(),
+            gas_cost_mode(),
             OrderKind::Buy,
             vec![
                 // User effectively pays `100_000` `sell_token`.

--- a/crates/price-estimation/src/competition/quote.rs
+++ b/crates/price-estimation/src/competition/quote.rs
@@ -1,5 +1,5 @@
 use {
-    super::{CompetitionEstimator, PriceRanking, compare_error},
+    super::{CompetitionEstimator, QuoteContextMode, compare_error},
     crate::{
         Estimate,
         PriceEstimateResult,
@@ -31,7 +31,9 @@ impl PriceEstimating for CompetitionEstimator<Arc<dyn PriceEstimating>> {
                 OrderKind::Buy => query.sell_token,
                 OrderKind::Sell => query.buy_token,
             };
-            let get_context = self.ranking.provide_context(out_token, query.timeout);
+            let get_context = self
+                .quote_context_mode
+                .provide_context(out_token, query.timeout);
 
             // Filter out obviously wrong estimates:
             // - 0 gas cost would lead to us paying huge subsidies
@@ -84,7 +86,7 @@ fn compare_quote_result(
     query: &Query,
     a: &PriceEstimateResult,
     b: &PriceEstimateResult,
-    context: &RankingContext,
+    context: &QuoteContext,
     prefer_verified_estimates: bool,
 ) -> Ordering {
     match (a, b) {
@@ -102,27 +104,24 @@ fn compare_quote_result(
     }
 }
 
-fn compare_quote(query: &Query, a: &Estimate, b: &Estimate, context: &RankingContext) -> Ordering {
-    let a = context.effective_eth_out(a, query.kind);
-    let b = context.effective_eth_out(b, query.kind);
+fn compare_quote(query: &Query, a: &Estimate, b: &Estimate, context: &QuoteContext) -> Ordering {
+    let a = context.out_amount(a, query.kind);
+    let b = context.out_amount(b, query.kind);
     match query.kind {
         OrderKind::Buy => a.cmp(&b).reverse(),
         OrderKind::Sell => a.cmp(&b),
     }
 }
 
-impl PriceRanking {
+impl QuoteContextMode {
     async fn provide_context(
         &self,
         token: Address,
         timeout: Duration,
-    ) -> Result<RankingContext, PriceEstimationError> {
+    ) -> Result<QuoteContext, PriceEstimationError> {
         match self {
-            PriceRanking::MaxOutAmount => Ok(RankingContext {
-                native_price: 1.0,
-                gas_price: 0.,
-            }),
-            PriceRanking::BestBangForBuck { native, gas } => {
+            QuoteContextMode::None => Ok(QuoteContext::None),
+            QuoteContextMode::GasCost { native, gas } => {
                 let gas = gas.clone();
                 let native = native.clone();
                 let gas = gas
@@ -131,7 +130,7 @@ impl PriceRanking {
                 let (native_price, gas_price) =
                     futures::try_join!(native.estimate_native_price(token, timeout), gas)?;
 
-                Ok(RankingContext {
+                Ok(QuoteContext::GasCost {
                     native_price,
                     gas_price: gas_price as f64,
                 })
@@ -140,35 +139,50 @@ impl PriceRanking {
     }
 }
 
-struct RankingContext {
-    native_price: f64,
-    gas_price: f64,
+enum QuoteContext {
+    /// Provides enough context to estimate how much of the quote's out_amount
+    /// would be lost due to paying for the gas cost.
+    /// If an extremely complex trade route would only result
+    /// in slightly more `out_amount` than a simple trade route the simple
+    /// trade route would report a higher `effective_out_amount`. This is also
+    /// referred to as "bang-for-buck" and what matters most to traders.
+    GasCost {
+        native_price: f64,
+        gas_price: f64,
+    },
+    None,
 }
 
-impl RankingContext {
-    /// Computes the actual received value from this estimate that takes `gas`
-    /// into account. If an extremely complex trade route would only result
-    /// in slightly more `out_amount` than a simple trade route the simple
-    /// trade route would report a higher `out_amount_in_eth`. This is also
-    /// referred to as "bang-for-buck" and what matters most to traders.
-    fn effective_eth_out(&self, estimate: &Estimate, kind: OrderKind) -> U256 {
-        let eth_out = f64::from(estimate.out_amount) * self.native_price;
-        let fees = estimate.gas as f64 * self.gas_price;
-        let effective_eth_out = match kind {
-            // High fees mean receiving less `buy_token` from your sell order.
-            OrderKind::Sell => eth_out - fees,
-            // High fees mean paying more `sell_token` for your buy order.
-            OrderKind::Buy => eth_out + fees,
-        };
-        match effective_eth_out {
-            // converts `NaN` and `(-∞, 0]` to `0`
-            v if v.is_sign_negative() || v.is_nan() => U256::ZERO,
-            // Previous case already covered negative infinity
-            v if v.is_infinite() => U256::MAX,
-            // Note on truncation: previously we used primitive_types::U256::from_f64_lossy which
-            // truncated the floating point, while alloy is slightly more faithful to the original
-            // value and rounds to closest integer: [0, 0.5) => 0, [0.5, 1] => 1
-            v => U256::from(v.trunc()),
+impl QuoteContext {
+    /// Computes the actual received value from this estimate given the
+    /// available context.
+    fn out_amount(&self, estimate: &Estimate, kind: OrderKind) -> U256 {
+        match self {
+            QuoteContext::None => estimate.out_amount,
+            QuoteContext::GasCost {
+                native_price,
+                gas_price,
+            } => {
+                let eth_out = f64::from(estimate.out_amount) * native_price;
+                let fees = estimate.gas as f64 * gas_price;
+                let effective_eth_out = match kind {
+                    // High fees mean receiving less `buy_token` from your sell order.
+                    OrderKind::Sell => eth_out - fees,
+                    // High fees mean paying more `sell_token` for your buy order.
+                    OrderKind::Buy => eth_out + fees,
+                };
+                match effective_eth_out {
+                    // converts `NaN` and `(-∞, 0]` to `0`
+                    v if v.is_sign_negative() || v.is_nan() => U256::ZERO,
+                    // Previous case already covered negative infinity
+                    v if v.is_infinite() => U256::MAX,
+                    // Note on truncation: previously we used primitive_types::U256::from_f64_lossy
+                    // which truncated the floating point, while alloy is
+                    // slightly more faithful to the original value and rounds
+                    // to closest integer: [0, 0.5) => 0, [0.5, 1] => 1
+                    v => U256::from(v.trunc()),
+                }
+            }
         }
     }
 }
@@ -321,7 +335,7 @@ mod tests {
     /// to be half as valuable as ETH and the gas price is 2.
     /// That effectively means every unit of `gas` in an estimate worth
     /// 4 units of `out_amount`.
-    fn bang_for_buck_ranking() -> PriceRanking {
+    fn bang_for_buck_ranking() -> QuoteContextMode {
         // Make `out_token` half as valuable as `ETH` and set gas price to 2.
         // That means 1 unit of `gas` is equal to 4 units of `out_token`.
         let mut native = MockNativePriceEstimating::new();
@@ -332,7 +346,7 @@ mod tests {
             max_fee_per_gas: 2,
             max_priority_fee_per_gas: 2,
         }));
-        PriceRanking::BestBangForBuck {
+        QuoteContextMode::GasCost {
             native: Arc::new(native),
             gas,
         }
@@ -341,7 +355,7 @@ mod tests {
     /// Returns the best estimate with respect to the provided ranking and order
     /// kind.
     async fn best_response(
-        ranking: PriceRanking,
+        ranking: QuoteContextMode,
         kind: OrderKind,
         estimates: Vec<PriceEstimateResult>,
         verification: QuoteVerificationMode,
@@ -458,7 +472,7 @@ mod tests {
     async fn returns_highest_priority_error() {
         // Returns errors with highest priority.
         let best = best_response(
-            PriceRanking::MaxOutAmount,
+            QuoteContextMode::None,
             OrderKind::Sell,
             vec![
                 error(PriceEstimationError::RateLimited),
@@ -474,7 +488,7 @@ mod tests {
     #[tokio::test]
     async fn prefer_estimate_over_error() {
         let best = best_response(
-            PriceRanking::MaxOutAmount,
+            QuoteContextMode::None,
             OrderKind::Sell,
             vec![
                 price(1, 1_000_000),
@@ -502,7 +516,7 @@ mod tests {
         });
 
         let best = best_response(
-            PriceRanking::MaxOutAmount,
+            QuoteContextMode::None,
             OrderKind::Sell,
             vec![
                 better_unverified_quote.clone(),
@@ -514,7 +528,7 @@ mod tests {
         assert_eq!(best, worse_verified_quote.clone());
 
         let best = best_response(
-            PriceRanking::MaxOutAmount,
+            QuoteContextMode::None,
             OrderKind::Sell,
             vec![
                 better_unverified_quote.clone(),

--- a/crates/price-estimation/src/factory.rs
+++ b/crates/price-estimation/src/factory.rs
@@ -358,11 +358,9 @@ impl<'a> PriceEstimatorFactory<'a> {
         gas: Arc<dyn GasPriceEstimating>,
     ) -> Result<Arc<dyn PriceEstimating>> {
         let estimators = self.get_estimators(solvers, |entry| &entry.optimal)?;
-        let competition_estimator = CompetitionEstimator::new(
-            vec![estimators],
-            QuoteContextMode::GasCost { native, gas },
-        )
-        .with_verification(self.args.quote_verification);
+        let competition_estimator =
+            CompetitionEstimator::new(vec![estimators], QuoteContextMode::GasCost { native, gas })
+                .with_verification(self.args.quote_verification);
         Ok(Arc::new(self.sanitized(Arc::new(competition_estimator))))
     }
 
@@ -403,10 +401,9 @@ impl<'a> PriceEstimatorFactory<'a> {
             estimators.push(stages);
         }
 
-        let competition_estimator =
-            CompetitionEstimator::new(estimators, QuoteContextMode::None)
-                .with_verification(self.args.quote_verification)
-                .with_early_return(results_required);
+        let competition_estimator = CompetitionEstimator::new(estimators, QuoteContextMode::None)
+            .with_verification(self.args.quote_verification)
+            .with_early_return(results_required);
         Ok(Box::new(competition_estimator))
     }
 

--- a/crates/price-estimation/src/factory.rs
+++ b/crates/price-estimation/src/factory.rs
@@ -13,7 +13,7 @@ use {
     crate::{
         ExternalSolver,
         buffered::{self, BufferedRequest, NativePriceBatchFetching},
-        competition::PriceRanking,
+        competition::QuoteContextMode,
         config::{native_price::NativePriceConfig, price_estimation::BalanceOverridesConfigExt},
     },
     alloy::primitives::Address,
@@ -360,7 +360,7 @@ impl<'a> PriceEstimatorFactory<'a> {
         let estimators = self.get_estimators(solvers, |entry| &entry.optimal)?;
         let competition_estimator = CompetitionEstimator::new(
             vec![estimators],
-            PriceRanking::BestBangForBuck { native, gas },
+            QuoteContextMode::GasCost { native, gas },
         )
         .with_verification(self.args.quote_verification);
         Ok(Arc::new(self.sanitized(Arc::new(competition_estimator))))
@@ -378,7 +378,7 @@ impl<'a> PriceEstimatorFactory<'a> {
             self.sanitized(Arc::new(
                 CompetitionEstimator::new(
                     vec![estimators],
-                    PriceRanking::BestBangForBuck { native, gas },
+                    QuoteContextMode::GasCost { native, gas },
                 )
                 .with_early_return(fast_price_estimation_results_required),
             )),
@@ -404,7 +404,7 @@ impl<'a> PriceEstimatorFactory<'a> {
         }
 
         let competition_estimator =
-            CompetitionEstimator::new(estimators, PriceRanking::MaxOutAmount)
+            CompetitionEstimator::new(estimators, QuoteContextMode::None)
                 .with_verification(self.args.quote_verification)
                 .with_early_return(results_required);
         Ok(Box::new(competition_estimator))


### PR DESCRIPTION
# Description
Because there are no rewards or penalties for providing native prices it's not something solvers optimize for. This can lead to solvers providing wildly inaccurate prices at times which then disrupt the auction.

# Changes
Since native prices don't have to be very competitive this PR changes the logic to pick the median price to easily discard outliers. For an even number of results the selection skews towards the worse price. Also this changes the required number of native prices to return early to 3. That should be okay since we have 3 cheap price sources (coingecko, baseline, quasimodo service).

Additionally while implementing this change I noticed that the naming of some of the concepts was strange. The primary reason for the code to be unintuitive is the fact that we have 1 shared `CompetitionEstimator` which can be parameterized with different functions depending on the it being a native price estimator or a quoter.
This means the 2 versions share the same fields internally which is just weird because the native price estimator doesn't need any additional quote context for the ranking.
I tried my best to make the code more understandable with better names but to resolve this fully I think we'd have to have dedicated types for the different estimators.

## How to test
updated existing unit test