### PR TITLE
Share v3 tick maps via Arc to cut per-solve copies

### DIFF
--- a/crates/driver/src/boundary/liquidity/uniswap/v3.rs
+++ b/crates/driver/src/boundary/liquidity/uniswap/v3.rs
@@ -58,8 +58,6 @@ pub fn to_domain(id: liquidity::Id, pool: ConcentratedLiquidity) -> Result<liqui
             sqrt_price: SqrtPrice(pool.pool.state.sqrt_price),
             liquidity: Liquidity(u128::try_from(pool.pool.state.liquidity)?),
             tick: Tick(pool.pool.state.tick),
-            // `Arc` clone — shares the tick map with the source `PoolInfo`
-            // instead of rebuilding it on every `/solve`.
             liquidity_net: pool.pool.state.liquidity_net.clone(),
             fee: Fee(pool.pool.state.fee),
         }),

--- a/crates/driver/src/boundary/liquidity/uniswap/v3.rs
+++ b/crates/driver/src/boundary/liquidity/uniswap/v3.rs
@@ -5,7 +5,7 @@ use {
             self,
             liquidity::{
                 self,
-                uniswap::v3::{Fee, Liquidity, LiquidityNet, Pool, SqrtPrice, Tick},
+                uniswap::v3::{Fee, Liquidity, Pool, SqrtPrice, Tick},
             },
         },
         infra::{self, blockchain::Ethereum, liquidity::config::UniswapV3PoolSource},
@@ -58,13 +58,9 @@ pub fn to_domain(id: liquidity::Id, pool: ConcentratedLiquidity) -> Result<liqui
             sqrt_price: SqrtPrice(pool.pool.state.sqrt_price),
             liquidity: Liquidity(u128::try_from(pool.pool.state.liquidity)?),
             tick: Tick(pool.pool.state.tick),
-            liquidity_net: pool
-                .pool
-                .state
-                .liquidity_net
-                .iter()
-                .map(|(key, value)| (Tick(*key), LiquidityNet(*value)))
-                .collect(),
+            // `Arc` clone — shares the tick map with the source `PoolInfo`
+            // instead of rebuilding it on every `/solve`.
+            liquidity_net: pool.pool.state.liquidity_net.clone(),
             fee: Fee(pool.pool.state.fee),
         }),
     })

--- a/crates/driver/src/domain/liquidity/uniswap/v3.rs
+++ b/crates/driver/src/domain/liquidity/uniswap/v3.rs
@@ -22,10 +22,8 @@ pub struct Pool {
     pub sqrt_price: SqrtPrice,
     pub liquidity: Liquidity,
     pub tick: Tick,
-    /// Tick index -> net liquidity. `Arc`-shared with the liquidity source's
-    /// `PoolInfo` so building this domain pool on every `/solve` doesn't
-    /// deep-copy the tick map (see
-    /// `boundary::liquidity::uniswap::v3::to_domain`).
+    /// Tick index -> net liquidity, `Arc`-shared with the source `PoolInfo` to
+    /// avoid deep-copying the tick map on every `/solve`.
     #[debug(ignore)]
     pub liquidity_net: Arc<BTreeMap<i32, i128>>,
     pub fee: Fee,

--- a/crates/driver/src/domain/liquidity/uniswap/v3.rs
+++ b/crates/driver/src/domain/liquidity/uniswap/v3.rs
@@ -8,7 +8,7 @@ use {
     },
     derive_more::Debug,
     eth_domain_types as eth,
-    std::collections::BTreeMap,
+    std::{collections::BTreeMap, sync::Arc},
 };
 
 /// A Uniswap V3 concentrated liquidity pool.
@@ -22,8 +22,12 @@ pub struct Pool {
     pub sqrt_price: SqrtPrice,
     pub liquidity: Liquidity,
     pub tick: Tick,
+    /// Tick index -> net liquidity. `Arc`-shared with the liquidity source's
+    /// `PoolInfo` so building this domain pool on every `/solve` doesn't
+    /// deep-copy the tick map (see
+    /// `boundary::liquidity::uniswap::v3::to_domain`).
     #[debug(ignore)]
-    pub liquidity_net: BTreeMap<Tick, LiquidityNet>,
+    pub liquidity_net: Arc<BTreeMap<i32, i128>>,
     pub fee: Fee,
 }
 
@@ -49,11 +53,6 @@ pub struct Liquidity(pub u128);
 /// [Uniswap V3 documentation](https://docs.uniswap.org/concepts/protocol/concentrated-liquidity#ticks).
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Tick(pub i32);
-
-/// The amount of liquidity added (or, if negative, removed) when the tick is
-/// crossed going left to right.
-#[derive(Debug, Copy, Clone)]
-pub struct LiquidityNet(pub i128);
 
 #[derive(Clone, Debug)]
 pub struct Fee(pub num::rational::Ratio<u32>);

--- a/crates/driver/src/infra/solver/dto/auction.rs
+++ b/crates/driver/src/infra/solver/dto/auction.rs
@@ -216,11 +216,7 @@ pub fn new(
                             sqrt_price: pool.sqrt_price.0,
                             liquidity: pool.liquidity.0,
                             tick: pool.tick.0,
-                            liquidity_net: pool
-                                .liquidity_net
-                                .iter()
-                                .map(|(key, value)| (*key, *value))
-                                .collect(),
+                            liquidity_net: pool.liquidity_net.clone(),
                             fee: rational_to_big_decimal(&pool.fee.0),
                         },
                     )

--- a/crates/driver/src/infra/solver/dto/auction.rs
+++ b/crates/driver/src/infra/solver/dto/auction.rs
@@ -219,7 +219,7 @@ pub fn new(
                             liquidity_net: pool
                                 .liquidity_net
                                 .iter()
-                                .map(|(key, value)| (key.0, value.0))
+                                .map(|(key, value)| (*key, *value))
                                 .collect(),
                             fee: rational_to_big_decimal(&pool.fee.0),
                         },

--- a/crates/liquidity-sources/src/uniswap_v3/pool_fetching.rs
+++ b/crates/liquidity-sources/src/uniswap_v3/pool_fetching.rs
@@ -11,8 +11,7 @@ use {
     },
     anyhow::{Context, Result},
     contracts::UniswapV3Pool::UniswapV3Pool::{
-        UniswapV3PoolEvents as AlloyUniswapV3PoolEvents,
-        UniswapV3PoolEvents,
+        UniswapV3PoolEvents as AlloyUniswapV3PoolEvents, UniswapV3PoolEvents,
     },
     ethrpc::{Web3, alloy::ProviderLabelingExt},
     event_indexing::{
@@ -63,11 +62,8 @@ pub struct PoolState {
     pub liquidity: U256,
     #[serde_as(as = "DisplayFromStr")]
     pub tick: i32,
-    // (tick_idx, liquidity_net). `Arc`-shared so cloning a `PoolInfo` (when
-    // applying events via `Arc::make_mut`, or converting to the domain type on
-    // every `/solve`) doesn't deep-copy the whole tick map. The map is only
-    // copied-on-write when actually mutated (Mint/Burn), not on the common Swap
-    // event or on read-only conversions.
+    // (tick_idx, liquidity_net). `Arc`-shared so cloning a `PoolInfo` doesn't
+    // deep-copy the tick map; copied-on-write only when mutated (Mint/Burn).
     #[serde_as(as = "Arc<BTreeMap<DisplayFromStr, DisplayFromStr>>")]
     pub liquidity_net: Arc<BTreeMap<i32, i128>>,
     #[serde(skip_serializing)]
@@ -469,8 +465,6 @@ fn append_events(
                         pool.liquidity -= U256::from(burn.amount);
                     }
 
-                    // Copy-on-write: only clone the shared tick map now that we
-                    // actually mutate it.
                     let liquidity_net = Arc::make_mut(&mut pool.liquidity_net);
                     update_liquidity_net(liquidity_net, tick_lower, -amount);
                     update_liquidity_net(liquidity_net, tick_upper, amount);
@@ -492,8 +486,6 @@ fn append_events(
                         pool.liquidity += U256::from(mint.amount);
                     }
 
-                    // Copy-on-write: only clone the shared tick map now that we
-                    // actually mutate it.
                     let liquidity_net = Arc::make_mut(&mut pool.liquidity_net);
                     update_liquidity_net(liquidity_net, tick_lower, amount);
                     update_liquidity_net(liquidity_net, tick_upper, -amount);

--- a/crates/liquidity-sources/src/uniswap_v3/pool_fetching.rs
+++ b/crates/liquidity-sources/src/uniswap_v3/pool_fetching.rs
@@ -63,9 +63,13 @@ pub struct PoolState {
     pub liquidity: U256,
     #[serde_as(as = "DisplayFromStr")]
     pub tick: i32,
-    // (tick_idx, liquidity_net)
-    #[serde_as(as = "BTreeMap<DisplayFromStr, DisplayFromStr>")]
-    pub liquidity_net: BTreeMap<i32, i128>,
+    // (tick_idx, liquidity_net). `Arc`-shared so cloning a `PoolInfo` (when
+    // applying events via `Arc::make_mut`, or converting to the domain type on
+    // every `/solve`) doesn't deep-copy the whole tick map. The map is only
+    // copied-on-write when actually mutated (Mint/Burn), not on the common Swap
+    // event or on read-only conversions.
+    #[serde_as(as = "Arc<BTreeMap<DisplayFromStr, DisplayFromStr>>")]
+    pub liquidity_net: Arc<BTreeMap<i32, i128>>,
     #[serde(skip_serializing)]
     pub fee: Ratio<u32>,
 }
@@ -90,18 +94,19 @@ impl TryFrom<PoolData> for PoolInfo {
                 sqrt_price: pool.sqrt_price,
                 liquidity: pool.liquidity,
                 tick: pool.tick,
-                liquidity_net: pool
-                    .ticks
-                    .context("no ticks")?
-                    .into_iter()
-                    .filter_map(|tick| {
-                        if tick.liquidity_net == 0 {
-                            None
-                        } else {
-                            Some((tick.tick_idx, tick.liquidity_net))
-                        }
-                    })
-                    .collect(),
+                liquidity_net: Arc::new(
+                    pool.ticks
+                        .context("no ticks")?
+                        .into_iter()
+                        .filter_map(|tick| {
+                            if tick.liquidity_net == 0 {
+                                None
+                            } else {
+                                Some((tick.tick_idx, tick.liquidity_net))
+                            }
+                        })
+                        .collect(),
+                ),
                 fee: Ratio::new(u32::try_from(pool.fee_tier)?, 1_000_000u32),
             },
             gas_stats: PoolStats {
@@ -464,8 +469,11 @@ fn append_events(
                         pool.liquidity -= U256::from(burn.amount);
                     }
 
-                    update_liquidity_net(&mut pool.liquidity_net, tick_lower, -amount);
-                    update_liquidity_net(&mut pool.liquidity_net, tick_upper, amount);
+                    // Copy-on-write: only clone the shared tick map now that we
+                    // actually mutate it.
+                    let liquidity_net = Arc::make_mut(&mut pool.liquidity_net);
+                    update_liquidity_net(liquidity_net, tick_lower, -amount);
+                    update_liquidity_net(liquidity_net, tick_upper, amount);
                 }
                 UniswapV3PoolEvents::Mint(mint) => {
                     let tick_lower = mint.tickLower.as_i32();
@@ -484,8 +492,11 @@ fn append_events(
                         pool.liquidity += U256::from(mint.amount);
                     }
 
-                    update_liquidity_net(&mut pool.liquidity_net, tick_lower, amount);
-                    update_liquidity_net(&mut pool.liquidity_net, tick_upper, -amount);
+                    // Copy-on-write: only clone the shared tick map now that we
+                    // actually mutate it.
+                    let liquidity_net = Arc::make_mut(&mut pool.liquidity_net);
+                    update_liquidity_net(liquidity_net, tick_lower, amount);
+                    update_liquidity_net(liquidity_net, tick_upper, -amount);
                 }
                 UniswapV3PoolEvents::Swap(swap) => {
                     pool.tick = swap.tick.as_i32();
@@ -591,11 +602,11 @@ mod tests {
                 sqrt_price: U256::from(792216481398733702759960397_u128),
                 liquidity: U256::from(303015134493562686441_u128),
                 tick: -92110,
-                liquidity_net: BTreeMap::from([
+                liquidity_net: Arc::new(BTreeMap::from([
                     (-122070, 104713649338178916454i128),
                     (-77030, 1182024318125220460617i128),
                     (67260, 5812623076452005012674i128),
-                ]),
+                ])),
                 fee: Ratio::new(10_000u32, 1_000_000u32),
             },
             gas_stats: PoolStats {
@@ -667,7 +678,7 @@ mod tests {
         );
         append_events(&mut pools, vec![event]);
         assert_eq!(
-            pools[&address].state.liquidity_net,
+            *pools[&address].state.liquidity_net,
             BTreeMap::from([(100_000, -12345i128), (110_000, 12345i128)])
         );
 
@@ -685,7 +696,7 @@ mod tests {
         );
         append_events(&mut pools, vec![event]);
         assert_eq!(
-            pools[&address].state.liquidity_net,
+            *pools[&address].state.liquidity_net,
             BTreeMap::from([
                 (100_000, -12345i128),
                 (105_000, -54321i128),
@@ -718,7 +729,7 @@ mod tests {
         );
         append_events(&mut pools, vec![event]);
         assert_eq!(
-            pools[&address].state.liquidity_net,
+            *pools[&address].state.liquidity_net,
             BTreeMap::from([(100_000, 12345i128), (110_000, -12345i128)])
         );
 
@@ -737,7 +748,7 @@ mod tests {
         );
         append_events(&mut pools, vec![event]);
         assert_eq!(
-            pools[&address].state.liquidity_net,
+            *pools[&address].state.liquidity_net,
             BTreeMap::from([
                 (100_000, 12345i128),
                 (105_000, 54321i128),

--- a/crates/liquidity-sources/src/uniswap_v3/pool_fetching.rs
+++ b/crates/liquidity-sources/src/uniswap_v3/pool_fetching.rs
@@ -11,7 +11,8 @@ use {
     },
     anyhow::{Context, Result},
     contracts::UniswapV3Pool::UniswapV3Pool::{
-        UniswapV3PoolEvents as AlloyUniswapV3PoolEvents, UniswapV3PoolEvents,
+        UniswapV3PoolEvents as AlloyUniswapV3PoolEvents,
+        UniswapV3PoolEvents,
     },
     ethrpc::{Web3, alloy::ProviderLabelingExt},
     event_indexing::{

--- a/crates/solvers-dto/src/auction.rs
+++ b/crates/solvers-dto/src/auction.rs
@@ -5,7 +5,10 @@ use {
     number::serialization::HexOrDecimalU256,
     serde::{Deserialize, Serialize},
     serde_with::{DisplayFromStr, serde_as},
-    std::collections::HashMap,
+    std::{
+        collections::{BTreeMap, HashMap},
+        sync::Arc,
+    },
 };
 
 #[serde_as]
@@ -271,8 +274,11 @@ pub struct ConcentratedLiquidityPool {
     #[serde_as(as = "DisplayFromStr")]
     pub liquidity: u128,
     pub tick: i32,
-    #[serde_as(as = "HashMap<DisplayFromStr, DisplayFromStr>")]
-    pub liquidity_net: HashMap<i32, i128>,
+    // `Arc`-shared with the driver's domain pool so building the solver request
+    // on every `/solve` doesn't deep-copy the tick map (potentially tens of
+    // thousands of entries) per pool per solver.
+    #[serde_as(as = "Arc<BTreeMap<DisplayFromStr, DisplayFromStr>>")]
+    pub liquidity_net: Arc<BTreeMap<i32, i128>>,
     pub fee: BigDecimal,
 }
 
@@ -318,4 +324,39 @@ pub struct WrapperCall {
     /// unmodified in a solution containing this order.
     #[serde(default)]
     pub is_omittable: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        serde_json::json,
+        std::{str::FromStr, sync::Arc},
+    };
+
+    /// `liquidity_net` is `Arc`-shared (not deep-copied) per `/solve`, but it
+    /// must still serialize as a plain JSON object of decimal-string keys to
+    /// decimal-string values, and round-trip. Guards the wire format against
+    /// the `HashMap<i32, i128>` -> `Arc<BTreeMap<i32, i128>>` change.
+    #[test]
+    fn concentrated_liquidity_net_wire_format_roundtrip() {
+        let pool = ConcentratedLiquidityPool {
+            id: "0x1".to_owned(),
+            address: Address::ZERO,
+            router: Address::ZERO,
+            gas_estimate: U256::from(108_163u64),
+            tokens: vec![Address::ZERO, Address::ZERO],
+            sqrt_price: U256::from(1u64),
+            liquidity: 2u128,
+            tick: -42,
+            liquidity_net: Arc::new(BTreeMap::from([(-100i32, 5i128), (200i32, -3i128)])),
+            fee: BigDecimal::from_str("0.003").unwrap(),
+        };
+
+        let value = serde_json::to_value(&pool).unwrap();
+        assert_eq!(value["liquidityNet"], json!({"-100": "5", "200": "-3"}));
+
+        let decoded: ConcentratedLiquidityPool = serde_json::from_value(value).unwrap();
+        assert_eq!(*decoded.liquidity_net, *pool.liquidity_net);
+    }
 }

--- a/crates/solvers-dto/src/auction.rs
+++ b/crates/solvers-dto/src/auction.rs
@@ -274,9 +274,8 @@ pub struct ConcentratedLiquidityPool {
     #[serde_as(as = "DisplayFromStr")]
     pub liquidity: u128,
     pub tick: i32,
-    // `Arc`-shared with the driver's domain pool so building the solver request
-    // on every `/solve` doesn't deep-copy the tick map (potentially tens of
-    // thousands of entries) per pool per solver.
+    // `Arc`-shared with the driver's domain pool to avoid deep-copying the tick
+    // map when building the solver request on every `/solve`.
     #[serde_as(as = "Arc<BTreeMap<DisplayFromStr, DisplayFromStr>>")]
     pub liquidity_net: Arc<BTreeMap<i32, i128>>,
     pub fee: BigDecimal,
@@ -324,39 +323,4 @@ pub struct WrapperCall {
     /// unmodified in a solution containing this order.
     #[serde(default)]
     pub is_omittable: bool,
-}
-
-#[cfg(test)]
-mod tests {
-    use {
-        super::*,
-        serde_json::json,
-        std::{str::FromStr, sync::Arc},
-    };
-
-    /// `liquidity_net` is `Arc`-shared (not deep-copied) per `/solve`, but it
-    /// must still serialize as a plain JSON object of decimal-string keys to
-    /// decimal-string values, and round-trip. Guards the wire format against
-    /// the `HashMap<i32, i128>` -> `Arc<BTreeMap<i32, i128>>` change.
-    #[test]
-    fn concentrated_liquidity_net_wire_format_roundtrip() {
-        let pool = ConcentratedLiquidityPool {
-            id: "0x1".to_owned(),
-            address: Address::ZERO,
-            router: Address::ZERO,
-            gas_estimate: U256::from(108_163u64),
-            tokens: vec![Address::ZERO, Address::ZERO],
-            sqrt_price: U256::from(1u64),
-            liquidity: 2u128,
-            tick: -42,
-            liquidity_net: Arc::new(BTreeMap::from([(-100i32, 5i128), (200i32, -3i128)])),
-            fee: BigDecimal::from_str("0.003").unwrap(),
-        };
-
-        let value = serde_json::to_value(&pool).unwrap();
-        assert_eq!(value["liquidityNet"], json!({"-100": "5", "200": "-3"}));
-
-        let decoded: ConcentratedLiquidityPool = serde_json::from_value(value).unwrap();
-        assert_eq!(*decoded.liquidity_net, *pool.liquidity_net);
-    }
 }


### PR DESCRIPTION
# Description
Share the Uniswap V3 `liquidity_net` tick map via `Arc` instead of deep-copying
it on every `/solve` (once into the driver domain pool, once per solver request).
The optimization relies on forcing the scalar types over wrappers due to Rust not being able to "see through" cross crate boundaries (driver/solver-dto), with the scalars it can do so and properly avoid a full clone.

# Changes

* `PoolState.liquidity_net` → `Arc<BTreeMap<i32, i128>>`, mutated copy-on-write
  via `Arc::make_mut` on Mint/Burn.
* Driver domain `Pool.liquidity_net` → `Arc<BTreeMap<i32, i128>>`; removed the
  now-unused `LiquidityNet` newtype.
* `solvers-dto` `ConcentratedLiquidityPool.liquidity_net`: `HashMap` →
  `Arc<BTreeMap<i32, i128>>`.

## How to test

Tested in staging, spikes are orders I placed, one can see that the size of the spike reduces considerably

<img width="799" height="1202" alt="image" src="https://github.com/user-attachments/assets/1aca3df8-b02a-40ad-bb6a-86ec0b720f18" />
