### PR TITLE
Log the winning estimator's response time per quote

### DIFF
--- a/crates/price-estimation/src/competition/mod.rs
+++ b/crates/price-estimation/src/competition/mod.rs
@@ -244,12 +244,6 @@ struct Metrics {
     /// estimators behave for buy vs sell orders.
     #[metric(labels("estimator_type", "order_kind"))]
     queries_won: prometheus::IntCounterVec,
-
-    /// Response time of the winning estimator, in seconds. Sizes the
-    /// streaming-quote timeout: the winner's own latency, not the competition's
-    /// wait-for-all / early-return time.
-    #[metric(buckets(0.25, 0.5, 0.75, 1, 1.5, 2, 2.5, 3, 3.5, 4, 5))]
-    winner_response_time: prometheus::Histogram,
 }
 
 fn metrics() -> &'static Metrics {

--- a/crates/price-estimation/src/competition/mod.rs
+++ b/crates/price-estimation/src/competition/mod.rs
@@ -18,7 +18,7 @@ use {
         fmt::Debug,
         num::NonZeroUsize,
         sync::{Arc, OnceLock},
-        time::Instant,
+        time::{Duration, Instant},
     },
 };
 
@@ -27,7 +27,7 @@ mod quote;
 
 /// Stage index and index within stage of an estimator stored in the
 /// [`CompetitionEstimator`] used as an identifier.
-#[derive(Copy, Debug, Clone, Default, Eq, PartialEq)]
+#[derive(Copy, Debug, Clone, Default, Eq, PartialEq, Hash)]
 struct EstimatorIndex(usize, usize);
 
 type PriceEstimationStage<T> = Vec<(String, T)>;
@@ -115,13 +115,15 @@ impl<T: Send + Sync + 'static> CompetitionEstimator<T> {
             while stage_index < self.stages.len() && requests.len() < requests_for_batch {
                 let stage = &self.stages.get(stage_index).expect("index checked by loop");
                 let futures = stage.iter().enumerate().map(|(index, (name, estimator))| {
+                    let estimator_index = EstimatorIndex(stage_index, index);
                     get_single_result(Context {
                         estimator,
                         name,
                         query: query.clone(),
                         remaining_stages: Arc::clone(&remaining_stages),
+                        index: estimator_index,
                     })
-                    .map(move |result| (EstimatorIndex(stage_index, index), result))
+                    .map(move |result| (estimator_index, result))
                     .boxed()
                 });
                 requests.extend(futures);
@@ -160,6 +162,7 @@ impl<T: Send + Sync + 'static> CompetitionEstimator<T> {
         query: &Q,
         kind: OrderKind,
         (index, result): ResultWithIndex<R>,
+        elapsed: Option<Duration>,
     ) -> Result<R, PriceEstimationError> {
         let EstimatorIndex(stage_index, estimator_index) = index;
         let (name, _estimator) = &self.stages[stage_index][estimator_index];
@@ -169,6 +172,13 @@ impl<T: Send + Sync + 'static> CompetitionEstimator<T> {
                 .queries_won
                 .with_label_values(&[name.as_str(), kind.label()])
                 .inc();
+            if let Some(elapsed) = elapsed {
+                tracing::debug!(
+                    estimator = name,
+                    elapsed_ms = elapsed.as_millis() as u64,
+                    "winning quote response time"
+                );
+            }
         }
         result
     }
@@ -198,6 +208,9 @@ struct Context<'a, ESTIMATOR, QUERY> {
     remaining_stages: Arc<OnceLock<usize>>,
     /// Name of the estimator
     name: &'a str,
+    /// Position of this estimator in the competition. Used as a collision-free
+    /// timing key, since names aren't guaranteed unique across stages.
+    index: EstimatorIndex,
 }
 
 impl<'a, E, Q> Context<'a, E, Q> {

--- a/crates/price-estimation/src/competition/mod.rs
+++ b/crates/price-estimation/src/competition/mod.rs
@@ -244,6 +244,12 @@ struct Metrics {
     /// estimators behave for buy vs sell orders.
     #[metric(labels("estimator_type", "order_kind"))]
     queries_won: prometheus::IntCounterVec,
+
+    /// Response time of the winning estimator, in seconds. Sizes the
+    /// streaming-quote timeout: the winner's own latency, not the competition's
+    /// wait-for-all / early-return time.
+    #[metric(buckets(0.25, 0.5, 0.75, 1, 1.5, 2, 2.5, 3, 3.5, 4, 5))]
+    winner_response_time: prometheus::Histogram,
 }
 
 fn metrics() -> &'static Metrics {

--- a/crates/price-estimation/src/competition/native.rs
+++ b/crates/price-estimation/src/competition/native.rs
@@ -54,7 +54,7 @@ impl NativePriceEstimating for CompetitionEstimator<Arc<dyn NativePriceEstimatin
                 .into_iter()
                 .max_by(|a, b| compare_native_result(&a.1, &b.1))
                 .context("could not get any native price")?;
-            self.report_winner(&token, OrderKind::Buy, winner)
+            self.report_winner(&token, OrderKind::Buy, winner, None)
         }
         .boxed()
     }

--- a/crates/price-estimation/src/competition/quote.rs
+++ b/crates/price-estimation/src/competition/quote.rs
@@ -1,5 +1,5 @@
 use {
-    super::{CompetitionEstimator, PriceRanking, compare_error},
+    super::{CompetitionEstimator, EstimatorIndex, PriceRanking, compare_error, metrics},
     crate::{
         Estimate,
         PriceEstimateResult,
@@ -15,7 +15,8 @@ use {
     serde::Serialize,
     std::{
         cmp::Ordering,
-        sync::Arc,
+        collections::HashMap,
+        sync::{Arc, Mutex},
         time::{Duration, Instant},
     },
     tracing::instrument,
@@ -40,21 +41,30 @@ impl PriceEstimating for CompetitionEstimator<Arc<dyn PriceEstimating>> {
                 r.as_ref()
                     .is_ok_and(|r| r.gas > 0 && !r.out_amount.is_zero())
             };
+            // Records each resolved estimator's own response time so we can
+            // observe the winner's latency after ranking.
+            let timings = Arc::new(Mutex::new(HashMap::<String, Duration>::new()));
             let get_results = self
-                .produce_results(query.clone(), is_reasonable, |context| {
-                    // Call estimate() eagerly so its side-effects still happen
-                    // when an early-return drops the future before it's polled.
-                    let start = Instant::now();
-                    let estimator_name = context.name;
-                    let inner_query = context.query.clone();
-                    context
-                        .estimator
-                        .estimate(context.query.clone())
-                        .map(move |res| {
-                            emit_quote_event(estimator_name, &inner_query, &res, start.elapsed());
-                            res
-                        })
-                        .boxed()
+                .produce_results(query.clone(), is_reasonable, {
+                    let timings = timings.clone();
+                    move |context| {
+                        // Call estimate() eagerly so its side-effects still happen
+                        // when an early-return drops the future before it's polled.
+                        let start = Instant::now();
+                        let estimator_name = context.name.to_string();
+                        let inner_query = context.query.clone();
+                        let timings = timings.clone();
+                        context
+                            .estimator
+                            .estimate(context.query.clone())
+                            .map(move |res| {
+                                let elapsed = start.elapsed();
+                                emit_quote_event(&estimator_name, &inner_query, &res, elapsed);
+                                timings.lock().unwrap().insert(estimator_name, elapsed);
+                                res
+                            })
+                            .boxed()
+                    }
                 })
                 .map(Result::Ok);
 
@@ -74,6 +84,15 @@ impl PriceEstimating for CompetitionEstimator<Arc<dyn PriceEstimating>> {
                 })
                 .with_context(|| "all price estimates were unreasonable (0 gas or 0 out_amount)")
                 .map_err(PriceEstimationError::EstimatorInternal)?;
+            if winner.1.is_ok() {
+                let EstimatorIndex(stage_index, estimator_index) = winner.0;
+                let name = &self.stages[stage_index][estimator_index].0;
+                if let Some(elapsed) = timings.lock().unwrap().get(name) {
+                    metrics()
+                        .winner_response_time
+                        .observe(elapsed.as_secs_f64());
+                }
+            }
             self.report_winner(&query, query.kind, winner)
         }
         .boxed()

--- a/crates/price-estimation/src/competition/quote.rs
+++ b/crates/price-estimation/src/competition/quote.rs
@@ -1,5 +1,5 @@
 use {
-    super::{CompetitionEstimator, EstimatorIndex, PriceRanking, compare_error, metrics},
+    super::{CompetitionEstimator, EstimatorIndex, PriceRanking, compare_error},
     crate::{
         Estimate,
         PriceEstimateResult,
@@ -42,7 +42,7 @@ impl PriceEstimating for CompetitionEstimator<Arc<dyn PriceEstimating>> {
                     .is_ok_and(|r| r.gas > 0 && !r.out_amount.is_zero())
             };
             // Records each resolved estimator's own response time so we can
-            // observe the winner's latency after ranking.
+            // log the winner's latency after ranking.
             let timings = Arc::new(Mutex::new(HashMap::<String, Duration>::new()));
             let get_results = self
                 .produce_results(query.clone(), is_reasonable, {
@@ -88,9 +88,13 @@ impl PriceEstimating for CompetitionEstimator<Arc<dyn PriceEstimating>> {
                 let EstimatorIndex(stage_index, estimator_index) = winner.0;
                 let name = &self.stages[stage_index][estimator_index].0;
                 if let Some(elapsed) = timings.lock().unwrap().get(name) {
-                    metrics()
-                        .winner_response_time
-                        .observe(elapsed.as_secs_f64());
+                    // Numeric field (not a Duration) so it can be aggregated, e.g.
+                    // quantile(elapsed_ms) to size the streaming-quote timeout.
+                    tracing::debug!(
+                        estimator = name,
+                        elapsed_ms = elapsed.as_millis(),
+                        "winning quote response time"
+                    );
                 }
             }
             self.report_winner(&query, query.kind, winner)

--- a/crates/price-estimation/src/competition/quote.rs
+++ b/crates/price-estimation/src/competition/quote.rs
@@ -43,7 +43,7 @@ impl PriceEstimating for CompetitionEstimator<Arc<dyn PriceEstimating>> {
             };
             // Records each resolved estimator's own response time so we can
             // log the winner's latency after ranking.
-            let timings = Arc::new(Mutex::new(HashMap::<String, Duration>::new()));
+            let timings = Arc::new(Mutex::new(HashMap::<EstimatorIndex, Duration>::new()));
             let get_results = self
                 .produce_results(query.clone(), is_reasonable, {
                     let timings = timings.clone();
@@ -52,6 +52,7 @@ impl PriceEstimating for CompetitionEstimator<Arc<dyn PriceEstimating>> {
                         // when an early-return drops the future before it's polled.
                         let start = Instant::now();
                         let estimator_name = context.name.to_string();
+                        let estimator_index = context.index;
                         let inner_query = context.query.clone();
                         let timings = timings.clone();
                         context
@@ -60,7 +61,7 @@ impl PriceEstimating for CompetitionEstimator<Arc<dyn PriceEstimating>> {
                             .map(move |res| {
                                 let elapsed = start.elapsed();
                                 emit_quote_event(&estimator_name, &inner_query, &res, elapsed);
-                                timings.lock().unwrap().insert(estimator_name, elapsed);
+                                timings.lock().unwrap().insert(estimator_index, elapsed);
                                 res
                             })
                             .boxed()
@@ -84,17 +85,8 @@ impl PriceEstimating for CompetitionEstimator<Arc<dyn PriceEstimating>> {
                 })
                 .with_context(|| "all price estimates were unreasonable (0 gas or 0 out_amount)")
                 .map_err(PriceEstimationError::EstimatorInternal)?;
-            if let (EstimatorIndex(stage_index, estimator_index), Ok(_)) = winner {
-                let name = &self.stages[stage_index][estimator_index].0;
-                if let Some(elapsed) = timings.lock().unwrap().get(name) {
-                    tracing::debug!(
-                        estimator = name,
-                        elapsed_ms = elapsed.as_millis(),
-                        "winning quote response time"
-                    );
-                }
-            }
-            self.report_winner(&query, query.kind, winner)
+            let elapsed = timings.lock().unwrap().get(&winner.0).copied();
+            self.report_winner(&query, query.kind, winner, elapsed)
         }
         .boxed()
     }

--- a/crates/price-estimation/src/competition/quote.rs
+++ b/crates/price-estimation/src/competition/quote.rs
@@ -84,12 +84,9 @@ impl PriceEstimating for CompetitionEstimator<Arc<dyn PriceEstimating>> {
                 })
                 .with_context(|| "all price estimates were unreasonable (0 gas or 0 out_amount)")
                 .map_err(PriceEstimationError::EstimatorInternal)?;
-            if winner.1.is_ok() {
-                let EstimatorIndex(stage_index, estimator_index) = winner.0;
+            if let (EstimatorIndex(stage_index, estimator_index), Ok(_)) = winner {
                 let name = &self.stages[stage_index][estimator_index].0;
                 if let Some(elapsed) = timings.lock().unwrap().get(name) {
-                    // Numeric field (not a Duration) so it can be aggregated, e.g.
-                    // quantile(elapsed_ms) to size the streaming-quote timeout.
                     tracing::debug!(
                         estimator = name,
                         elapsed_ms = elapsed.as_millis(),


### PR DESCRIPTION
# Description
The streaming-quote API (#4469) needs a timeout. To size it we need the winning solver's own latency, not the whole competition's time, which waits for every estimator or early-returns once enough arrive. No existing log carries this directly: "new price estimate" logs every estimator's time win or lose, "winning price estimate" names the winner but has no timing, and correlating them after the fact needs a flaky per-trace join. So we log the winner's response time on its own line.

# Changes
- During a quote competition, record each resolved estimator's response time and, after ranking, log the winner's as a numeric `elapsed_ms` field (quote path only, OK winners only).

# How to test
Staging
