### PR TITLE
debounce gas price rpc requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4544,6 +4544,7 @@ dependencies = [
  "prometheus",
  "prometheus-metric-storage",
  "reqwest",
+ "serde_json",
  "tokio",
  "tracing",
  "url",

--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -275,8 +275,9 @@ pub async fn run(config: Configuration, shutdown_controller: ShutdownController)
     let gas_price_estimator = Arc::new(
         gas_price_estimation::create_priority_estimator(
             http_factory.create(),
-            &web3,
+            &web3.provider,
             &gas_estimators,
+            eth.current_block(),
         )
         .await
         .expect("failed to create gas price estimator"),

--- a/crates/driver/src/infra/blockchain/gas.rs
+++ b/crates/driver/src/infra/blockchain/gas.rs
@@ -8,7 +8,7 @@ use {
     alloy::eips::eip1559::Eip1559Estimation,
     anyhow::anyhow,
     eth_domain_types as eth,
-    ethrpc::Web3,
+    ethrpc::{AlloyProvider, block_stream::CurrentBlockWatcher},
     gas_price_estimation::{
         GasPriceEstimating,
         configurable_alloy::ConfigurableGasPriceEstimator,
@@ -17,67 +17,41 @@ use {
     std::sync::Arc,
 };
 
-type MaxAdditionalTip = eth::U256;
-type AdditionalTipPercentage = f64;
-type AdditionalTip = (MaxAdditionalTip, AdditionalTipPercentage);
-
-pub struct GasPriceEstimator {
-    pub(super) gas: Arc<dyn GasPriceEstimating>,
-    additional_tip: AdditionalTip,
+/// Set of tweaks to fine tune the computed gas price.
+pub struct ManualAdjustments {
+    max_additional_tip: eth::U256,
+    additional_tip_percentage: f64,
     max_fee_per_gas: eth::U256,
     min_priority_fee: eth::U256,
 }
 
+pub struct GasPriceEstimator {
+    pub(super) gas: Arc<dyn GasPriceEstimating>,
+    adjustments: ManualAdjustments,
+}
+
 impl GasPriceEstimator {
     pub async fn new(
-        web3: &Web3,
+        provider: &AlloyProvider,
+        current_block: &CurrentBlockWatcher,
         gas_estimator_type: &GasEstimatorType,
-        mempools: &[mempool::Config],
+        adjustments: ManualAdjustments,
     ) -> Result<Self, Error> {
         let gas: Arc<dyn GasPriceEstimating> = match gas_estimator_type {
-            GasEstimatorType::Web3 => Arc::new(NodeGasPriceEstimator::new(web3.provider.clone())),
+            GasEstimatorType::Web3 => Arc::new(NodeGasPriceEstimator::new(provider.clone())),
             GasEstimatorType::Alloy {
                 past_blocks,
                 reward_percentile,
             } => Arc::new(ConfigurableGasPriceEstimator::new(
-                web3.provider.clone(),
+                provider.clone(),
                 configs::gas_price_estimation::EstimatorConfig {
                     past_blocks: *past_blocks,
                     reward_percentile: *reward_percentile,
                 },
+                current_block.clone(),
             )),
         };
-        // TODO: simplify logic by moving gas price adjustments out of the individual
-        // mempool configs
-        let additional_tip = mempools
-            .iter()
-            .map(|mempool| {
-                (
-                    mempool.max_additional_tip,
-                    mempool.additional_tip_percentage,
-                )
-            })
-            .next()
-            .unwrap_or((eth::U256::ZERO, 0.));
-        // Use the lowest max_fee_per_gas of all mempools as the max_fee_per_gas
-        let max_fee_per_gas = mempools
-            .iter()
-            .map(|mempool| mempool.gas_price_cap)
-            .min()
-            .expect("at least one mempool");
-
-        // Use the highest min_priority_fee of all mempools as the min_priority_fee
-        let min_priority_fee = mempools
-            .iter()
-            .map(|mempool| mempool.min_priority_fee)
-            .max()
-            .expect("at least one mempool");
-        Ok(Self {
-            gas,
-            additional_tip,
-            max_fee_per_gas,
-            min_priority_fee,
-        })
+        Ok(Self { gas, adjustments })
     }
 
     /// Estimates the gas price for a transaction.
@@ -88,29 +62,25 @@ impl GasPriceEstimator {
         let estimate = self.gas.estimate().await.map_err(Error::GasPrice)?;
 
         let max_priority_fee_per_gas = {
-            // the driver supports tweaking the tx gas price tip in case the gas
-            // price estimator is systematically too low => compute configured tip bump
-            let (max_additional_tip, tip_percentage_increase) = self.additional_tip;
-
             // Calculate additional tip in integer space to avoid precision loss
             // Convert percentage to basis points (multiply by 10000) to maintain precision
-            // e.g., tip_percentage_increase = 0.125 (12.5%) becomes 1250
+            // e.g., additional_tip_percentage = 0.125 (12.5%) becomes 1250
             let overflow_err = || {
                 Error::GasPrice(anyhow!(
                     "overflow on multiplication (max_priority_fee_per_gas * tip_percentage_as_bps)"
                 ))
             };
-            let tip_percentage_as_bps = tip_percentage_increase * 10000.0;
+            let tip_percentage_as_bps = self.adjustments.additional_tip_percentage * 10000.0;
             let calculated_tip = eth::U256::from(estimate.max_priority_fee_per_gas)
                 .checked_mul(eth::U256::from(tip_percentage_as_bps))
                 .ok_or_else(overflow_err)?
                 / eth::U256::from(10000u128);
 
-            let additional_tip = max_additional_tip.min(calculated_tip);
+            let additional_tip = self.adjustments.max_additional_tip.min(calculated_tip);
 
             // make sure we tip at least some configurable minimum amount
             std::cmp::max(
-                self.min_priority_fee,
+                self.adjustments.min_priority_fee,
                 eth::U256::from(estimate.max_priority_fee_per_gas) + additional_tip,
             )
         };
@@ -120,7 +90,7 @@ impl GasPriceEstimator {
         let suggested_max_fee_per_gas = eth::U256::from(estimate.max_fee_per_gas);
         let suggested_max_fee_per_gas =
             std::cmp::max(suggested_max_fee_per_gas, max_priority_fee_per_gas);
-        if suggested_max_fee_per_gas > self.max_fee_per_gas {
+        if suggested_max_fee_per_gas > self.adjustments.max_fee_per_gas {
             return Err(Error::GasPrice(anyhow::anyhow!(
                 "suggested gas price is higher than maximum allowed gas price (network is too \
                  congested)"
@@ -144,5 +114,40 @@ impl GasPriceEstimating for GasPriceEstimator {
 
     async fn base_fee(&self) -> ::anyhow::Result<Option<u64>> {
         self.gas.base_fee().await
+    }
+}
+
+pub fn adjustments(mempools: &[mempool::Config]) -> ManualAdjustments {
+    // TODO: simplify logic by moving gas price adjustments out of the individual
+    // mempool configs
+    let (max_additional_tip, additional_tip_percentage) = mempools
+        .iter()
+        .map(|mempool| {
+            (
+                mempool.max_additional_tip,
+                mempool.additional_tip_percentage,
+            )
+        })
+        .next()
+        .unwrap_or((eth::U256::ZERO, 0.));
+    // Use the lowest max_fee_per_gas of all mempools as the max_fee_per_gas
+    let max_fee_per_gas = mempools
+        .iter()
+        .map(|mempool| mempool.gas_price_cap)
+        .min()
+        .expect("at least one mempool");
+
+    // Use the highest min_priority_fee of all mempools as the min_priority_fee
+    let min_priority_fee = mempools
+        .iter()
+        .map(|mempool| mempool.min_priority_fee)
+        .max()
+        .expect("at least one mempool");
+
+    ManualAdjustments {
+        max_additional_tip,
+        additional_tip_percentage,
+        max_fee_per_gas,
+        min_priority_fee,
     }
 }

--- a/crates/driver/src/infra/blockchain/gas.rs
+++ b/crates/driver/src/infra/blockchain/gas.rs
@@ -17,17 +17,9 @@ use {
     std::sync::Arc,
 };
 
-/// Set of tweaks to fine tune the computed gas price.
-pub struct ManualAdjustments {
-    max_additional_tip: eth::U256,
-    additional_tip_percentage: f64,
-    max_fee_per_gas: eth::U256,
-    min_priority_fee: eth::U256,
-}
-
 pub struct GasPriceEstimator {
     pub(super) gas: Arc<dyn GasPriceEstimating>,
-    adjustments: ManualAdjustments,
+    adjustments: GasPriceParameters,
 }
 
 impl GasPriceEstimator {
@@ -35,7 +27,7 @@ impl GasPriceEstimator {
         provider: &AlloyProvider,
         current_block: &CurrentBlockWatcher,
         gas_estimator_type: &GasEstimatorType,
-        adjustments: ManualAdjustments,
+        adjustments: GasPriceParameters,
     ) -> Result<Self, Error> {
         let gas: Arc<dyn GasPriceEstimating> = match gas_estimator_type {
             GasEstimatorType::Web3 => Arc::new(NodeGasPriceEstimator::new(provider.clone())),
@@ -70,7 +62,7 @@ impl GasPriceEstimator {
                     "overflow on multiplication (max_priority_fee_per_gas * tip_percentage_as_bps)"
                 ))
             };
-            let tip_percentage_as_bps = self.adjustments.additional_tip_percentage * 10000.0;
+            let tip_percentage_as_bps = self.adjustments.additional_tip_factor * 10000.0;
             let calculated_tip = eth::U256::from(estimate.max_priority_fee_per_gas)
                 .checked_mul(eth::U256::from(tip_percentage_as_bps))
                 .ok_or_else(overflow_err)?
@@ -117,36 +109,40 @@ impl GasPriceEstimating for GasPriceEstimator {
     }
 }
 
-pub fn adjustments(mempools: &[mempool::Config]) -> ManualAdjustments {
-    // TODO: simplify logic by moving gas price adjustments out of the individual
-    // mempool configs
-    let (max_additional_tip, additional_tip_percentage) = mempools
-        .iter()
-        .map(|mempool| {
-            (
-                mempool.max_additional_tip,
-                mempool.additional_tip_percentage,
-            )
-        })
-        .next()
-        .unwrap_or((eth::U256::ZERO, 0.));
-    // Use the lowest max_fee_per_gas of all mempools as the max_fee_per_gas
-    let max_fee_per_gas = mempools
-        .iter()
-        .map(|mempool| mempool.gas_price_cap)
-        .min()
-        .expect("at least one mempool");
+/// Set of tweaks to fine tune the computed gas price.
+pub struct GasPriceParameters {
+    /// Maximum priority_fee_per_gas added on top of the price suggested by the
+    /// estimator.
+    max_additional_tip: eth::U256,
+    /// The max_priority_fee_per_gas suggested by the gas price estimator gets
+    /// multiplied with this factor and get capped at `max_additional_tip`.
+    additional_tip_factor: f64,
+    /// Highest `max_fee_per_gas` at which we still want to submit a tx.
+    max_fee_per_gas: eth::U256,
+    /// We'll always tip at least this value for `max_priority_fee_per_gas`.
+    min_priority_fee: eth::U256,
+}
 
-    // Use the highest min_priority_fee of all mempools as the min_priority_fee
-    let min_priority_fee = mempools
-        .iter()
-        .map(|mempool| mempool.min_priority_fee)
-        .max()
-        .expect("at least one mempool");
+pub fn adjustments(mempools: &[mempool::Config]) -> GasPriceParameters {
+    // TODO: make configuration of those parameters more obvious by moving them
+    // into a separate config field instead of deriving them from the mempool
+    // configs
+    let mut max_additional_tip = eth::U256::ZERO;
+    let mut additional_tip_percentage = 0.0f64;
+    let mut max_fee_per_gas = eth::U256::MAX;
+    let mut min_priority_fee = eth::U256::ZERO;
 
-    ManualAdjustments {
+    for mempool in mempools {
+        max_additional_tip = max_additional_tip.max(mempool.max_additional_tip);
+        additional_tip_percentage =
+            additional_tip_percentage.max(mempool.additional_tip_percentage);
+        max_fee_per_gas = max_fee_per_gas.min(mempool.gas_price_cap);
+        min_priority_fee = min_priority_fee.max(mempool.min_priority_fee);
+    }
+
+    GasPriceParameters {
         max_additional_tip,
-        additional_tip_percentage,
+        additional_tip_factor: additional_tip_percentage,
         max_fee_per_gas,
         min_priority_fee,
     }

--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -2,7 +2,7 @@ use {
     crate::{
         boundary,
         domain::blockchain::TxStatus,
-        infra::{blockchain::gas::ManualAdjustments, config::file::GasEstimatorType},
+        infra::{blockchain::gas::GasPriceParameters, config::file::GasEstimatorType},
     },
     account_balances::{BalanceSimulator, SimulationError},
     alloy::{
@@ -111,7 +111,7 @@ impl Ethereum {
         current_block_args: &shared::current_block::Arguments,
         tx_gas_limit: eth::Gas,
         gas_estimator_type: &GasEstimatorType,
-        gas_adjustments: ManualAdjustments,
+        gas_adjustments: GasPriceParameters,
     ) -> Self {
         let Rpc { web3, chain, args } = rpc;
         let current_block_stream = current_block_args

--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -1,5 +1,9 @@
 use {
-    crate::{boundary, domain::blockchain::TxStatus},
+    crate::{
+        boundary,
+        domain::blockchain::TxStatus,
+        infra::{blockchain::gas::ManualAdjustments, config::file::GasEstimatorType},
+    },
     account_balances::{BalanceSimulator, SimulationError},
     alloy::{
         eips::eip1559::Eip1559Estimation,
@@ -104,15 +108,27 @@ impl Ethereum {
     pub async fn new(
         rpc: Rpc,
         addresses: contracts::Addresses,
-        gas: Arc<GasPriceEstimator>,
         current_block_args: &shared::current_block::Arguments,
         tx_gas_limit: eth::Gas,
+        gas_estimator_type: &GasEstimatorType,
+        gas_adjustments: ManualAdjustments,
     ) -> Self {
         let Rpc { web3, chain, args } = rpc;
         let current_block_stream = current_block_args
             .stream(args.url.clone(), web3.provider.clone())
             .await
             .expect("couldn't initialize current block stream");
+
+        let gas = Arc::new(
+            GasPriceEstimator::new(
+                &web3.provider,
+                &current_block_stream,
+                gas_estimator_type,
+                gas_adjustments,
+            )
+            .await
+            .expect("initialize gas price estimator"),
+        );
 
         let contracts = Contracts::new(&web3, chain, addresses)
             .await

--- a/crates/driver/src/run.rs
+++ b/crates/driver/src/run.rs
@@ -7,7 +7,7 @@ use {
         infra::{
             self,
             Api,
-            blockchain::{self, Ethereum},
+            blockchain::{self, Ethereum, gas},
             cli,
             config,
             liquidity,
@@ -16,12 +16,11 @@ use {
         },
     },
     clap::Parser,
-    eth_domain_types as eth,
     futures::future::join_all,
     http_client::HttpClientFactory,
     shared::arguments::tracing_config,
     simulator::{self, Simulator},
-    std::{net::SocketAddr, sync::Arc, time::Duration},
+    std::{net::SocketAddr, time::Duration},
     tokio::sync::oneshot,
 };
 
@@ -64,7 +63,16 @@ async fn run_with(args: cli::Args, addr_sender: Option<oneshot::Sender<SocketAdd
     tracing::info!(%commit_hash, "running driver with {config:#?}");
 
     let (shutdown_sender, shutdown_receiver) = tokio::sync::oneshot::channel();
-    let eth = ethereum(&config, ethrpc.clone(), &args.current_block).await;
+    let eth = Ethereum::new(
+        ethrpc.clone(),
+        config.contracts.clone(),
+        &args.current_block,
+        config.tx_gas_limit.into(),
+        &config.gas_estimator,
+        gas::adjustments(&config.mempools),
+    )
+    .await;
+
     let simulator_eth = simulator::Ethereum::new(
         ethrpc.web3().clone(),
         ethrpc.chain(),
@@ -184,26 +192,6 @@ async fn ethrpc(args: &cli::Args) -> blockchain::Rpc {
     blockchain::Rpc::try_new(args)
         .await
         .expect("connect ethereum RPC")
-}
-
-async fn ethereum(
-    config: &infra::Config,
-    ethrpc: blockchain::Rpc,
-    current_block_args: &shared::current_block::Arguments,
-) -> Ethereum {
-    let gas = Arc::new(
-        blockchain::GasPriceEstimator::new(ethrpc.web3(), &config.gas_estimator, &config.mempools)
-            .await
-            .expect("initialize gas price estimator"),
-    );
-    Ethereum::new(
-        ethrpc,
-        config.contracts.clone(),
-        gas,
-        current_block_args,
-        eth::Gas(config.tx_gas_limit),
-    )
-    .await
 }
 
 async fn solvers(config: &config::Config, eth: &Ethereum) -> Vec<Solver> {

--- a/crates/driver/src/tests/setup/solver.rs
+++ b/crates/driver/src/tests/setup/solver.rs
@@ -9,7 +9,12 @@ use {
             competition::order,
             time::{self},
         },
-        infra::{self, Ethereum, blockchain::contracts::Addresses, config::file::FeeHandler},
+        infra::{
+            self,
+            Ethereum,
+            blockchain::{contracts::Addresses, gas},
+            config::file::FeeHandler,
+        },
         tests::setup::blockchain::Trade,
     },
     alloy::{primitives::Address, signers::local::PrivateKeySigner},
@@ -474,17 +479,6 @@ impl Solver {
         })
         .await
         .unwrap();
-        let gas = Arc::new(
-            infra::blockchain::GasPriceEstimator::new(
-                rpc.web3(),
-                &Default::default(),
-                &[infra::mempool::Config::test_config(
-                    config.blockchain.web3_url.parse().unwrap(),
-                )],
-            )
-            .await
-            .unwrap(),
-        );
         let eth = Ethereum::new(
             rpc,
             Addresses {
@@ -495,12 +489,15 @@ impl Solver {
                 cow_amm_helper_by_factory: Default::default(),
                 flashloan_router: Some((*config.blockchain.flashloan_router.address()).into()),
             },
-            gas,
             &shared::current_block::Arguments {
                 block_stream_poll_interval: None,
                 node_ws_url: Some(config.blockchain.web3_ws_url.parse().unwrap()),
             },
             eth_domain_types::Gas(eth_domain_types::U256::from(45_000_000u64)),
+            &Default::default(),
+            gas::adjustments(&[infra::mempool::Config::test_config(
+                config.blockchain.web3_url.parse().unwrap(),
+            )]),
         )
         .await;
 

--- a/crates/gas-price-estimation/Cargo.toml
+++ b/crates/gas-price-estimation/Cargo.toml
@@ -23,6 +23,7 @@ url = { workspace = true }
 
 [dev-dependencies]
 mockall = { workspace = true }
+serde_json = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/gas-price-estimation/src/configurable_alloy.rs
+++ b/crates/gas-price-estimation/src/configurable_alloy.rs
@@ -7,11 +7,13 @@
 
 use {
     crate::GasPriceEstimating,
-    alloy_eips::{BlockId, BlockNumberOrTag, eip1559::Eip1559Estimation},
+    alloy_eips::{BlockNumberOrTag, eip1559::Eip1559Estimation},
     alloy_provider::{Provider, utils::eip1559_default_estimator},
     anyhow::{Context, Result},
     configs::gas_price_estimation::EstimatorConfig,
-    ethrpc::AlloyProvider,
+    ethrpc::{AlloyProvider, block_stream::CurrentBlockWatcher},
+    futures::StreamExt as _,
+    tokio::sync::watch,
     tracing::instrument,
 };
 
@@ -19,71 +21,113 @@ use {
 ///
 /// Uses alloy's default estimation algorithm but with configurable
 /// `past_blocks` and `reward_percentile` parameters for the fee history query.
+/// This component uses a background task to update the gas price once every
+/// block to avoid multiple RPC requests for the same block.
 pub struct ConfigurableGasPriceEstimator {
-    provider: AlloyProvider,
-    config: EstimatorConfig,
+    current_block: CurrentBlockWatcher,
+    lastest_gas_price: watch::Receiver<Eip1559Estimation>,
 }
 
 impl ConfigurableGasPriceEstimator {
-    pub fn new(provider: AlloyProvider, config: EstimatorConfig) -> Self {
-        Self { provider, config }
+    pub fn new(
+        provider: AlloyProvider,
+        config: EstimatorConfig,
+        current_block: CurrentBlockWatcher,
+    ) -> Self {
+        // use some reasonable initial value. The exact value doesn't matter much since
+        // the background task will update the gas price immediately anyway
+        // since the block stream yields the current block immediately
+        let base_fee = current_block.borrow().base_fee;
+        let init = Eip1559Estimation {
+            max_fee_per_gas: u128::from(base_fee * 2),
+            max_priority_fee_per_gas: u128::from(base_fee * 2),
+        };
+
+        let (sender, receiver) = watch::channel(init);
+        let mut current_block_stream = ethrpc::block_stream::into_stream(current_block.clone());
+        tokio::task::spawn(async move {
+            while current_block_stream.next().await.is_some() {
+                let gas_price = match current_gas_price(&provider, &config).await {
+                    Ok(gas_price) => gas_price,
+                    Err(err) => {
+                        tracing::warn!(?err, "failed to computed gas price");
+                        continue;
+                    }
+                };
+                if let Err(err) = sender.send(gas_price) {
+                    // at this point all [`watch::Receiver`] have been dropped and new ones
+                    // could only be created with [`watch::Sender::subscribe()`] but the only
+                    // Sender instance lives in this background task and can not be accessed
+                    // anymore
+                    tracing::debug!(
+                        ?err,
+                        "all gas price estimators dropped, terminating update loop"
+                    );
+                    break;
+                }
+            }
+            tracing::debug!("terminating gas price update task");
+        });
+
+        Self {
+            current_block,
+            lastest_gas_price: receiver,
+        }
     }
+}
+
+async fn current_gas_price(
+    provider: &AlloyProvider,
+    config: &EstimatorConfig,
+) -> Result<Eip1559Estimation> {
+    // Fetch fee history with our configured parameters
+    let fee_history = provider
+        .get_fee_history(
+            config.past_blocks,
+            BlockNumberOrTag::Latest,
+            &[config.reward_percentile],
+        )
+        .await
+        .context("failed to fetch fee history")?;
+
+    // Get base fee: use latest block's base fee, or fall back to fetching
+    // latest block directly if fee history is empty
+    let base_fee_per_gas = match fee_history.latest_block_base_fee() {
+        Some(base_fee) if base_fee != 0 => base_fee,
+        _ => {
+            // empty response, fetch basefee from latest block directly
+            let block = provider
+                .get_block_by_number(BlockNumberOrTag::Latest)
+                .await
+                .context("failed to fetch latest block")?
+                .context("latest block not found")?;
+            u128::from(
+                block
+                    .header
+                    .base_fee_per_gas
+                    .context("base_fee_per_gas not available (eip1559 not supported)")?,
+            )
+        }
+    };
+
+    // Use alloy's default estimation algorithm
+    let estimation =
+        eip1559_default_estimator(base_fee_per_gas, &fee_history.reward.unwrap_or_default());
+
+    Ok(Eip1559Estimation {
+        max_fee_per_gas: estimation.max_fee_per_gas,
+        max_priority_fee_per_gas: estimation.max_priority_fee_per_gas,
+    })
 }
 
 #[async_trait::async_trait]
 impl GasPriceEstimating for ConfigurableGasPriceEstimator {
     async fn base_fee(&self) -> Result<Option<u64>> {
-        Ok(self
-            .provider
-            .get_block(BlockId::latest())
-            .await?
-            .and_then(|block| block.header.base_fee_per_gas))
+        Ok(Some(self.current_block.borrow().base_fee))
     }
 
-    #[instrument(skip(self), fields(
-        past_blocks = %self.config.past_blocks,
-        reward_percentile = %self.config.reward_percentile
-    ))]
+    #[instrument(skip_all)]
     async fn estimate(&self) -> Result<Eip1559Estimation> {
-        // Fetch fee history with our configured parameters
-        let fee_history = self
-            .provider
-            .get_fee_history(
-                self.config.past_blocks,
-                BlockNumberOrTag::Latest,
-                &[self.config.reward_percentile],
-            )
-            .await
-            .context("failed to fetch fee history")?;
-
-        // Get base fee: use latest block's base fee, or fall back to fetching
-        // latest block directly if fee history is empty
-        let base_fee_per_gas = match fee_history.latest_block_base_fee() {
-            Some(base_fee) if base_fee != 0 => base_fee,
-            _ => {
-                // empty response, fetch basefee from latest block directly
-                let block = self
-                    .provider
-                    .get_block_by_number(BlockNumberOrTag::Latest)
-                    .await
-                    .context("failed to fetch latest block")?
-                    .context("latest block not found")?;
-                u128::from(
-                    block
-                        .header
-                        .base_fee_per_gas
-                        .context("base_fee_per_gas not available (eip1559 not supported)")?,
-                )
-            }
-        };
-
-        // Use alloy's default estimation algorithm
-        let estimation =
-            eip1559_default_estimator(base_fee_per_gas, &fee_history.reward.unwrap_or_default());
-
-        Ok(Eip1559Estimation {
-            max_fee_per_gas: estimation.max_fee_per_gas,
-            max_priority_fee_per_gas: estimation.max_priority_fee_per_gas,
-        })
+        Ok(*self.lastest_gas_price.borrow())
     }
 }

--- a/crates/gas-price-estimation/src/configurable_alloy.rs
+++ b/crates/gas-price-estimation/src/configurable_alloy.rs
@@ -11,7 +11,10 @@ use {
     alloy_provider::{Provider, utils::eip1559_default_estimator},
     anyhow::{Context, Result},
     configs::gas_price_estimation::EstimatorConfig,
-    ethrpc::{AlloyProvider, block_stream::CurrentBlockWatcher},
+    ethrpc::{
+        AlloyProvider,
+        block_stream::{BlockInfo, CurrentBlockWatcher},
+    },
     futures::StreamExt as _,
     tokio::sync::watch,
     tracing::instrument,
@@ -46,8 +49,8 @@ impl ConfigurableGasPriceEstimator {
         let (sender, receiver) = watch::channel(init);
         let mut current_block_stream = ethrpc::block_stream::into_stream(current_block.clone());
         tokio::task::spawn(async move {
-            while current_block_stream.next().await.is_some() {
-                let gas_price = match current_gas_price(&provider, &config).await {
+            while let Some(block) = current_block_stream.next().await {
+                let gas_price = match current_gas_price(&provider, &config, &block).await {
                     Ok(gas_price) => gas_price,
                     Err(err) => {
                         tracing::warn!(?err, "failed to compute gas price");
@@ -79,6 +82,7 @@ impl ConfigurableGasPriceEstimator {
 async fn current_gas_price(
     provider: &AlloyProvider,
     config: &EstimatorConfig,
+    block: &BlockInfo,
 ) -> Result<Eip1559Estimation> {
     // Fetch fee history with our configured parameters
     let fee_history = provider
@@ -96,17 +100,7 @@ async fn current_gas_price(
         Some(base_fee) if base_fee != 0 => base_fee,
         _ => {
             // empty response, fetch basefee from latest block directly
-            let block = provider
-                .get_block_by_number(BlockNumberOrTag::Latest)
-                .await
-                .context("failed to fetch latest block")?
-                .context("latest block not found")?;
-            u128::from(
-                block
-                    .header
-                    .base_fee_per_gas
-                    .context("base_fee_per_gas not available (eip1559 not supported)")?,
-            )
+            block.base_fee.into()
         }
     };
 

--- a/crates/gas-price-estimation/src/configurable_alloy.rs
+++ b/crates/gas-price-estimation/src/configurable_alloy.rs
@@ -34,9 +34,9 @@ impl ConfigurableGasPriceEstimator {
         config: EstimatorConfig,
         current_block: CurrentBlockWatcher,
     ) -> Self {
-        // use some reasonable initial value. The exact value doesn't matter much since
-        // the background task will update the gas price immediately anyway
-        // since the block stream yields the current block immediately
+        // use some reasonable initial value. The exact value doesn't matter much since the background
+        // task will update the gas price immediately anyway since the block stream yields
+        // the current block immediately
         let base_fee = current_block.borrow().base_fee;
         let init = Eip1559Estimation {
             max_fee_per_gas: u128::from(base_fee * 2),
@@ -131,3 +131,140 @@ impl GasPriceEstimating for ConfigurableGasPriceEstimator {
         Ok(*self.lastest_gas_price.borrow())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        alloy_provider::{Provider, ProviderBuilder, mock::Asserter},
+        ethrpc::block_stream::{BlockInfo, mock_single_block},
+        tokio::{sync::watch, time::Duration},
+    };
+
+    fn mock_provider(asserter: Asserter) -> ethrpc::AlloyProvider {
+        ProviderBuilder::new()
+            .connect_mocked_client(asserter)
+            .erased()
+    }
+
+    fn default_config() -> EstimatorConfig {
+        EstimatorConfig {
+            past_blocks: 5,
+            reward_percentile: 50.0,
+        }
+    }
+
+    fn block_with_base_fee(base_fee: u64) -> BlockInfo {
+        BlockInfo {
+            base_fee,
+            ..Default::default()
+        }
+    }
+
+    // Pushes a fee_history JSON response where `latest_block_base_fee()` returns
+    // `base_fee` and the reward is `tip`. The resulting estimate will be:
+    //   max_priority_fee_per_gas = tip
+    //   max_fee_per_gas          = base_fee * 2 + tip
+    fn push_fee_history(asserter: &Asserter, base_fee: u128, tip: u128) {
+        asserter.push_success(&serde_json::json!({
+            // baseFeePerGas[len-2] is the latest block base fee,
+            // baseFeePerGas[len-1] is the projected next block base fee
+            "baseFeePerGas": [format!("0x{base_fee:x}"), format!("0x{:x}", base_fee * 2)],
+            "gasUsedRatio": [0.5],
+            "oldestBlock": "0x1",
+            "reward": [[format!("0x{tip:x}")]]
+        }));
+    }
+
+    #[tokio::test]
+    async fn base_fee_reads_from_block_watcher_not_rpc() {
+        let base_fee: u64 = 5_000_000_000;
+        let current_block = mock_single_block(block_with_base_fee(base_fee));
+        let asserter = Asserter::new();
+        // Queue one response for the background task's initial fee history fetch.
+        push_fee_history(&asserter, base_fee as u128, 1_000_000_000);
+        let provider = mock_provider(asserter);
+
+        let estimator =
+            ConfigurableGasPriceEstimator::new(provider, default_config(), current_block);
+
+        // base_fee() reads from the block watcher directly — no RPC call needed.
+        let result = estimator.base_fee().await.unwrap();
+        assert_eq!(result, Some(base_fee));
+    }
+
+    #[tokio::test]
+    async fn estimate_caches_result_between_blocks() {
+        let base_fee: u128 = 10_000_000_000;
+        let tip: u128 = 1_000_000_000;
+
+        // Keep the sender alive so the background task does not terminate.
+        let (block_sender, block_receiver) = watch::channel(block_with_base_fee(1));
+        let asserter = Asserter::new();
+        // Only one response is queued — the estimator must not call RPC more than once.
+        push_fee_history(&asserter, base_fee, tip);
+        let provider = mock_provider(asserter.clone());
+
+        let estimator =
+            ConfigurableGasPriceEstimator::new(provider, default_config(), block_receiver);
+
+        // Give the background task time to process the initial block.
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        let first = estimator.estimate().await.unwrap();
+        let second = estimator.estimate().await.unwrap();
+
+        assert_eq!(first, second, "estimate should return the same cached value");
+        assert!(
+            asserter.read_q().is_empty(),
+            "no additional RPC calls should have been made between estimate() calls"
+        );
+    }
+
+    #[tokio::test]
+    async fn estimate_updates_when_new_block_arrives() {
+        let base_fee_1: u128 = 10_000_000_000;
+        let base_fee_2: u128 = 20_000_000_000;
+        let tip: u128 = 1_000_000_000;
+
+        let (block_sender, block_receiver) = watch::channel(block_with_base_fee(1));
+        let asserter = Asserter::new();
+        push_fee_history(&asserter, base_fee_1, tip);
+        let provider = mock_provider(asserter.clone());
+
+        let estimator =
+            ConfigurableGasPriceEstimator::new(provider, default_config(), block_receiver);
+
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        let estimate_after_block_1 = estimator.estimate().await.unwrap();
+        assert_eq!(
+            estimate_after_block_1.max_fee_per_gas,
+            base_fee_1 * 2 + tip,
+            "max_fee after block 1"
+        );
+        assert_eq!(
+            estimate_after_block_1.max_priority_fee_per_gas,
+            tip,
+            "max_priority after block 1"
+        );
+
+        // Queue the response for the second block and trigger the update.
+        push_fee_history(&asserter, base_fee_2, tip);
+        block_sender.send(block_with_base_fee(2)).unwrap();
+
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        let estimate_after_block_2 = estimator.estimate().await.unwrap();
+        assert_eq!(
+            estimate_after_block_2.max_fee_per_gas,
+            base_fee_2 * 2 + tip,
+            "max_fee after block 2"
+        );
+        assert!(
+            asserter.read_q().is_empty(),
+            "both fee_history responses should have been consumed"
+        );
+    }
+}
+

--- a/crates/gas-price-estimation/src/configurable_alloy.rs
+++ b/crates/gas-price-estimation/src/configurable_alloy.rs
@@ -50,7 +50,7 @@ impl ConfigurableGasPriceEstimator {
                 let gas_price = match current_gas_price(&provider, &config).await {
                     Ok(gas_price) => gas_price,
                     Err(err) => {
-                        tracing::warn!(?err, "failed to computed gas price");
+                        tracing::warn!(?err, "failed to compute gas price");
                         continue;
                     }
                 };

--- a/crates/gas-price-estimation/src/configurable_alloy.rs
+++ b/crates/gas-price-estimation/src/configurable_alloy.rs
@@ -199,7 +199,7 @@ mod tests {
         let tip: u128 = 1_000_000_000;
 
         // Keep the sender alive so the background task does not terminate.
-        let (block_sender, block_receiver) = watch::channel(block_with_base_fee(1));
+        let (_block_sender, block_receiver) = watch::channel(block_with_base_fee(1));
         let asserter = Asserter::new();
         // Only one response is queued — the estimator must not call RPC more than once.
         push_fee_history(&asserter, base_fee, tip);

--- a/crates/gas-price-estimation/src/configurable_alloy.rs
+++ b/crates/gas-price-estimation/src/configurable_alloy.rs
@@ -34,9 +34,9 @@ impl ConfigurableGasPriceEstimator {
         config: EstimatorConfig,
         current_block: CurrentBlockWatcher,
     ) -> Self {
-        // use some reasonable initial value. The exact value doesn't matter much since the background
-        // task will update the gas price immediately anyway since the block stream yields
-        // the current block immediately
+        // use some reasonable initial value. The exact value doesn't matter much since
+        // the background task will update the gas price immediately anyway
+        // since the block stream yields the current block immediately
         let base_fee = current_block.borrow().base_fee;
         let init = Eip1559Estimation {
             max_fee_per_gas: u128::from(base_fee * 2),
@@ -214,7 +214,10 @@ mod tests {
         let first = estimator.estimate().await.unwrap();
         let second = estimator.estimate().await.unwrap();
 
-        assert_eq!(first, second, "estimate should return the same cached value");
+        assert_eq!(
+            first, second,
+            "estimate should return the same cached value"
+        );
         assert!(
             asserter.read_q().is_empty(),
             "no additional RPC calls should have been made between estimate() calls"
@@ -244,8 +247,7 @@ mod tests {
             "max_fee after block 1"
         );
         assert_eq!(
-            estimate_after_block_1.max_priority_fee_per_gas,
-            tip,
+            estimate_after_block_1.max_priority_fee_per_gas, tip,
             "max_priority after block 1"
         );
 
@@ -267,4 +269,3 @@ mod tests {
         );
     }
 }
-

--- a/crates/gas-price-estimation/src/lib.rs
+++ b/crates/gas-price-estimation/src/lib.rs
@@ -19,7 +19,7 @@ use {
         default_past_blocks,
         default_reward_percentile,
     },
-    ethrpc::Web3,
+    ethrpc::{AlloyProvider, block_stream::CurrentBlockWatcher},
     tracing::instrument,
     url::Url,
 };
@@ -54,10 +54,11 @@ pub enum GasEstimatorType {
 #[instrument(skip_all)]
 pub async fn create_priority_estimator(
     http_client: reqwest::Client,
-    web3: &Web3,
+    provider: &AlloyProvider,
     estimator_types: &[GasEstimatorType],
+    current_block: &CurrentBlockWatcher,
 ) -> Result<impl GasPriceEstimating + use<>> {
-    let network_id = web3.provider.get_chain_id().await?.to_string();
+    let network_id = provider.get_chain_id().await?.to_string();
     let mut estimators = Vec::<Box<dyn GasPriceEstimating>>::new();
 
     for estimator_type in estimator_types {
@@ -67,19 +68,20 @@ pub async fn create_priority_estimator(
                 estimators.push(Box::new(DriverGasEstimator::new(
                     http_client.clone(),
                     url.clone(),
-                    web3.provider.clone(),
+                    provider.clone(),
                 )));
             }
             GasEstimatorType::Web3 => {
-                estimators.push(Box::new(NodeGasPriceEstimator::new(web3.provider.clone())))
+                estimators.push(Box::new(NodeGasPriceEstimator::new(provider.clone())))
             }
             GasEstimatorType::Alloy => {
                 let estimator = ConfigurableGasPriceEstimator::new(
-                    web3.provider.clone(),
+                    provider.clone(),
                     EstimatorConfig {
                         past_blocks: default_past_blocks(),
                         reward_percentile: default_reward_percentile(),
                     },
+                    current_block.clone(),
                 );
                 estimators.push(Box::new(estimator))
             }

--- a/crates/orderbook/src/run.rs
+++ b/crates/orderbook/src/run.rs
@@ -213,16 +213,6 @@ pub async fn run(config: Configuration) {
         .iter()
         .map(shared::arguments::gas_estimator_type_from_config)
         .collect();
-    let gas_price_estimator = Arc::new(InstrumentedGasEstimator::new(
-        gas_price_estimation::create_priority_estimator(
-            http_factory.create(),
-            &web3,
-            &gas_estimators,
-        )
-        .await
-        .expect("failed to create gas price estimator"),
-    ));
-
     let deny_listed_tokens = DenyListedTokens::new(config.unsupported_tokens);
 
     let current_block_args = shared::current_block::Arguments::from(&config.shared.current_block);
@@ -230,6 +220,17 @@ pub async fn run(config: Configuration) {
         .stream(config.shared.node_url.clone(), web3.provider.clone())
         .await
         .unwrap();
+
+    let gas_price_estimator = Arc::new(InstrumentedGasEstimator::new(
+        gas_price_estimation::create_priority_estimator(
+            http_factory.create(),
+            &web3.provider,
+            &gas_estimators,
+            &current_block_stream,
+        )
+        .await
+        .expect("failed to create gas price estimator"),
+    ));
 
     let token_info_fetcher = Arc::new(CachedTokenInfoFetcher::new(Arc::new(TokenInfoFetcher {
         web3: web3.clone(),


### PR DESCRIPTION
# Description
When we switched from the old gas price estimation crate to a new one built on top of alloy we lost a key optimization. The old gas price estimation updated the gas price in a background task so the total number of RPC requests was constant while they scale with the number of connected solvers and such for the new logic.

For example on mainnet this causes the driver to spend a third of its RPC requests on gas price computation which is obviously insane.
<img width="1187" height="304" alt="Screenshot 2026-06-29 at 09 10 08" src="https://github.com/user-attachments/assets/087a847b-6cb5-413e-ae94-681e1f1dad57" />

# Changes
Implements a background task for the alloy based gas price estimator which updates the gas price once for every new block.

To break up a circular dependency when creating the `Ethereum` instance in the driver I needed to move the creation of the gas price estimator into `Ethereum::new()` which in turn required a few other changes.

## How to test
Added unit test

Also deployed this temporarily to prod BNB and the time to convert the DTO to the domain types dropped from ~200ms to 3ms because we don't have any RPC calls on the hot path anymore.
<img width="1599" height="819" alt="Screenshot 2026-06-30 at 08 26 10" src="https://github.com/user-attachments/assets/c4d00479-5826-45de-87b1-d94ff829baf1" />
