### PR TITLE
Do not log unsupported token orders on quotes

### DIFF
--- a/crates/driver/src/domain/competition/risk_detector/mod.rs
+++ b/crates/driver/src/domain/competition/risk_detector/mod.rs
@@ -137,7 +137,7 @@ impl Detector {
         }
 
         auction.orders = supported_orders;
-        if !removed_uids.is_empty() {
+        if !removed_uids.is_empty() && auction.id.is_some() {
             tracing::debug!(orders = ?removed_uids, "ignored orders with unsupported tokens");
         }
 


### PR DESCRIPTION
# Description
The log in question is creating quite a bit of noise *and* work for vector. Since auctions with id == None are quotes, and we don't really care about order 0x000...000 so there's no point in logging it.

Context: https://nomevlabs.slack.com/archives/C0361CDD1FZ/p1782822341859389

# Changes

* If auction is a quote, do not log unsupported orders
