### PR TITLE
Only track balances of tokens with internal buffer trading

### DIFF
--- a/crates/driver/src/infra/api/routes/solve/dto/solve_request.rs
+++ b/crates/driver/src/infra/api/routes/solve/dto/solve_request.rs
@@ -41,6 +41,14 @@ impl SolveRequest {
             .collect();
         let token_infos = tokens.get(&token_addresses).await;
 
+        // register all tokens where internal buffer trading is allowed
+        // for continuous balance monitoring
+        tokens.keep_track_of_balances(
+            self.tokens
+                .iter()
+                .filter_map(|t| t.trusted.then_some(&t.address)),
+        );
+
         competition::Auction::new(
             Some(self.id.try_into()?),
             self.orders

--- a/crates/driver/src/infra/tokens.rs
+++ b/crates/driver/src/infra/tokens.rs
@@ -20,6 +20,9 @@ pub struct Metadata {
     pub symbol: Option<String>,
     /// Current balance of the smart contract.
     pub balance: eth::TokenAmount,
+    /// If this flag is true a background task will continuously
+    /// update this token's [`Metadata::balance`] field.
+    pub keep_track_of_balance: bool,
 }
 
 #[derive(Clone)]
@@ -50,6 +53,35 @@ impl Fetcher {
     ) -> HashMap<eth::TokenAddress, Metadata> {
         self.0.get(addresses).await
     }
+
+    /// Tells the cache to continuously update the settlement contract balance
+    /// of the given tokens if they are already present in the cache. That only
+    /// really makes sense for tokens where internal buffer trading is allowed.
+    pub fn keep_track_of_balances<'a>(&self, tokens: impl IntoIterator<Item = &'a eth::Address>) {
+        // most of the time no updates are needed so we first take a read lock to
+        // check if we even have to take a write lock for updating the tokens at all
+        let tokens_to_update: Vec<_> = {
+            let cache = self.0.cache.read().unwrap();
+            tokens
+                .into_iter()
+                .filter(|token| {
+                    cache
+                        .get(&((**token).into()))
+                        .is_some_and(|entry| !entry.keep_track_of_balance)
+                })
+                .collect()
+        };
+        if !tokens_to_update.is_empty() {
+            // now that we know we actually have to update some tokens we take a write
+            // lock
+            let mut cache = self.0.cache.write().unwrap();
+            tokens_to_update.into_iter().for_each(|token| {
+                if let Some(entry) = cache.get_mut(&((*token).into())) {
+                    entry.keep_track_of_balance = true;
+                }
+            })
+        }
+    }
 }
 
 /// Runs a single cache update cycle whenever a new block arrives until the
@@ -71,18 +103,21 @@ async fn update_task(blocks: CurrentBlockWatcher, inner: std::sync::Weak<Inner>)
 /// Updates the settlement contract's balance for every cached token.
 async fn update_balances(inner: Arc<Inner>) -> Result<(), blockchain::Error> {
     let settlement = *inner.eth.contracts().settlement().address();
-    let futures = {
+    let futures: Vec<_> = {
         let cache = inner.cache.read().unwrap();
-        let tokens = cache.keys().cloned().collect::<Vec<_>>();
-        tokens.into_iter().map(|token| {
-            let erc20 = inner.eth.erc20(token);
-            async move {
-                Ok::<(eth::TokenAddress, eth::TokenAmount), blockchain::Error>((
-                    token,
-                    erc20.balance(settlement).await?,
-                ))
-            }
-        })
+        cache
+            .iter()
+            .filter(|(_token, info)| info.keep_track_of_balance)
+            .map(|(token, _info)| {
+                let erc20 = inner.eth.erc20(*token);
+                async move {
+                    Ok::<(eth::TokenAddress, eth::TokenAmount), blockchain::Error>((
+                        erc20.address(),
+                        erc20.balance(settlement).await?,
+                    ))
+                }
+            })
+            .collect()
     };
 
     tracing::debug!(
@@ -152,6 +187,7 @@ impl Inner {
                             decimals,
                             symbol,
                             balance,
+                            keep_track_of_balance: false,
                         },
                     ))
                 }

--- a/crates/driver/src/infra/tokens.rs
+++ b/crates/driver/src/infra/tokens.rs
@@ -22,7 +22,7 @@ pub struct Metadata {
     pub balance: eth::TokenAmount,
     /// If this flag is true a background task will continuously
     /// update this token's [`Metadata::balance`] field.
-    pub keep_track_of_balance: bool,
+    pub monitor_balance: bool,
 }
 
 #[derive(Clone)]
@@ -67,7 +67,7 @@ impl Fetcher {
                 .filter(|token| {
                     cache
                         .get(&((**token).into()))
-                        .is_some_and(|entry| !entry.keep_track_of_balance)
+                        .is_some_and(|entry| !entry.monitor_balance)
                 })
                 .collect()
         };
@@ -77,7 +77,7 @@ impl Fetcher {
             let mut cache = self.0.cache.write().unwrap();
             tokens_to_update.into_iter().for_each(|token| {
                 if let Some(entry) = cache.get_mut(&((*token).into())) {
-                    entry.keep_track_of_balance = true;
+                    entry.monitor_balance = true;
                 }
             })
         }
@@ -107,7 +107,7 @@ async fn update_balances(inner: Arc<Inner>) -> Result<(), blockchain::Error> {
         let cache = inner.cache.read().unwrap();
         cache
             .iter()
-            .filter(|(_token, info)| info.keep_track_of_balance)
+            .filter(|(_token, info)| info.monitor_balance)
             .map(|(token, _info)| {
                 let erc20 = inner.eth.erc20(*token);
                 async move {
@@ -187,7 +187,7 @@ impl Inner {
                             decimals,
                             symbol,
                             balance,
-                            keep_track_of_balance: false,
+                            monitor_balance: false,
                         },
                     ))
                 }

--- a/crates/driver/src/infra/tokens.rs
+++ b/crates/driver/src/infra/tokens.rs
@@ -110,12 +110,7 @@ async fn update_balances(inner: Arc<Inner>) -> Result<(), blockchain::Error> {
             .filter(|(_token, info)| info.monitor_balance)
             .map(|(token, _info)| {
                 let erc20 = inner.eth.erc20(*token);
-                async move {
-                    Ok::<(eth::TokenAddress, eth::TokenAmount), blockchain::Error>((
-                        erc20.address(),
-                        erc20.balance(settlement).await?,
-                    ))
-                }
+                async move { (erc20.address(), erc20.balance(settlement).await) }
             })
             .collect()
     };
@@ -128,25 +123,25 @@ async fn update_balances(inner: Arc<Inner>) -> Result<(), blockchain::Error> {
     // Don't hold on to the lock while fetching balances to allow concurrent
     // updates. This may lead to new entries arriving in the meantime, however
     // their balances should already be up-to-date.
-    let mut balances = futures::future::try_join_all(futures)
-        .await?
-        .into_iter()
-        .collect::<HashMap<_, _>>();
+    let balances = futures::future::join_all(futures).await;
 
-    let mut keys_without_balances = vec![];
+    let mut failed_updates = vec![];
     {
         let mut cache = inner.cache.write().unwrap();
-        for (key, entry) in cache.iter_mut() {
-            if let Some(balance) = balances.remove(key) {
+        for (token, balance_result) in balances {
+            let Ok(balance) = balance_result else {
+                failed_updates.push(token);
+                continue;
+            };
+
+            if let Some(entry) = cache.get_mut(&token) {
                 entry.balance = balance;
-            } else {
-                // Avoid logging while holding the exclusive lock.
-                keys_without_balances.push(*key);
             }
         }
     }
-    if !keys_without_balances.is_empty() {
-        tracing::info!(keys = ?keys_without_balances, "updated keys without balance");
+
+    if !failed_updates.is_empty() {
+        tracing::info!(tokens = ?failed_updates, "failed to update token balance");
     }
 
     Ok(())

--- a/crates/driver/src/infra/tokens.rs
+++ b/crates/driver/src/infra/tokens.rs
@@ -72,8 +72,6 @@ impl Fetcher {
                 .collect()
         };
         if !tokens_to_update.is_empty() {
-            // now that we know we actually have to update some tokens we take a write
-            // lock
             let mut cache = self.0.cache.write().unwrap();
             tokens_to_update.into_iter().for_each(|token| {
                 if let Some(entry) = cache.get_mut(&((*token).into())) {


### PR DESCRIPTION
# Description
The protocol allows to do internal buffer trading which means a solver is allowed to use the settlement contract's token balances as if it was an AMM. To enable solvers to make use of this the driver continuously monitors the settlement contract's token balances and writes them into the auction instance.
However, so far the driver kept monitoring token balances for every token it ever needed to fetch metadata for despite only a couple of tokens actually being allow listed for internal buffer trading.

This oversight leads to tons of RPC requests being wasted. The number scales with the `tokens_seen_by_driver * block_interval` which leads to especially wasteful traffic on chains like BNB which have a good amount of traffic and are very fast.
For example here we can see that after 4 days of running the driver we continuously use ~4 times as many RPC requests for fetching token balances for the settlement contract as for the traders. At the peak roughly half of the driver's RPC requests were dedicated to that when it actually should be 0 because as it turns out there aren't even any tokens on BNB where internal buffer trading is currently allowed.
<img width="1902" height="303" alt="Screenshot 2026-07-01 at 08 46 30" src="https://github.com/user-attachments/assets/dfa9d80b-edc6-4bb5-b9c1-0a49f8ae7b2c" />  

# Changes
Instead of monitoring the balances for every tokens the driver ever saw we explicitly mark tokens for monitoring whenever we build a new auction.
Since the set of tokens to monitor is not expected to change often I tried to make this logic as zero overhead as possible by first taking a read lock to see which tokens need updating at all (on average 0) and I also avoided allocating vectors as much as possible.