### PR TITLE
Add debug headers to RPC requests

### DIFF
--- a/crates/ethrpc/src/alloy/mod.rs
+++ b/crates/ethrpc/src/alloy/mod.rs
@@ -2,6 +2,7 @@ mod buffering;
 pub mod errors;
 mod evm_ext;
 mod instrumentation;
+mod rpc_headers;
 mod wallet;
 
 use {
@@ -10,11 +11,15 @@ use {
     alloy_rpc_client::{ClientBuilder, RpcClient},
     buffering::BatchCallLayer,
     instrumentation::{InstrumentationLayer, LabelingLayer},
+    rpc_headers::RpcHeadersLayer,
 };
 pub use {evm_ext::EvmProviderExt, instrumentation::ProviderLabelingExt, wallet::MutWallet};
 
 /// Creates an [`RpcClient`] from the given URL with [`LabelingLayer`],
-/// [`InstrumentationLayer`] and [`BatchCallLayer`].
+/// [`InstrumentationLayer`], [`BatchCallLayer`] and [`RpcHeadersLayer`].
+///
+/// [`RpcHeadersLayer`] is installed last so it runs innermost — it must observe
+/// the packet after [`BatchCallLayer`] has coalesced calls into a batch.
 fn rpc(url: &str, config: Config, label: Option<&str>) -> RpcClient {
     ClientBuilder::default()
         .layer(LabelingLayer {
@@ -22,6 +27,7 @@ fn rpc(url: &str, config: Config, label: Option<&str>) -> RpcClient {
         })
         .layer(InstrumentationLayer)
         .layer(BatchCallLayer::new(config))
+        .layer(RpcHeadersLayer)
         .http(url.parse().unwrap())
 }
 
@@ -37,6 +43,7 @@ fn unbuffered_rpc(url: &str, label: Option<&str>) -> RpcClient {
             label: label.unwrap_or("main_unbuffered").into(),
         })
         .layer(InstrumentationLayer)
+        .layer(RpcHeadersLayer)
         .http(url.parse().unwrap())
 }
 

--- a/crates/ethrpc/src/alloy/mod.rs
+++ b/crates/ethrpc/src/alloy/mod.rs
@@ -11,21 +11,26 @@ use {
     alloy_rpc_client::{ClientBuilder, RpcClient},
     buffering::BatchCallLayer,
     instrumentation::{InstrumentationLayer, LabelingLayer},
-    rpc_headers::RpcHeadersLayer,
+    rpc_headers::{RpcHeadersLayer, TracingRequestIdLayer},
 };
 pub use {evm_ext::EvmProviderExt, instrumentation::ProviderLabelingExt, wallet::MutWallet};
 
 /// Creates an [`RpcClient`] from the given URL with [`LabelingLayer`],
-/// [`InstrumentationLayer`], [`BatchCallLayer`] and [`RpcHeadersLayer`].
+/// [`InstrumentationLayer`], [`TracingRequestIdLayer`], [`BatchCallLayer`] and
+/// [`RpcHeadersLayer`].
 ///
-/// [`RpcHeadersLayer`] is installed last so it runs innermost — it must observe
-/// the packet after [`BatchCallLayer`] has coalesced calls into a batch.
+/// [`TracingRequestIdLayer`] is installed *before* [`BatchCallLayer`] so it
+/// runs on the caller's task and can capture the tracing request id from the
+/// current span. [`RpcHeadersLayer`] is installed last so it runs innermost —
+/// it must observe the packet after [`BatchCallLayer`] has coalesced calls into
+/// a batch.
 fn rpc(url: &str, config: Config, label: Option<&str>) -> RpcClient {
     ClientBuilder::default()
         .layer(LabelingLayer {
             label: label.unwrap_or("main").into(),
         })
         .layer(InstrumentationLayer)
+        .layer(TracingRequestIdLayer)
         .layer(BatchCallLayer::new(config))
         .layer(RpcHeadersLayer)
         .http(url.parse().unwrap())
@@ -43,6 +48,7 @@ fn unbuffered_rpc(url: &str, label: Option<&str>) -> RpcClient {
             label: label.unwrap_or("main_unbuffered").into(),
         })
         .layer(InstrumentationLayer)
+        .layer(TracingRequestIdLayer)
         .layer(RpcHeadersLayer)
         .http(url.parse().unwrap())
 }

--- a/crates/ethrpc/src/alloy/rpc_headers.rs
+++ b/crates/ethrpc/src/alloy/rpc_headers.rs
@@ -1,16 +1,7 @@
 //! Transport layers that annotate outgoing HTTP RPC requests with headers
 //! describing the JSON-RPC call(s) they carry: the `method:id` pair(s) and the
 //! distributed-tracing request id.
-//!
-//! Two layers cooperate:
-//! - [`TracingRequestIdLayer`] runs *outside* the batching layer, while still
-//!   on the caller's task, and stamps the current span's distributed-tracing
-//!   request id onto the request. This is necessary because the batching layer
-//!   forwards requests from a background task that no longer sees that span.
-//! - [`RpcHeadersLayer`] MUST be installed as the innermost layer (closest to
-//!   the HTTP transport) so it observes the final (possibly batched) packet on
-//!   the wire; it writes the `method:id` list and aggregates the request ids
-//!   stamped above.
+
 use {
     alloy_json_rpc::RequestPacket,
     reqwest::header::{HeaderName, HeaderValue},
@@ -28,6 +19,9 @@ const CALLS: &str = "x-rpc-calls";
 /// task's logs across processes.
 const TRACING_REQUEST_ID: &str = "x-request-id";
 
+/// MUST be installed as the innermost layer (closest to the HTTP transport)
+/// so it observes the final (possibly batched) packet on the wire;
+/// it writes the `method:id` list and aggregates the request ids stamped above.
 pub(crate) struct RpcHeadersLayer;
 
 impl<S> Layer<S> for RpcHeadersLayer {
@@ -38,6 +32,10 @@ impl<S> Layer<S> for RpcHeadersLayer {
     }
 }
 
+/// Runs *outside* the batching layer, while still on the caller's task,
+/// and stamps the current span's distributed-tracing request id onto the
+/// request. This is necessary because the batching layer forwards requests
+/// from a  background task that no longer sees that span.
 #[derive(Debug, Clone)]
 pub(crate) struct RpcHeadersService<S> {
     inner: S,

--- a/crates/ethrpc/src/alloy/rpc_headers.rs
+++ b/crates/ethrpc/src/alloy/rpc_headers.rs
@@ -1,0 +1,157 @@
+//! Transport layer that annotates outgoing HTTP RPC requests with headers
+//! describing the JSON-RPC call(s) they carry: the method(s), the request
+//! id(s), and the distributed-tracing request id.
+//!
+//! It MUST be installed as the innermost layer (closest to the HTTP transport,
+//! i.e. after [`super::buffering::BatchCallLayer`]) so that it observes the
+//! request packet exactly as it goes out on the wire — in particular *after*
+//! the batching layer has coalesced individual calls into a batch.
+use {
+    alloy_json_rpc::{RequestPacket, SerializedRequest},
+    reqwest::header::{HeaderName, HeaderValue},
+    std::task::{Context, Poll},
+    tower::{Layer, Service},
+};
+
+/// Comma-separated list of the JSON-RPC method(s) in the packet.
+const METHOD: &str = "x-rpc-method";
+/// Comma-separated list of the JSON-RPC id(s) in the packet.
+const REQUEST_ID: &str = "x-rpc-request-id";
+/// Distributed-tracing request id, correlating this call with the originating
+/// task's logs across processes.
+const TRACING_REQUEST_ID: &str = "x-request-id";
+
+pub(crate) struct RpcHeadersLayer;
+
+impl<S> Layer<S> for RpcHeadersLayer {
+    type Service = RpcHeadersService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        RpcHeadersService { inner }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RpcHeadersService<S> {
+    inner: S,
+}
+
+impl<S> Service<RequestPacket> for RpcHeadersService<S>
+where
+    S: Service<RequestPacket> + Send + 'static,
+    S::Future: Send + 'static,
+{
+    type Error = S::Error;
+    type Future = S::Future;
+    type Response = S::Response;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: RequestPacket) -> Self::Future {
+        let request_id = observe::tracing::distributed::request_id::from_current_span();
+        annotate(&mut req, request_id.as_deref());
+        self.inner.call(req)
+    }
+}
+
+/// Attaches the RPC correlation headers to the packet.
+///
+/// The batching layer may coalesce several calls into one packet, so the method
+/// and id headers list every call. The headers are written onto the last
+/// request because header aggregation across a packet is last-wins, so a single
+/// writer surfaces them for the whole request.
+fn annotate(req: &mut RequestPacket, request_id: Option<&str>) {
+    let requests = req.requests_mut();
+    let methods = requests
+        .iter()
+        .map(SerializedRequest::method)
+        .collect::<Vec<_>>()
+        .join(",");
+    let ids = requests
+        .iter()
+        .map(|r| r.id().to_string())
+        .collect::<Vec<_>>()
+        .join(",");
+    let Some(last) = requests.last_mut() else {
+        return;
+    };
+    let headers = last.headers_mut();
+    if let Some(v) = header_value(&methods) {
+        headers.insert(HeaderName::from_static(METHOD), v);
+    }
+    if let Some(v) = header_value(&ids) {
+        headers.insert(HeaderName::from_static(REQUEST_ID), v);
+    }
+    if let Some(v) = request_id.and_then(header_value) {
+        headers.insert(HeaderName::from_static(TRACING_REQUEST_ID), v);
+    }
+}
+
+fn header_value(s: &str) -> Option<HeaderValue> {
+    HeaderValue::from_str(s).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        alloy_json_rpc::{Id, Request},
+    };
+
+    fn request(method: &'static str, id: u64) -> SerializedRequest {
+        Request::new(method, Id::Number(id), ())
+            .serialize()
+            .expect("serialize request")
+    }
+
+    #[test]
+    fn single_call_lists_method_and_id() {
+        let mut packet = RequestPacket::Single(request("eth_sendRawTransaction", 7));
+        // No tracing request id in scope, so `x-request-id` should be absent.
+        annotate(&mut packet, None);
+
+        let headers = packet.headers();
+        assert_eq!(headers[METHOD], "eth_sendRawTransaction");
+        assert_eq!(headers[REQUEST_ID], "7");
+        assert!(!headers.contains_key(TRACING_REQUEST_ID));
+    }
+
+    #[test]
+    fn always_forwards_tracing_request_id() {
+        let mut single = RequestPacket::Single(request("eth_call", 1));
+        annotate(&mut single, Some("auction-42"));
+        assert_eq!(single.headers()[TRACING_REQUEST_ID], "auction-42");
+
+        let mut batch =
+            RequestPacket::Batch(vec![request("eth_call", 1), request("eth_getBalance", 2)]);
+        annotate(&mut batch, Some("auction-42"));
+        assert_eq!(batch.headers()[TRACING_REQUEST_ID], "auction-42");
+    }
+
+    #[test]
+    fn batch_lists_all_methods_and_ids() {
+        let mut packet = RequestPacket::Batch(vec![
+            request("eth_call", 1),
+            request("eth_getBalance", 2),
+            request("eth_chainId", 3),
+        ]);
+        annotate(&mut packet, Some("auction-42"));
+
+        let headers = packet.headers();
+        assert_eq!(headers[METHOD], "eth_call,eth_getBalance,eth_chainId");
+        assert_eq!(headers[REQUEST_ID], "1,2,3");
+        assert_eq!(headers[TRACING_REQUEST_ID], "auction-42");
+    }
+
+    #[test]
+    fn batch_of_one_lists_single_method() {
+        let mut packet = RequestPacket::Batch(vec![request("eth_chainId", 9)]);
+        annotate(&mut packet, None);
+
+        let headers = packet.headers();
+        assert_eq!(headers[METHOD], "eth_chainId");
+        assert_eq!(headers[REQUEST_ID], "9");
+    }
+}

--- a/crates/ethrpc/src/alloy/rpc_headers.rs
+++ b/crates/ethrpc/src/alloy/rpc_headers.rs
@@ -2,10 +2,8 @@
 //! describing the JSON-RPC call(s) they carry: the method(s), the request
 //! id(s), and the distributed-tracing request id.
 //!
-//! It MUST be installed as the innermost layer (closest to the HTTP transport,
-//! i.e. after [`super::buffering::BatchCallLayer`]) so that it observes the
-//! request packet exactly as it goes out on the wire — in particular *after*
-//! the batching layer has coalesced individual calls into a batch.
+//! It MUST be installed as the innermost layer (closest to the HTTP transpor)
+//! so that it observes the request packet exactly as it goes out on the wire.
 use {
     alloy_json_rpc::{RequestPacket, SerializedRequest},
     reqwest::header::{HeaderName, HeaderValue},

--- a/crates/ethrpc/src/alloy/rpc_headers.rs
+++ b/crates/ethrpc/src/alloy/rpc_headers.rs
@@ -1,20 +1,22 @@
 //! Transport layer that annotates outgoing HTTP RPC requests with headers
-//! describing the JSON-RPC call(s) they carry: the method(s), the request
-//! id(s), and the distributed-tracing request id.
+//! describing the JSON-RPC call(s) they carry: the `method:id` pair(s) and the
+//! distributed-tracing request id.
 //!
-//! It MUST be installed as the innermost layer (closest to the HTTP transpor)
+//! It MUST be installed as the innermost layer (closest to the HTTP transport)
 //! so that it observes the request packet exactly as it goes out on the wire.
 use {
-    alloy_json_rpc::{RequestPacket, SerializedRequest},
+    alloy_json_rpc::RequestPacket,
     reqwest::header::{HeaderName, HeaderValue},
-    std::task::{Context, Poll},
+    std::{
+        fmt::Write as _,
+        task::{Context, Poll},
+    },
     tower::{Layer, Service},
 };
 
-/// Comma-separated list of the JSON-RPC method(s) in the packet.
-const METHOD: &str = "x-rpc-method";
-/// Comma-separated list of the JSON-RPC id(s) in the packet.
-const REQUEST_ID: &str = "x-rpc-request-id";
+/// Comma-separated list of the JSON-RPC calls in the packet, each formatted as
+/// `method:id` so every method stays paired with its id.
+const CALLS: &str = "x-rpc-calls";
 /// Distributed-tracing request id, correlating this call with the originating
 /// task's logs across processes.
 const TRACING_REQUEST_ID: &str = "x-request-id";
@@ -56,31 +58,27 @@ where
 
 /// Attaches the RPC correlation headers to the packet.
 ///
-/// The batching layer may coalesce several calls into one packet, so the method
-/// and id headers list every call. The headers are written onto the last
-/// request because header aggregation across a packet is last-wins, so a single
-/// writer surfaces them for the whole request.
+/// The batching layer may coalesce several calls into one packet, so the calls
+/// header lists every `method:id` pair. It is written onto the last request
+/// because header aggregation across a packet is last-wins, so a single writer
+/// surfaces it for the whole request.
 fn annotate(req: &mut RequestPacket, request_id: Option<&str>) {
     let requests = req.requests_mut();
-    let methods = requests
-        .iter()
-        .map(SerializedRequest::method)
-        .collect::<Vec<_>>()
-        .join(",");
-    let ids = requests
-        .iter()
-        .map(|r| r.id().to_string())
-        .collect::<Vec<_>>()
-        .join(",");
+    // Build the `method:id` list in a single pass, writing directly into the
+    // buffer to avoid intermediate `Vec` and per-id `String` allocations.
+    let mut calls = String::new();
+    for (i, r) in requests.iter().enumerate() {
+        if i > 0 {
+            calls.push(',');
+        }
+        let _ = write!(calls, "{}:{}", r.method(), r.id());
+    }
     let Some(last) = requests.last_mut() else {
         return;
     };
     let headers = last.headers_mut();
-    if let Some(v) = header_value(&methods) {
-        headers.insert(HeaderName::from_static(METHOD), v);
-    }
-    if let Some(v) = header_value(&ids) {
-        headers.insert(HeaderName::from_static(REQUEST_ID), v);
+    if let Some(v) = header_value(&calls) {
+        headers.insert(HeaderName::from_static(CALLS), v);
     }
     if let Some(v) = request_id.and_then(header_value) {
         headers.insert(HeaderName::from_static(TRACING_REQUEST_ID), v);
@@ -95,7 +93,7 @@ fn header_value(s: &str) -> Option<HeaderValue> {
 mod tests {
     use {
         super::*,
-        alloy_json_rpc::{Id, Request},
+        alloy_json_rpc::{Id, Request, SerializedRequest},
     };
 
     fn request(method: &'static str, id: u64) -> SerializedRequest {
@@ -111,8 +109,7 @@ mod tests {
         annotate(&mut packet, None);
 
         let headers = packet.headers();
-        assert_eq!(headers[METHOD], "eth_sendRawTransaction");
-        assert_eq!(headers[REQUEST_ID], "7");
+        assert_eq!(headers[CALLS], "eth_sendRawTransaction:7");
         assert!(!headers.contains_key(TRACING_REQUEST_ID));
     }
 
@@ -138,8 +135,7 @@ mod tests {
         annotate(&mut packet, Some("auction-42"));
 
         let headers = packet.headers();
-        assert_eq!(headers[METHOD], "eth_call,eth_getBalance,eth_chainId");
-        assert_eq!(headers[REQUEST_ID], "1,2,3");
+        assert_eq!(headers[CALLS], "eth_call:1,eth_getBalance:2,eth_chainId:3");
         assert_eq!(headers[TRACING_REQUEST_ID], "auction-42");
     }
 
@@ -149,7 +145,6 @@ mod tests {
         annotate(&mut packet, None);
 
         let headers = packet.headers();
-        assert_eq!(headers[METHOD], "eth_chainId");
-        assert_eq!(headers[REQUEST_ID], "9");
+        assert_eq!(headers[CALLS], "eth_chainId:9");
     }
 }

--- a/crates/ethrpc/src/alloy/rpc_headers.rs
+++ b/crates/ethrpc/src/alloy/rpc_headers.rs
@@ -1,9 +1,16 @@
-//! Transport layer that annotates outgoing HTTP RPC requests with headers
+//! Transport layers that annotate outgoing HTTP RPC requests with headers
 //! describing the JSON-RPC call(s) they carry: the `method:id` pair(s) and the
 //! distributed-tracing request id.
 //!
-//! It MUST be installed as the innermost layer (closest to the HTTP transport)
-//! so that it observes the request packet exactly as it goes out on the wire.
+//! Two layers cooperate:
+//! - [`TracingRequestIdLayer`] runs *outside* the batching layer, while still
+//!   on the caller's task, and stamps the current span's distributed-tracing
+//!   request id onto the request. This is necessary because the batching layer
+//!   forwards requests from a background task that no longer sees that span.
+//! - [`RpcHeadersLayer`] MUST be installed as the innermost layer (closest to
+//!   the HTTP transport) so it observes the final (possibly batched) packet on
+//!   the wire; it writes the `method:id` list and aggregates the request ids
+//!   stamped above.
 use {
     alloy_json_rpc::RequestPacket,
     reqwest::header::{HeaderName, HeaderValue},
@@ -50,28 +57,103 @@ where
     }
 
     fn call(&mut self, mut req: RequestPacket) -> Self::Future {
-        let request_id = observe::tracing::distributed::request_id::from_current_span();
-        annotate(&mut req, request_id.as_deref());
+        annotate(&mut req);
+        self.inner.call(req)
+    }
+}
+
+/// Stamps the current span's distributed-tracing request id onto the request as
+/// a header.
+///
+/// This MUST run *outside* the batching layer. The batching layer forwards
+/// requests to the transport from a background task that no longer has the
+/// originating span in scope, so the id has to be captured here — while we are
+/// still on the caller's task — and carried on the request itself.
+pub(crate) struct TracingRequestIdLayer;
+
+impl<S> Layer<S> for TracingRequestIdLayer {
+    type Service = TracingRequestIdService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        TracingRequestIdService { inner }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct TracingRequestIdService<S> {
+    inner: S,
+}
+
+impl<S> Service<RequestPacket> for TracingRequestIdService<S>
+where
+    S: Service<RequestPacket> + Send + 'static,
+    S::Future: Send + 'static,
+{
+    type Error = S::Error;
+    type Future = S::Future;
+    type Response = S::Response;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: RequestPacket) -> Self::Future {
+        if let Some(request_id) = observe::tracing::distributed::request_id::from_current_span()
+            .as_deref()
+            .and_then(header_value)
+        {
+            for r in req.requests_mut() {
+                r.headers_mut().insert(
+                    HeaderName::from_static(TRACING_REQUEST_ID),
+                    request_id.clone(),
+                );
+            }
+        }
         self.inner.call(req)
     }
 }
 
 /// Attaches the RPC correlation headers to the packet.
 ///
-/// The batching layer may coalesce several calls into one packet, so the calls
-/// header lists every `method:id` pair. It is written onto the last request
-/// because header aggregation across a packet is last-wins, so a single writer
-/// surfaces it for the whole request.
-fn annotate(req: &mut RequestPacket, request_id: Option<&str>) {
+/// A batched packet coalesces several calls, so the calls header lists every
+/// `method:id` pair and the request-id header aggregates the distinct tracing
+/// ids that [`TracingRequestIdLayer`] stamped on the individual sub-requests.
+/// The packet's HTTP headers are the union of every sub-request's headers, so
+/// both are consolidated onto a single sub-request (the last) — writing them on
+/// more than one would send the header repeatedly.
+fn annotate(req: &mut RequestPacket) {
     let requests = req.requests_mut();
-    // Build the `method:id` list in a single pass, writing directly into the
-    // buffer to avoid intermediate `Vec` and per-id `String` allocations.
+    // Build the `method:id` list and aggregate the tracing request ids in a
+    // single pass, writing directly into the buffers to avoid intermediate
+    // `Vec` and per-item `String` allocations.
     let mut calls = String::new();
+    let mut request_ids = String::new();
     for (i, r) in requests.iter().enumerate() {
         if i > 0 {
             calls.push(',');
         }
         let _ = write!(calls, "{}:{}", r.method(), r.id());
+
+        if let Some(id) = r
+            .headers()
+            .and_then(|h| h.get(TRACING_REQUEST_ID))
+            .and_then(|v| v.to_str().ok())
+        {
+            // A batch can merge several calls sharing one id; keep them distinct.
+            if !request_ids.split(',').any(|seen| seen == id) {
+                if !request_ids.is_empty() {
+                    request_ids.push(',');
+                }
+                request_ids.push_str(id);
+            }
+        }
+    }
+    // The packet's HTTP headers are the union of every sub-request's headers, so
+    // a header present on multiple sub-requests would be sent repeatedly. Strip
+    // the per-sub-request tracing ids and re-emit the aggregate on the last
+    // request only.
+    for r in requests.iter_mut() {
+        r.headers_mut().remove(TRACING_REQUEST_ID);
     }
     let Some(last) = requests.last_mut() else {
         return;
@@ -80,7 +162,9 @@ fn annotate(req: &mut RequestPacket, request_id: Option<&str>) {
     if let Some(v) = header_value(&calls) {
         headers.insert(HeaderName::from_static(CALLS), v);
     }
-    if let Some(v) = request_id.and_then(header_value) {
+    if !request_ids.is_empty()
+        && let Some(v) = header_value(&request_ids)
+    {
         headers.insert(HeaderName::from_static(TRACING_REQUEST_ID), v);
     }
 }
@@ -102,27 +186,25 @@ mod tests {
             .expect("serialize request")
     }
 
+    /// Stamps the tracing request id header, mirroring what
+    /// [`TracingRequestIdService`] does before the batching layer.
+    fn with_request_id(mut req: SerializedRequest, id: &str) -> SerializedRequest {
+        req.headers_mut().insert(
+            HeaderName::from_static(TRACING_REQUEST_ID),
+            HeaderValue::from_str(id).unwrap(),
+        );
+        req
+    }
+
     #[test]
     fn single_call_lists_method_and_id() {
         let mut packet = RequestPacket::Single(request("eth_sendRawTransaction", 7));
-        // No tracing request id in scope, so `x-request-id` should be absent.
-        annotate(&mut packet, None);
+        // No tracing request id stamped, so `x-request-id` should be absent.
+        annotate(&mut packet);
 
         let headers = packet.headers();
         assert_eq!(headers[CALLS], "eth_sendRawTransaction:7");
         assert!(!headers.contains_key(TRACING_REQUEST_ID));
-    }
-
-    #[test]
-    fn always_forwards_tracing_request_id() {
-        let mut single = RequestPacket::Single(request("eth_call", 1));
-        annotate(&mut single, Some("auction-42"));
-        assert_eq!(single.headers()[TRACING_REQUEST_ID], "auction-42");
-
-        let mut batch =
-            RequestPacket::Batch(vec![request("eth_call", 1), request("eth_getBalance", 2)]);
-        annotate(&mut batch, Some("auction-42"));
-        assert_eq!(batch.headers()[TRACING_REQUEST_ID], "auction-42");
     }
 
     #[test]
@@ -132,19 +214,54 @@ mod tests {
             request("eth_getBalance", 2),
             request("eth_chainId", 3),
         ]);
-        annotate(&mut packet, Some("auction-42"));
+        annotate(&mut packet);
 
-        let headers = packet.headers();
-        assert_eq!(headers[CALLS], "eth_call:1,eth_getBalance:2,eth_chainId:3");
-        assert_eq!(headers[TRACING_REQUEST_ID], "auction-42");
+        assert_eq!(
+            packet.headers()[CALLS],
+            "eth_call:1,eth_getBalance:2,eth_chainId:3"
+        );
     }
 
     #[test]
     fn batch_of_one_lists_single_method() {
         let mut packet = RequestPacket::Batch(vec![request("eth_chainId", 9)]);
-        annotate(&mut packet, None);
+        annotate(&mut packet);
+
+        assert_eq!(packet.headers()[CALLS], "eth_chainId:9");
+    }
+
+    #[test]
+    fn forwards_single_request_id() {
+        let mut packet =
+            RequestPacket::Single(with_request_id(request("eth_call", 1), "auction-42"));
+        annotate(&mut packet);
 
         let headers = packet.headers();
-        assert_eq!(headers[CALLS], "eth_chainId:9");
+        assert_eq!(headers[CALLS], "eth_call:1");
+        assert_eq!(headers[TRACING_REQUEST_ID], "auction-42");
+    }
+
+    #[test]
+    fn aggregates_distinct_tracing_request_ids() {
+        // A batch merged across auctions carries several ids; they are all kept.
+        let mut packet = RequestPacket::Batch(vec![
+            with_request_id(request("eth_call", 1), "auction-1"),
+            with_request_id(request("eth_getBalance", 2), "auction-2"),
+        ]);
+        annotate(&mut packet);
+
+        assert_eq!(packet.headers()[TRACING_REQUEST_ID], "auction-1,auction-2");
+    }
+
+    #[test]
+    fn deduplicates_shared_tracing_request_id() {
+        // Sub-requests sharing one id collapse to a single value.
+        let mut packet = RequestPacket::Batch(vec![
+            with_request_id(request("eth_call", 1), "auction-42"),
+            with_request_id(request("eth_getBalance", 2), "auction-42"),
+        ]);
+        annotate(&mut packet);
+
+        assert_eq!(packet.headers()[TRACING_REQUEST_ID], "auction-42");
     }
 }


### PR DESCRIPTION
# Description
It looks like we dropped our rpc debug headers when moving from ethcontracts to alloy. This makes it harder to trace requests through our whole stack and understand for instance which node responded to a specific RPC request. This PR re-creates the annotation logic and adds `X-Rpc-Method` / `X-Rpc-Request-Id` / `X-Request-Id` request headers that our node proxies log.

e68c266c4b6ba7cb5ac29d23c722d50feb9dc834 (in particular crates/ethrpc/src/http.rs) contains the old logic.

Unlike the old logic, we now fold batch requests into comma separated lists (before we would have only very limited visibility). Given our current maximum batch size (30-40) I don't foresee the size increase to be an issue.

# Changes
* Create a new tower layer to annotate the requests
* Wires the layer into the current stack
* Unit tests for annotations logic

## How to test
Unit tests. Once merged, check on the node-proxy that the logs are populated correctly again.