### PR TITLE
Cap gas estimation at the configured per-tx gas limit

### DIFF
--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -231,12 +231,17 @@ impl Ethereum {
 
     /// Estimate gas used by a transaction.
     pub async fn estimate_gas(&self, tx: eth::Tx) -> Result<eth::Gas, Error> {
+        // Cap the search at the per-tx gas limit so a rogue solution can't force
+        // the node to binary-search up to the block gas limit while we re-check
+        // the settlement on every block during submission.
+        let gas_limit = u64::try_from(self.inner.tx_gas_limit.0).unwrap_or(u64::MAX);
         let tx = TransactionRequest::default()
             .from(tx.from)
             .to(tx.to)
             .value(tx.value.0)
             .input(tx.input.into())
-            .access_list(tx.access_list.into());
+            .access_list(tx.access_list.into())
+            .with_gas_limit(gas_limit);
 
         let tx = match self.simulation_gas_price().await {
             Some(gas_price) => tx.with_gas_price(gas_price),

--- a/crates/driver/src/infra/blockchain/mod.rs
+++ b/crates/driver/src/infra/blockchain/mod.rs
@@ -234,7 +234,11 @@ impl Ethereum {
         // Cap the search at the per-tx gas limit so a rogue solution can't force
         // the node to binary-search up to the block gas limit while we re-check
         // the settlement on every block during submission.
-        let gas_limit = u64::try_from(self.inner.tx_gas_limit.0).unwrap_or(u64::MAX);
+        let gas_limit = u64::try_from(self.inner.tx_gas_limit.0).map_err(|err| {
+            Error::GasPrice(anyhow::anyhow!(
+                "failed to convert gas_limit to u64: {err:?}"
+            ))
+        })?;
         let tx = TransactionRequest::default()
             .from(tx.from)
             .to(tx.to)

--- a/crates/simulator/src/ethereum/mod.rs
+++ b/crates/simulator/src/ethereum/mod.rs
@@ -114,7 +114,13 @@ impl Ethereum {
     where
         T: Into<TransactionRequest>,
     {
-        let tx = tx.into();
+        // Cap the search at the per-tx gas limit so a rogue solution can't force
+        // the node to binary-search up to the block gas limit. `Gas::new` rejects
+        // anything above this cap anyway, so no accepted solution is affected.
+        let gas_limit = self.inner.tx_gas_limit.try_into().map_err(|err| {
+            Error::GasPrice(anyhow!("failed to convert gas_limit to u64: {err:?}"))
+        })?;
+        let tx = tx.into().with_gas_limit(gas_limit);
         let tx = match self.simulation_gas_price().await {
             Some(gas_price) => tx.with_gas_price(gas_price),
             _ => tx,

--- a/crates/simulator/src/ethereum/mod.rs
+++ b/crates/simulator/src/ethereum/mod.rs
@@ -117,10 +117,13 @@ impl Ethereum {
         // Cap the search at the per-tx gas limit so a rogue solution can't force
         // the node to binary-search up to the block gas limit. `Gas::new` rejects
         // anything above this cap anyway, so no accepted solution is affected.
+        // A cap only lowers, so keep a tighter ceiling if the caller set one.
         let gas_limit = self.inner.tx_gas_limit.try_into().map_err(|err| {
             Error::GasPrice(anyhow!("failed to convert gas_limit to u64: {err:?}"))
         })?;
-        let tx = tx.into().with_gas_limit(gas_limit);
+        let tx = tx.into();
+        let gas_limit = tx.gas.map(|g| g.min(gas_limit)).unwrap_or(gas_limit);
+        let tx = tx.with_gas_limit(gas_limit);
         let tx = match self.simulation_gas_price().await {
             Some(gas_price) => tx.with_gas_price(gas_price),
             _ => tx,

--- a/crates/simulator/src/ethereum/mod.rs
+++ b/crates/simulator/src/ethereum/mod.rs
@@ -91,7 +91,10 @@ impl Ethereum {
         let gas_limit = self.inner.tx_gas_limit.try_into().map_err(|err| {
             Error::GasPrice(anyhow!("failed to convert gas_limit to u64: {err:?}"))
         })?;
-        let tx = tx.into().with_gas_limit(gas_limit);
+        // A cap only lowers, so keep a tighter ceiling if the caller set one.
+        let tx = tx.into();
+        let gas_limit = tx.gas.map(|g| g.min(gas_limit)).unwrap_or(gas_limit);
+        let tx = tx.with_gas_limit(gas_limit);
         let tx = match self.simulation_gas_price().await {
             Some(gas_price) => tx.with_gas_price(gas_price),
             _ => tx,

--- a/crates/simulator/src/ethereum/mod.rs
+++ b/crates/simulator/src/ethereum/mod.rs
@@ -84,17 +84,24 @@ impl Ethereum {
         }
     }
 
+    /// Cap the transaction's gas limit at the configured per-tx gas limit so a
+    /// rogue solution can't force the node to binary-search up to the block gas
+    /// limit. `Gas::new` rejects anything above this cap anyway, so no accepted
+    /// solution is affected. A cap only lowers, so a tighter ceiling set by the
+    /// caller is kept.
+    fn cap_gas_limit(&self, tx: TransactionRequest) -> Result<TransactionRequest, Error> {
+        let cap = self.inner.tx_gas_limit.try_into().map_err(|err| {
+            Error::GasPrice(anyhow!("failed to convert gas_limit to u64: {err:?}"))
+        })?;
+        let gas_limit = tx.gas.map(|g| g.min(cap)).unwrap_or(cap);
+        Ok(tx.with_gas_limit(gas_limit))
+    }
+
     pub async fn create_access_list<T>(&self, tx: T) -> Result<AccessList, Error>
     where
         T: Into<TransactionRequest>,
     {
-        let gas_limit = self.inner.tx_gas_limit.try_into().map_err(|err| {
-            Error::GasPrice(anyhow!("failed to convert gas_limit to u64: {err:?}"))
-        })?;
-        // A cap only lowers, so keep a tighter ceiling if the caller set one.
-        let tx = tx.into();
-        let gas_limit = tx.gas.map(|g| g.min(gas_limit)).unwrap_or(gas_limit);
-        let tx = tx.with_gas_limit(gas_limit);
+        let tx = self.cap_gas_limit(tx.into())?;
         let tx = match self.simulation_gas_price().await {
             Some(gas_price) => tx.with_gas_price(gas_price),
             _ => tx,
@@ -117,16 +124,7 @@ impl Ethereum {
     where
         T: Into<TransactionRequest>,
     {
-        // Cap the search at the per-tx gas limit so a rogue solution can't force
-        // the node to binary-search up to the block gas limit. `Gas::new` rejects
-        // anything above this cap anyway, so no accepted solution is affected.
-        // A cap only lowers, so keep a tighter ceiling if the caller set one.
-        let gas_limit = self.inner.tx_gas_limit.try_into().map_err(|err| {
-            Error::GasPrice(anyhow!("failed to convert gas_limit to u64: {err:?}"))
-        })?;
-        let tx = tx.into();
-        let gas_limit = tx.gas.map(|g| g.min(gas_limit)).unwrap_or(gas_limit);
-        let tx = tx.with_gas_limit(gas_limit);
+        let tx = self.cap_gas_limit(tx.into())?;
         let tx = match self.simulation_gas_price().await {
             Some(gas_price) => tx.with_gas_price(gas_price),
             _ => tx,


### PR DESCRIPTION
# Description
When the driver needs to know how much gas a settlement uses, it asks the node via `eth_estimateGas`. The node answers by running the transaction and binary-searching for the smallest gas that succeeds, and with no ceiling set it searches all the way up to the block gas limit. A solver can return a settlement that burns gas in a loop to make every step of that search maximally expensive. Solver responses are untrusted on the non-colocated path (KYC, no staked COW), so this is a real way to overload the node the driver depends on, and it is worse on high-gas-limit chains.

Two paths ran the estimation with no ceiling:
- the pre-competition solution simulation (`Simulator::gas`), run for every solution and re-run every block by `resimulate_until_revert`,
- the submission loop (`blockchain::Ethereum::estimate_gas`), run every block while the settlement sits in the mempool.

No new config is needed. Operators already set `tx_gas_limit`, and it was already applied in `create_access_list`, just not in either `estimate_gas`.

# Changes
- Cap the `eth_estimateGas` search at the configured `tx_gas_limit` on both the simulation and submission paths.
- Make the cap only ever lower a ceiling, never raise one the caller already set.
- Error out rather than run uncapped if `tx_gas_limit` does not fit a `u64`.

# How to test
Existing tests. On the competition path, `Gas::new` already rejects any solution estimated above `min(block_limit / 2, tx_gas_limit)`, so bounding the search by `tx_gas_limit` returns the same estimate for every accepted solution, and only solutions that would be rejected now fail at the RPC instead of the post-check. On the submission path the submitted tx's gas limit is already `<= tx_gas_limit`, so a settlement that needs more only shifts from a doomed on-chain revert to an earlier pre-submission abort.
