### PR TITLE
Bound RecentBlockCache by age

### DIFF
--- a/crates/driver/src/boundary/liquidity/mod.rs
+++ b/crates/driver/src/boundary/liquidity/mod.rs
@@ -33,7 +33,7 @@ pub mod zeroex;
 /// The default pool caching configuration to use.
 fn cache_config() -> CacheConfig {
     CacheConfig {
-        number_of_blocks_to_cache: NonZeroU64::new(10).unwrap(),
+        number_of_blocks_to_cache: NonZeroU64::new(2).unwrap(),
         number_of_entries_to_auto_update: NonZeroUsize::new(1000).unwrap(),
         auto_update_ttl: Duration::from_mins(5),
         maximum_recent_block_age: 4,

--- a/crates/driver/src/boundary/liquidity/mod.rs
+++ b/crates/driver/src/boundary/liquidity/mod.rs
@@ -35,6 +35,7 @@ fn cache_config() -> CacheConfig {
     CacheConfig {
         number_of_blocks_to_cache: NonZeroU64::new(10).unwrap(),
         number_of_entries_to_auto_update: NonZeroUsize::new(1000).unwrap(),
+        auto_update_ttl: Duration::from_mins(5),
         maximum_recent_block_age: 4,
         max_retries: 5,
         delay_between_retries: Duration::from_secs(1),

--- a/crates/e2e/src/setup/onchain_components/mod.rs
+++ b/crates/e2e/src/setup/onchain_components/mod.rs
@@ -16,7 +16,7 @@ use {
         GPv2AllowListAuthentication::GPv2AllowListAuthentication,
         test::CowProtocolToken,
     },
-    ethrpc::alloy::{CallBuilderExt, ProviderSignerExt},
+    ethrpc::alloy::{CallBuilderExt, EvmProviderExt, ProviderSignerExt},
     hex_literal::hex,
     model::{
         DomainSeparator,
@@ -491,6 +491,9 @@ impl OnchainComponents {
     ///
     /// This can be used to modify the pool reserves during a test.
     pub async fn mint_token_to_weth_uni_v2_pool(&self, token: &MintableToken, amount: U256) {
+        // disable auto-mine to ensure we update the pool within 1 block
+        self.web3().provider.evm_set_automine(false).await.unwrap();
+
         let pair = contracts::IUniswapLikePair::Instance::new(
             self.contracts
                 .uniswap_v2_factory
@@ -504,22 +507,32 @@ impl OnchainComponents {
 
         // Mint amount + 1 to the pool, and then swap out 1 of the minted token
         // in order to force it to update its K-value.
-        token.mint(*pair.address(), amount + U256::ONE).await;
+        let mint_tx = token
+            .contract
+            .mint(*pair.address(), amount + U256::ONE)
+            .from(token.minter)
+            .send()
+            .await
+            .unwrap();
+
         let (out0, out1) = if self.contracts.weth.address() < token.address() {
             (1, 0)
         } else {
             (0, 1)
         };
-        pair.swap(
-            U256::from(out0),
-            U256::from(out1),
-            token.minter,
-            Default::default(),
-        )
-        .from(token.minter)
-        .send_and_watch()
-        .await
-        .expect("Uniswap V2 pair couldn't mint");
+        let swap_tx = pair
+            .swap(
+                U256::from(out0),
+                U256::from(out1),
+                token.minter,
+                Default::default(),
+            )
+            .from(token.minter)
+            .send()
+            .await
+            .expect("Uniswap V2 pair couldn't mint");
+        self.web3().provider.evm_set_automine(true).await.unwrap();
+        tokio::try_join!(mint_tx.watch(), swap_tx.watch()).unwrap();
     }
 
     pub async fn deploy_cow_token(&self, supply: U256) -> CowToken {

--- a/crates/liquidity-sources/src/recent_block_cache.rs
+++ b/crates/liquidity-sources/src/recent_block_cache.rs
@@ -27,7 +27,7 @@
 use {
     alloy::eips::BlockId,
     anyhow::{Context, Result},
-    cached::{Cached, SizedCache},
+    cached::{Cached, TimedSizedCache},
     ethrpc::block_stream::CurrentBlockWatcher,
     futures::{FutureExt, StreamExt},
     itertools::Itertools,
@@ -116,6 +116,7 @@ where
 pub struct CacheConfig {
     pub number_of_blocks_to_cache: NonZeroU64,
     pub number_of_entries_to_auto_update: NonZeroUsize,
+    pub auto_update_ttl: Duration,
     pub maximum_recent_block_age: u64,
     pub max_retries: u32,
     pub delay_between_retries: Duration,
@@ -126,6 +127,7 @@ impl Default for CacheConfig {
         Self {
             number_of_blocks_to_cache: NonZeroU64::new(1).unwrap(),
             number_of_entries_to_auto_update: NonZeroUsize::new(1).unwrap(),
+            auto_update_ttl: Duration::from_secs(1),
             maximum_recent_block_age: Default::default(),
             max_retries: Default::default(),
             delay_between_retries: Default::default(),
@@ -170,6 +172,7 @@ where
         let inner = Arc::new(Inner {
             mutexed: Mutex::new(Mutexed::new(
                 config.number_of_entries_to_auto_update,
+                config.auto_update_ttl,
                 block,
                 config.maximum_recent_block_age,
             )),
@@ -356,7 +359,7 @@ struct Mutexed<K, V>
 where
     K: CacheKey<V>,
 {
-    recently_used: SizedCache<K, ()>,
+    recently_used: TimedSizedCache<K, ()>,
     // For quickly finding at which block an entry is cached.
     cached_most_recently_at_block: HashMap<K, u64>,
     // Tuple ordering allows us to efficiently construct range queries by block.
@@ -373,11 +376,15 @@ where
 {
     fn new(
         entries_lru_size: NonZeroUsize,
+        entries_ttl: Duration,
         current_block: u64,
         maximum_recent_block_age: u64,
     ) -> Self {
         Self {
-            recently_used: SizedCache::with_size(entries_lru_size.get()),
+            recently_used: TimedSizedCache::with_size_and_lifespan(
+                entries_lru_size.get(),
+                entries_ttl.as_secs(),
+            ),
             cached_most_recently_at_block: HashMap::new(),
             entries: BTreeMap::new(),
             last_update_block: current_block,


### PR DESCRIPTION
# Description
Especially on BNB we are using an insane amount of RPC calls for fetching uniswap v2 liquidity which already starts high after a restart and then grows over time until it flattens out.
<img width="1418" height="838" alt="Screenshot 2026-07-02 at 20 18 56" src="https://github.com/user-attachments/assets/6a4c1a33-474b-4744-82d8-6069d67cc102" />
As it turns out the graph flattens out when the `recently_used` set of the `RecentBlockCache` hits its size limit of 1000 - meaning at this point we try to keep 1000 uni v2 pools up-to-date via a background task. However, in a usual auction we actually only deliver ~500 uni v2 pools to the solvers for building their solutions. So effectively we are wasting half of those RPC requests keeping pools updated that can only be used during quoting.

The reason the cache starts huge and grows even bigger is that we have a lot of long standing limit order with many different tokens (initial size) and over time market orders increase the set of used tokens even further (growth) until we hit the limit.

# Changes
To keep all the relevant pools updated without suffering linear growth over time the `recently_used` set is now also bounded to 5 minutes. That way an order requiring new liquidity will have plenty of time to get settled and soon after the now irrelevant AMM stops getting updated.

Additionally I reduced the number of blocks a cache snapshot is kept alive to 2 (from 10). This should effectively reduce the cache size by 80%. This should also not cause any issues with liquidity that gets flushed out too soon.
This long lookback was primarily intended to have liquidity quickly available for quoting when the liquidity caches were fragmented across different orderbook instances but since they now live in the driver and the driver keeps a ton of highly relevant liquidity up-to-date for the auctions we'll still get a high cache hit rate with shorter lookback.

## How to test
test run in prod to verify constant RPC calls and reduced memory usage.

I also updated the quoting with stale liquidity e2e test since we now have to unbalance the pool with a single block to uphold the original assertion with a recent block cache depth of 2 blocks.