### PR TITLE
feat(solana-indexer) PR 6: decoder account-key resolution

### DIFF
--- a/crates/solana-indexer/src/indexer/decoder.rs
+++ b/crates/solana-indexer/src/indexer/decoder.rs
@@ -109,9 +109,10 @@ struct RawInstruction<'a> {
     /// Top-level instruction index. For a CPI, the top-level instruction it
     /// runs under.
     instruction_index: u32,
-    /// Position within the top-level instruction's inner list, or `None` for a
-    /// top-level instruction.
-    inner_index: Option<u32>,
+    /// Path within the top-level instruction's CPI tree (see
+    /// `ResolvedInstruction::inner_ix_path`). Empty for a top-level
+    /// instruction.
+    inner_ix_path: Vec<u8>,
     /// Index of the invoked program in the account list.
     program_id_index: u32,
     /// Account-list indices of the accounts the instruction touches.
@@ -127,7 +128,7 @@ impl RawInstruction<'_> {
     /// left to the decode step. Returns `None` if the program is untracked or
     /// its index is out of range.
     fn resolve_protocol_instruction(
-        &self,
+        self,
         account_keys: &[Pubkey],
         settlement_program: &Pubkey,
         solflow_program: &Pubkey,
@@ -141,10 +142,15 @@ impl RawInstruction<'_> {
             data: Bytes::copy_from_slice(self.data),
             accounts: self.account_indices.to_vec(),
             instruction_index: self.instruction_index,
-            inner_index: self.inner_index,
+            inner_ix_path: self.inner_ix_path,
         })
     }
 }
+
+/// Solana caps the instruction stack at height 5 (top-level = height 1), so a
+/// CPI path is at most 4 deep. Clamping to it guards against a corrupt
+/// `stack_height` forcing a huge allocation.
+const MAX_CPI_DEPTH: usize = 4;
 
 /// Resolve every instruction against `account_keys` and keep only those whose
 /// program is the settlement or SolFlow program, where settlement is often
@@ -171,35 +177,66 @@ fn relevant_instructions(
         .map(|meta| meta.inner_instructions.as_slice())
         .unwrap_or_default();
 
-    top_level
-        .iter()
-        .enumerate()
-        .flat_map(|(index, ix)| {
-            let index = index as u32;
-            let top = RawInstruction {
-                instruction_index: index,
-                inner_index: None,
-                program_id_index: ix.program_id_index,
-                account_indices: &ix.accounts,
-                data: &ix.data,
+    let mut resolved = Vec::new();
+    for (index, ix) in top_level.iter().enumerate() {
+        let instruction_index = index as u32;
+        let top = RawInstruction {
+            instruction_index,
+            inner_ix_path: Vec::new(),
+            program_id_index: ix.program_id_index,
+            account_indices: &ix.accounts,
+            data: &ix.data,
+        };
+        if let Some(resolved_ix) =
+            top.resolve_protocol_instruction(&account_keys, settlement_program, solflow_program)
+        {
+            resolved.push(resolved_ix);
+        }
+
+        let Some(group) = inner_groups
+            .iter()
+            .find(|group| group.index == instruction_index)
+        else {
+            continue;
+        };
+
+        // `group.instructions` is a depth-first, execution-ordered flat list of
+        // every CPI under this top-level instruction, across all nesting levels.
+        // `stack_height` is the only per-CPI depth signal (2 = a direct CPI, 3 =
+        // a CPI that one made, ...), so rebuild the sibling position at each
+        // level from it. A dropped (untracked) inner still advances the counter,
+        // so kept siblings keep their true position. A missing stack_height
+        // (pre-Solana-1.14.6 data) falls back to depth 1.
+        let mut path: Vec<u8> = Vec::new();
+        for inner in &group.instructions {
+            let depth = inner
+                .stack_height
+                .map(|height| height.saturating_sub(1) as usize)
+                .unwrap_or(1)
+                .clamp(1, MAX_CPI_DEPTH);
+            if depth > path.len() {
+                path.resize(depth, 0);
+            } else {
+                path.truncate(depth);
+                if let Some(last) = path.last_mut() {
+                    *last = last.saturating_add(1);
+                }
+            }
+            let raw = RawInstruction {
+                instruction_index,
+                inner_ix_path: path.clone(),
+                program_id_index: inner.program_id_index,
+                account_indices: &inner.accounts,
+                data: &inner.data,
             };
-            let inners = inner_groups
-                .iter()
-                .filter(move |group| group.index == index)
-                .flat_map(|group| group.instructions.iter().enumerate())
-                .map(move |(offset, ix)| RawInstruction {
-                    instruction_index: index,
-                    inner_index: Some(offset as u32),
-                    program_id_index: ix.program_id_index,
-                    account_indices: &ix.accounts,
-                    data: &ix.data,
-                });
-            std::iter::once(top).chain(inners)
-        })
-        .filter_map(|raw| {
-            raw.resolve_protocol_instruction(&account_keys, settlement_program, solflow_program)
-        })
-        .collect()
+            if let Some(resolved_ix) =
+                raw.resolve_protocol_instruction(&account_keys, settlement_program, solflow_program)
+            {
+                resolved.push(resolved_ix);
+            }
+        }
+    }
+    resolved
 }
 
 #[cfg(test)]

--- a/crates/solana-indexer/src/indexer/decoder.rs
+++ b/crates/solana-indexer/src/indexer/decoder.rs
@@ -125,7 +125,7 @@ impl RawInstruction<'_> {
     /// if that program is the settlement or SolFlow program. Account indices
     /// are carried through unresolved. Returns `None` if the program is
     /// untracked or its index is out of range.
-    fn resolve(
+    fn resolve_protocol_instruction(
         &self,
         account_keys: &[Pubkey],
         settlement_program: &Pubkey,
@@ -146,8 +146,10 @@ impl RawInstruction<'_> {
 }
 
 /// Resolve every instruction against `account_keys` and keep only those whose
-/// program is the settlement or SolFlow program. Walks top-level instructions
-/// then inner/CPI ones, where settlement is often reached only as a CPI.
+/// program is the settlement or SolFlow program, where settlement is often
+/// reached only as a CPI. Instructions are returned in on-chain execution
+/// order: each top-level instruction is followed by the inner (CPI)
+/// instructions it triggered.
 fn relevant_instructions(
     tx: &SubscribeUpdateTransactionInfo,
     settlement_program: &Pubkey,
@@ -159,40 +161,41 @@ fn relevant_instructions(
         .as_ref()
         .and_then(|transaction| transaction.message.as_ref())
         .map(|message| message.instructions.as_slice())
-        .unwrap_or_default()
-        .iter()
-        .enumerate()
-        .map(|(index, ix)| RawInstruction {
-            instruction_index: index as u32,
-            inner_index: None,
-            program_id_index: ix.program_id_index,
-            account_indices: &ix.accounts,
-            data: &ix.data,
-        });
-    let inner = tx
+        .unwrap_or_default();
+    let inner_groups = tx
         .meta
         .as_ref()
         .map(|meta| meta.inner_instructions.as_slice())
-        .unwrap_or_default()
+        .unwrap_or_default();
+
+    top_level
         .iter()
-        .flat_map(|group| {
-            group
-                .instructions
+        .enumerate()
+        .flat_map(|(index, ix)| {
+            let index = index as u32;
+            let top = RawInstruction {
+                instruction_index: index,
+                inner_index: None,
+                program_id_index: ix.program_id_index,
+                account_indices: &ix.accounts,
+                data: &ix.data,
+            };
+            let inners = inner_groups
                 .iter()
-                .enumerate()
+                .filter(move |group| group.index == index)
+                .flat_map(|group| group.instructions.iter().enumerate())
                 .map(move |(offset, ix)| RawInstruction {
-                    instruction_index: group.index,
+                    instruction_index: index,
                     inner_index: Some(offset as u32),
                     program_id_index: ix.program_id_index,
                     account_indices: &ix.accounts,
                     data: &ix.data,
-                })
-        });
-    // TODO: top-level instructions come before inner ones here, which is not the
-    // on-chain execution order. Revisit if ordering across the two matters.
-    top_level
-        .chain(inner)
-        .filter_map(|raw| raw.resolve(&account_keys, settlement_program, solflow_program))
+                });
+            std::iter::once(top).chain(inners)
+        })
+        .filter_map(|raw| {
+            raw.resolve_protocol_instruction(&account_keys, settlement_program, solflow_program)
+        })
         .collect()
 }
 

--- a/crates/solana-indexer/src/indexer/decoder.rs
+++ b/crates/solana-indexer/src/indexer/decoder.rs
@@ -15,6 +15,7 @@ use {
             channel::{PartialHalf, StreamUpdate},
             errors::PersistenceError,
             slot::Slot,
+            wire::SubscribeUpdateTransactionInfo,
         },
     },
     dashmap::DashMap,
@@ -71,3 +72,127 @@ impl Decoder {
         unimplemented!()
     }
 }
+
+/// A transaction instruction (top-level or inner/CPI) as it appears on the
+/// wire, before its `program_id_index` and account indices are resolved to
+/// pubkeys against the transaction's account list.
+struct RawInstruction<'a> {
+    /// Index into the account list identifying the program invoked.
+    program_id_index: u32,
+    /// Indices into the account list of the accounts the instruction touches.
+    account_indices: &'a [u8],
+    /// Raw instruction data (discriminator + payload).
+    data: &'a [u8],
+}
+
+/// An instruction that targets a program the decoder tracks, with its program
+/// and accounts resolved against the transaction's full account list. This is
+/// what the per-program dispatch consumes.
+pub(crate) struct RelevantInstruction {
+    /// Resolved program id: the settlement or SolFlow program.
+    pub program: Pubkey,
+    /// The instruction's accounts, resolved to pubkeys in order.
+    pub accounts: Vec<Pubkey>,
+    /// Raw instruction data, decoded by the per-program dispatch.
+    pub data: Vec<u8>,
+}
+
+/// §6.3.1.a: the transaction's full account list - `message.account_keys` then
+/// the ALT-loaded writable then readonly addresses, concatenated in that fixed
+/// order. Versioned transactions put ALT-loaded accounts in the latter two
+/// fields, so an instruction's `program_id_index` only resolves against the
+/// concatenation.
+///
+/// A wrong-length key becomes the zero pubkey to keep index alignment. It
+/// cannot match a tracked program, so any instruction naming it as its program
+/// is dropped by [`filter_relevant`].
+fn build_account_keys(tx: &SubscribeUpdateTransactionInfo) -> Vec<Pubkey> {
+    let static_keys = tx
+        .transaction
+        .as_ref()
+        .and_then(|transaction| transaction.message.as_ref())
+        .map(|message| message.account_keys.as_slice())
+        .unwrap_or_default();
+    let (writable, readonly) = tx
+        .meta
+        .as_ref()
+        .map(|meta| {
+            (
+                meta.loaded_writable_addresses.as_slice(),
+                meta.loaded_readonly_addresses.as_slice(),
+            )
+        })
+        .unwrap_or_default();
+    static_keys
+        .iter()
+        .chain(writable)
+        .chain(readonly)
+        .map(|key| Pubkey::try_from(key.as_slice()).unwrap_or_default())
+        .collect()
+}
+
+/// §6.3.1.b: every instruction in the transaction - top-level
+/// (`message.instructions`) followed by inner/CPI
+/// (`meta.inner_instructions[_].instructions`). CPIs into the settlement
+/// program appear only in the inner list.
+fn walk_instructions(tx: &SubscribeUpdateTransactionInfo) -> Vec<RawInstruction<'_>> {
+    let top_level = tx
+        .transaction
+        .as_ref()
+        .and_then(|transaction| transaction.message.as_ref())
+        .map(|message| message.instructions.as_slice())
+        .unwrap_or_default()
+        .iter()
+        .map(|ix| RawInstruction {
+            program_id_index: ix.program_id_index,
+            account_indices: &ix.accounts,
+            data: &ix.data,
+        });
+    let inner = tx
+        .meta
+        .as_ref()
+        .map(|meta| meta.inner_instructions.as_slice())
+        .unwrap_or_default()
+        .iter()
+        .flat_map(|group| group.instructions.iter())
+        .map(|ix| RawInstruction {
+            program_id_index: ix.program_id_index,
+            account_indices: &ix.accounts,
+            data: &ix.data,
+        });
+    top_level.chain(inner).collect()
+}
+
+/// §6.3.1.c: keep only the instructions whose `program_id_index` resolves,
+/// against `account_keys`, to the settlement or SolFlow program, with their
+/// program and accounts resolved to pubkeys. An instruction whose program or
+/// account indices fall outside the account list is malformed and dropped.
+fn filter_relevant(
+    account_keys: &[Pubkey],
+    instructions: &[RawInstruction],
+    settlement_program: &Pubkey,
+    solflow_program: &Pubkey,
+) -> Vec<RelevantInstruction> {
+    instructions
+        .iter()
+        .filter_map(|instruction| {
+            let program = *account_keys.get(instruction.program_id_index as usize)?;
+            if program != *settlement_program && program != *solflow_program {
+                return None;
+            }
+            let accounts = instruction
+                .account_indices
+                .iter()
+                .map(|&index| account_keys.get(index as usize).copied())
+                .collect::<Option<Vec<_>>>()?;
+            Some(RelevantInstruction {
+                program,
+                accounts,
+                data: instruction.data.to_vec(),
+            })
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/solana-indexer/src/indexer/decoder.rs
+++ b/crates/solana-indexer/src/indexer/decoder.rs
@@ -73,18 +73,6 @@ impl Decoder {
     }
 }
 
-/// A transaction instruction (top-level or inner/CPI) as it appears on the
-/// wire, before its `program_id_index` and account indices are resolved to
-/// pubkeys against the transaction's account list.
-struct RawInstruction<'a> {
-    /// Index into the account list identifying the program invoked.
-    program_id_index: u32,
-    /// Indices into the account list of the accounts the instruction touches.
-    account_indices: &'a [u8],
-    /// Raw instruction data (discriminator + payload).
-    data: &'a [u8],
-}
-
 /// An instruction that targets a program the decoder tracks, with its program
 /// and accounts resolved against the transaction's full account list. This is
 /// what the per-program dispatch consumes.
@@ -105,7 +93,7 @@ pub(crate) struct RelevantInstruction {
 ///
 /// A wrong-length key becomes the zero pubkey to keep index alignment. It
 /// cannot match a tracked program, so any instruction naming it as its program
-/// is dropped by [`filter_relevant`].
+/// is dropped by [`relevant_instructions`].
 fn build_account_keys(tx: &SubscribeUpdateTransactionInfo) -> Vec<Pubkey> {
     let static_keys = tx
         .transaction
@@ -131,11 +119,37 @@ fn build_account_keys(tx: &SubscribeUpdateTransactionInfo) -> Vec<Pubkey> {
         .collect()
 }
 
-/// §6.3.1.b: every instruction in the transaction - top-level
-/// (`message.instructions`) followed by inner/CPI
+/// §6.3.1.b/c: resolve every instruction in the transaction against
+/// `account_keys` and keep only those whose program is the settlement or
+/// SolFlow program. Walks top-level (`message.instructions`) then inner/CPI
 /// (`meta.inner_instructions[_].instructions`). CPIs into the settlement
-/// program appear only in the inner list.
-fn walk_instructions(tx: &SubscribeUpdateTransactionInfo) -> Vec<RawInstruction<'_>> {
+/// program appear only in the inner list. An instruction whose program or
+/// account indices fall outside the account list is malformed and dropped.
+fn relevant_instructions(
+    tx: &SubscribeUpdateTransactionInfo,
+    settlement_program: &Pubkey,
+    solflow_program: &Pubkey,
+) -> Vec<RelevantInstruction> {
+    let account_keys = build_account_keys(tx);
+    let resolve = |program_id_index: u32,
+                   account_indices: &[u8],
+                   data: &[u8]|
+     -> Option<RelevantInstruction> {
+        let program = *account_keys.get(program_id_index as usize)?;
+        if program != *settlement_program && program != *solflow_program {
+            return None;
+        }
+        let accounts = account_indices
+            .iter()
+            .map(|&index| account_keys.get(index as usize).copied())
+            .collect::<Option<Vec<_>>>()?;
+        Some(RelevantInstruction {
+            program,
+            accounts,
+            data: data.to_vec(),
+        })
+    };
+
     let top_level = tx
         .transaction
         .as_ref()
@@ -143,11 +157,7 @@ fn walk_instructions(tx: &SubscribeUpdateTransactionInfo) -> Vec<RawInstruction<
         .map(|message| message.instructions.as_slice())
         .unwrap_or_default()
         .iter()
-        .map(|ix| RawInstruction {
-            program_id_index: ix.program_id_index,
-            account_indices: &ix.accounts,
-            data: &ix.data,
-        });
+        .filter_map(|ix| resolve(ix.program_id_index, &ix.accounts, &ix.data));
     let inner = tx
         .meta
         .as_ref()
@@ -155,43 +165,8 @@ fn walk_instructions(tx: &SubscribeUpdateTransactionInfo) -> Vec<RawInstruction<
         .unwrap_or_default()
         .iter()
         .flat_map(|group| group.instructions.iter())
-        .map(|ix| RawInstruction {
-            program_id_index: ix.program_id_index,
-            account_indices: &ix.accounts,
-            data: &ix.data,
-        });
+        .filter_map(|ix| resolve(ix.program_id_index, &ix.accounts, &ix.data));
     top_level.chain(inner).collect()
-}
-
-/// §6.3.1.c: keep only the instructions whose `program_id_index` resolves,
-/// against `account_keys`, to the settlement or SolFlow program, with their
-/// program and accounts resolved to pubkeys. An instruction whose program or
-/// account indices fall outside the account list is malformed and dropped.
-fn filter_relevant(
-    account_keys: &[Pubkey],
-    instructions: &[RawInstruction],
-    settlement_program: &Pubkey,
-    solflow_program: &Pubkey,
-) -> Vec<RelevantInstruction> {
-    instructions
-        .iter()
-        .filter_map(|instruction| {
-            let program = *account_keys.get(instruction.program_id_index as usize)?;
-            if program != *settlement_program && program != *solflow_program {
-                return None;
-            }
-            let accounts = instruction
-                .account_indices
-                .iter()
-                .map(|&index| account_keys.get(index as usize).copied())
-                .collect::<Option<Vec<_>>>()?;
-            Some(RelevantInstruction {
-                program,
-                accounts,
-                data: instruction.data.to_vec(),
-            })
-        })
-        .collect()
 }
 
 #[cfg(test)]

--- a/crates/solana-indexer/src/indexer/decoder.rs
+++ b/crates/solana-indexer/src/indexer/decoder.rs
@@ -74,9 +74,16 @@ impl Decoder {
 }
 
 /// An instruction that targets a program the decoder tracks, with its program
-/// and accounts resolved against the transaction's full account list. This is
-/// what the per-program dispatch consumes.
+/// and accounts resolved against the transaction's full account list, and its
+/// position in the transaction. This is what the per-program dispatch consumes.
 pub(crate) struct RelevantInstruction {
+    /// Top-level instruction index. For a CPI, the index of the top-level
+    /// instruction it runs under. PR7 maps `(instruction_index, inner_index)`
+    /// to the `solana.trades` `(instruction_index, inner_ix_path)` key.
+    pub instruction_index: u32,
+    /// Position within the top-level instruction's inner list, or `None` for a
+    /// top-level instruction.
+    pub inner_index: Option<u32>,
     /// Resolved program id: the settlement or SolFlow program.
     pub program: Pubkey,
     /// The instruction's accounts, resolved to pubkeys in order.
@@ -119,37 +126,68 @@ fn build_account_keys(tx: &SubscribeUpdateTransactionInfo) -> Vec<Pubkey> {
         .collect()
 }
 
+/// A transaction instruction (top-level or inner/CPI) paired with its position
+/// in the transaction, before its program and account indices are resolved to
+/// pubkeys.
+struct RawInstruction<'a> {
+    /// Top-level instruction index. For a CPI, the index of the top-level
+    /// instruction it runs under (`InnerInstructions.index`).
+    instruction_index: u32,
+    /// Position within that top-level instruction's inner list, or `None` for a
+    /// top-level instruction.
+    inner_index: Option<u32>,
+    /// Index into the account list identifying the program invoked.
+    program_id_index: u32,
+    /// Indices into the account list of the accounts the instruction touches.
+    account_indices: &'a [u8],
+    /// Raw instruction data (discriminator + payload).
+    data: &'a [u8],
+}
+
+impl RawInstruction<'_> {
+    /// Resolve against `account_keys`, keeping the instruction only if its
+    /// program is the settlement or SolFlow program. Returns `None` when the
+    /// program is untracked, or when the program or an account index falls
+    /// outside the account list.
+    fn resolve(
+        &self,
+        account_keys: &[Pubkey],
+        settlement_program: &Pubkey,
+        solflow_program: &Pubkey,
+    ) -> Option<RelevantInstruction> {
+        let program = *account_keys.get(self.program_id_index as usize)?;
+        if program != *settlement_program && program != *solflow_program {
+            return None;
+        }
+        // TODO(PR7): here the program matched a tracked program but an account
+        // index is out of range - a malformed settlement we identified and then
+        // drop with no trace. Decide whether to dead-letter or log instead.
+        let accounts = self
+            .account_indices
+            .iter()
+            .map(|&index| account_keys.get(index as usize).copied())
+            .collect::<Option<Vec<_>>>()?;
+        Some(RelevantInstruction {
+            instruction_index: self.instruction_index,
+            inner_index: self.inner_index,
+            program,
+            accounts,
+            data: self.data.to_vec(),
+        })
+    }
+}
+
 /// §6.3.1.b/c: resolve every instruction in the transaction against
 /// `account_keys` and keep only those whose program is the settlement or
 /// SolFlow program. Walks top-level (`message.instructions`) then inner/CPI
 /// (`meta.inner_instructions[_].instructions`). CPIs into the settlement
-/// program appear only in the inner list. An instruction whose program or
-/// account indices fall outside the account list is malformed and dropped.
+/// program appear only in the inner list.
 fn relevant_instructions(
     tx: &SubscribeUpdateTransactionInfo,
     settlement_program: &Pubkey,
     solflow_program: &Pubkey,
 ) -> Vec<RelevantInstruction> {
     let account_keys = build_account_keys(tx);
-    let resolve = |program_id_index: u32,
-                   account_indices: &[u8],
-                   data: &[u8]|
-     -> Option<RelevantInstruction> {
-        let program = *account_keys.get(program_id_index as usize)?;
-        if program != *settlement_program && program != *solflow_program {
-            return None;
-        }
-        let accounts = account_indices
-            .iter()
-            .map(|&index| account_keys.get(index as usize).copied())
-            .collect::<Option<Vec<_>>>()?;
-        Some(RelevantInstruction {
-            program,
-            accounts,
-            data: data.to_vec(),
-        })
-    };
-
     let top_level = tx
         .transaction
         .as_ref()
@@ -157,16 +195,41 @@ fn relevant_instructions(
         .map(|message| message.instructions.as_slice())
         .unwrap_or_default()
         .iter()
-        .filter_map(|ix| resolve(ix.program_id_index, &ix.accounts, &ix.data));
+        .enumerate()
+        .map(|(index, ix)| RawInstruction {
+            instruction_index: index as u32,
+            inner_index: None,
+            program_id_index: ix.program_id_index,
+            account_indices: &ix.accounts,
+            data: &ix.data,
+        });
     let inner = tx
         .meta
         .as_ref()
         .map(|meta| meta.inner_instructions.as_slice())
         .unwrap_or_default()
         .iter()
-        .flat_map(|group| group.instructions.iter())
-        .filter_map(|ix| resolve(ix.program_id_index, &ix.accounts, &ix.data));
-    top_level.chain(inner).collect()
+        .flat_map(|group| {
+            group
+                .instructions
+                .iter()
+                .enumerate()
+                .map(move |(offset, ix)| RawInstruction {
+                    instruction_index: group.index,
+                    inner_index: Some(offset as u32),
+                    program_id_index: ix.program_id_index,
+                    account_indices: &ix.accounts,
+                    data: &ix.data,
+                })
+        });
+    // TODO(PR7): top-level instructions are emitted before inner/CPI ones, not
+    // in on-chain execution order (CPIs run interleaved with their parent).
+    // Confirm PR7 keys off (instruction_index, inner_index) rather than list
+    // order, or interleave here if it needs execution order.
+    top_level
+        .chain(inner)
+        .filter_map(|raw| raw.resolve(&account_keys, settlement_program, solflow_program))
+        .collect()
 }
 
 #[cfg(test)]

--- a/crates/solana-indexer/src/indexer/decoder.rs
+++ b/crates/solana-indexer/src/indexer/decoder.rs
@@ -77,7 +77,7 @@ impl Decoder {
 /// The transaction's full account list that instruction indices resolve
 /// against: static keys, then ALT-loaded writable addresses, then readonly, in
 /// that order. A wrong-length key becomes the zero pubkey to keep the indices
-/// aligned, so it matches no tracked program.
+/// aligned, so it does not match a tracked program.
 fn build_account_keys(tx: &SubscribeUpdateTransactionInfo) -> Vec<Pubkey> {
     let static_keys = tx
         .transaction
@@ -122,9 +122,10 @@ struct RawInstruction<'a> {
 
 impl RawInstruction<'_> {
     /// Resolve the program against `account_keys`, keeping the instruction only
-    /// if that program is the settlement or SolFlow program. Account indices
-    /// are carried through unresolved. Returns `None` if the program is
-    /// untracked or its index is out of range.
+    /// if that program is the settlement or SolFlow program. The `accounts`
+    /// field keeps the raw account-list indices, resolving them to pubkeys is
+    /// left to the decode step. Returns `None` if the program is untracked or
+    /// its index is out of range.
     fn resolve_protocol_instruction(
         &self,
         account_keys: &[Pubkey],
@@ -147,9 +148,11 @@ impl RawInstruction<'_> {
 
 /// Resolve every instruction against `account_keys` and keep only those whose
 /// program is the settlement or SolFlow program, where settlement is often
-/// reached only as a CPI. Instructions are returned in on-chain execution
-/// order: each top-level instruction is followed by the inner (CPI)
-/// instructions it triggered.
+/// reached only as a CPI. A top-level instruction and its inner instructions
+/// are filtered independently, so a top-level call to an untracked program is
+/// dropped while a settlement CPI nested under it is still kept. Instructions
+/// are returned in on-chain execution order: each top-level instruction is
+/// followed by the inner (CPI) instructions it triggered.
 fn relevant_instructions(
     tx: &SubscribeUpdateTransactionInfo,
     settlement_program: &Pubkey,

--- a/crates/solana-indexer/src/indexer/decoder.rs
+++ b/crates/solana-indexer/src/indexer/decoder.rs
@@ -3,9 +3,8 @@
 //! settlement-program and SolFlow transactions, joins account-update snapshots,
 //! and persists typed events.
 
-// TODO: This file only declares the component skeleton. The `run` body is
-// `unimplemented!`; the dispatch logic and persist path arrive in a later
-// change.
+// TODO: `run` is unimplemented. The dispatch and persist steps that consume the
+// resolved instructions below are not wired up yet.
 
 use {
     crate::{
@@ -73,13 +72,12 @@ impl Decoder {
     }
 }
 
-/// An instruction that targets a program the decoder tracks, with its program
-/// and accounts resolved against the transaction's full account list, and its
-/// position in the transaction. This is what the per-program dispatch consumes.
+/// An instruction targeting a tracked program (settlement or SolFlow), with its
+/// program and accounts resolved to pubkeys and its position in the
+/// transaction.
 pub(crate) struct RelevantInstruction {
-    /// Top-level instruction index. For a CPI, the index of the top-level
-    /// instruction it runs under. PR7 maps `(instruction_index, inner_index)`
-    /// to the `solana.trades` `(instruction_index, inner_ix_path)` key.
+    /// Top-level instruction index. For a CPI, the top-level instruction it
+    /// runs under.
     pub instruction_index: u32,
     /// Position within the top-level instruction's inner list, or `None` for a
     /// top-level instruction.
@@ -88,19 +86,14 @@ pub(crate) struct RelevantInstruction {
     pub program: Pubkey,
     /// The instruction's accounts, resolved to pubkeys in order.
     pub accounts: Vec<Pubkey>,
-    /// Raw instruction data, decoded by the per-program dispatch.
+    /// Raw instruction data.
     pub data: Vec<u8>,
 }
 
-/// §6.3.1.a: the transaction's full account list - `message.account_keys` then
-/// the ALT-loaded writable then readonly addresses, concatenated in that fixed
-/// order. Versioned transactions put ALT-loaded accounts in the latter two
-/// fields, so an instruction's `program_id_index` only resolves against the
-/// concatenation.
-///
-/// A wrong-length key becomes the zero pubkey to keep index alignment. It
-/// cannot match a tracked program, so any instruction naming it as its program
-/// is dropped by [`relevant_instructions`].
+/// The transaction's full account list that instruction indices resolve
+/// against: static keys, then ALT-loaded writable addresses, then readonly, in
+/// that order. A wrong-length key becomes the zero pubkey to keep the indices
+/// aligned, so it matches no tracked program.
 fn build_account_keys(tx: &SubscribeUpdateTransactionInfo) -> Vec<Pubkey> {
     let static_keys = tx
         .transaction
@@ -126,29 +119,27 @@ fn build_account_keys(tx: &SubscribeUpdateTransactionInfo) -> Vec<Pubkey> {
         .collect()
 }
 
-/// A transaction instruction (top-level or inner/CPI) paired with its position
-/// in the transaction, before its program and account indices are resolved to
-/// pubkeys.
+/// A top-level or inner (CPI) instruction with its position, before its program
+/// and account indices are resolved to pubkeys.
 struct RawInstruction<'a> {
-    /// Top-level instruction index. For a CPI, the index of the top-level
-    /// instruction it runs under (`InnerInstructions.index`).
+    /// Top-level instruction index. For a CPI, the top-level instruction it
+    /// runs under.
     instruction_index: u32,
-    /// Position within that top-level instruction's inner list, or `None` for a
+    /// Position within the top-level instruction's inner list, or `None` for a
     /// top-level instruction.
     inner_index: Option<u32>,
-    /// Index into the account list identifying the program invoked.
+    /// Index of the invoked program in the account list.
     program_id_index: u32,
-    /// Indices into the account list of the accounts the instruction touches.
+    /// Account-list indices of the accounts the instruction touches.
     account_indices: &'a [u8],
-    /// Raw instruction data (discriminator + payload).
+    /// Raw instruction data.
     data: &'a [u8],
 }
 
 impl RawInstruction<'_> {
     /// Resolve against `account_keys`, keeping the instruction only if its
-    /// program is the settlement or SolFlow program. Returns `None` when the
-    /// program is untracked, or when the program or an account index falls
-    /// outside the account list.
+    /// program is the settlement or SolFlow program. Returns `None` if the
+    /// program is untracked or any index is out of range.
     fn resolve(
         &self,
         account_keys: &[Pubkey],
@@ -159,9 +150,8 @@ impl RawInstruction<'_> {
         if program != *settlement_program && program != *solflow_program {
             return None;
         }
-        // TODO(PR7): here the program matched a tracked program but an account
-        // index is out of range - a malformed settlement we identified and then
-        // drop with no trace. Decide whether to dead-letter or log instead.
+        // TODO: a tracked program with an out-of-range account index is dropped
+        // silently here. Consider surfacing it instead.
         let accounts = self
             .account_indices
             .iter()
@@ -177,11 +167,9 @@ impl RawInstruction<'_> {
     }
 }
 
-/// §6.3.1.b/c: resolve every instruction in the transaction against
-/// `account_keys` and keep only those whose program is the settlement or
-/// SolFlow program. Walks top-level (`message.instructions`) then inner/CPI
-/// (`meta.inner_instructions[_].instructions`). CPIs into the settlement
-/// program appear only in the inner list.
+/// Resolve every instruction against `account_keys` and keep only those whose
+/// program is the settlement or SolFlow program. Walks top-level instructions
+/// then inner/CPI ones, where settlement is often reached only as a CPI.
 fn relevant_instructions(
     tx: &SubscribeUpdateTransactionInfo,
     settlement_program: &Pubkey,
@@ -222,10 +210,8 @@ fn relevant_instructions(
                     data: &ix.data,
                 })
         });
-    // TODO(PR7): top-level instructions are emitted before inner/CPI ones, not
-    // in on-chain execution order (CPIs run interleaved with their parent).
-    // Confirm PR7 keys off (instruction_index, inner_index) rather than list
-    // order, or interleave here if it needs execution order.
+    // TODO: top-level instructions come before inner ones here, which is not the
+    // on-chain execution order. Revisit if ordering across the two matters.
     top_level
         .chain(inner)
         .filter_map(|raw| raw.resolve(&account_keys, settlement_program, solflow_program))

--- a/crates/solana-indexer/src/indexer/decoder.rs
+++ b/crates/solana-indexer/src/indexer/decoder.rs
@@ -14,9 +14,11 @@ use {
             channel::{PartialHalf, StreamUpdate},
             errors::PersistenceError,
             slot::Slot,
+            tx::ResolvedInstruction,
             wire::SubscribeUpdateTransactionInfo,
         },
     },
+    bytes::Bytes,
     dashmap::DashMap,
     solana_sdk::pubkey::Pubkey,
     std::sync::Arc,
@@ -72,24 +74,6 @@ impl Decoder {
     }
 }
 
-/// An instruction targeting a tracked program (settlement or SolFlow), with its
-/// program and accounts resolved to pubkeys and its position in the
-/// transaction.
-pub(crate) struct RelevantInstruction {
-    /// Top-level instruction index. For a CPI, the top-level instruction it
-    /// runs under.
-    pub instruction_index: u32,
-    /// Position within the top-level instruction's inner list, or `None` for a
-    /// top-level instruction.
-    pub inner_index: Option<u32>,
-    /// Resolved program id: the settlement or SolFlow program.
-    pub program: Pubkey,
-    /// The instruction's accounts, resolved to pubkeys in order.
-    pub accounts: Vec<Pubkey>,
-    /// Raw instruction data.
-    pub data: Vec<u8>,
-}
-
 /// The transaction's full account list that instruction indices resolve
 /// against: static keys, then ALT-loaded writable addresses, then readonly, in
 /// that order. A wrong-length key becomes the zero pubkey to keep the indices
@@ -137,32 +121,26 @@ struct RawInstruction<'a> {
 }
 
 impl RawInstruction<'_> {
-    /// Resolve against `account_keys`, keeping the instruction only if its
-    /// program is the settlement or SolFlow program. Returns `None` if the
-    /// program is untracked or any index is out of range.
+    /// Resolve the program against `account_keys`, keeping the instruction only
+    /// if that program is the settlement or SolFlow program. Account indices
+    /// are carried through unresolved. Returns `None` if the program is
+    /// untracked or its index is out of range.
     fn resolve(
         &self,
         account_keys: &[Pubkey],
         settlement_program: &Pubkey,
         solflow_program: &Pubkey,
-    ) -> Option<RelevantInstruction> {
-        let program = *account_keys.get(self.program_id_index as usize)?;
-        if program != *settlement_program && program != *solflow_program {
+    ) -> Option<ResolvedInstruction> {
+        let program_id = *account_keys.get(self.program_id_index as usize)?;
+        if program_id != *settlement_program && program_id != *solflow_program {
             return None;
         }
-        // TODO: a tracked program with an out-of-range account index is dropped
-        // silently here. Consider surfacing it instead.
-        let accounts = self
-            .account_indices
-            .iter()
-            .map(|&index| account_keys.get(index as usize).copied())
-            .collect::<Option<Vec<_>>>()?;
-        Some(RelevantInstruction {
+        Some(ResolvedInstruction {
+            program_id,
+            data: Bytes::copy_from_slice(self.data),
+            accounts: self.account_indices.to_vec(),
             instruction_index: self.instruction_index,
             inner_index: self.inner_index,
-            program,
-            accounts,
-            data: self.data.to_vec(),
         })
     }
 }
@@ -174,7 +152,7 @@ fn relevant_instructions(
     tx: &SubscribeUpdateTransactionInfo,
     settlement_program: &Pubkey,
     solflow_program: &Pubkey,
-) -> Vec<RelevantInstruction> {
+) -> Vec<ResolvedInstruction> {
     let account_keys = build_account_keys(tx);
     let top_level = tx
         .transaction

--- a/crates/solana-indexer/src/indexer/decoder/tests.rs
+++ b/crates/solana-indexer/src/indexer/decoder/tests.rs
@@ -1,0 +1,147 @@
+use {
+    super::{RelevantInstruction, build_account_keys, filter_relevant, walk_instructions},
+    crate::types::wire::{
+        CompiledInstruction,
+        InnerInstruction,
+        InnerInstructions,
+        Message,
+        SubscribeUpdateTransactionInfo,
+        Transaction,
+        TransactionStatusMeta,
+    },
+    solana_sdk::pubkey::Pubkey,
+};
+
+fn pubkey(n: u8) -> Pubkey {
+    Pubkey::new_from_array([n; 32])
+}
+
+fn key_bytes(key: Pubkey) -> Vec<u8> {
+    key.to_bytes().to_vec()
+}
+
+fn compiled(program_id_index: u32, accounts: Vec<u8>, data: Vec<u8>) -> CompiledInstruction {
+    CompiledInstruction {
+        program_id_index,
+        accounts,
+        data,
+    }
+}
+
+fn inner(program_id_index: u32, accounts: Vec<u8>, data: Vec<u8>) -> InnerInstruction {
+    InnerInstruction {
+        program_id_index,
+        accounts,
+        data,
+        stack_height: None,
+    }
+}
+
+/// Build a transaction-update fixture from resolved pubkeys: the static account
+/// keys, the ALT-loaded writable and readonly addresses, the top-level
+/// instructions, and the inner-instruction groups.
+fn tx_info(
+    account_keys: Vec<Pubkey>,
+    loaded_writable: Vec<Pubkey>,
+    loaded_readonly: Vec<Pubkey>,
+    instructions: Vec<CompiledInstruction>,
+    inner_instructions: Vec<InnerInstructions>,
+) -> SubscribeUpdateTransactionInfo {
+    SubscribeUpdateTransactionInfo {
+        transaction: Some(Transaction {
+            message: Some(Message {
+                account_keys: account_keys.into_iter().map(key_bytes).collect(),
+                instructions,
+                ..Default::default()
+            }),
+            ..Default::default()
+        }),
+        meta: Some(TransactionStatusMeta {
+            inner_instructions,
+            loaded_writable_addresses: loaded_writable.into_iter().map(key_bytes).collect(),
+            loaded_readonly_addresses: loaded_readonly.into_iter().map(key_bytes).collect(),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
+fn relevant_instructions(
+    tx: &SubscribeUpdateTransactionInfo,
+    settlement: &Pubkey,
+    solflow: &Pubkey,
+) -> Vec<RelevantInstruction> {
+    let account_keys = build_account_keys(tx);
+    let instructions = walk_instructions(tx);
+    filter_relevant(&account_keys, &instructions, settlement, solflow)
+}
+
+#[test]
+fn top_level_settlement_instruction_is_kept() {
+    let (settlement, solflow) = (pubkey(1), pubkey(2));
+    let (acct_a, acct_b) = (pubkey(3), pubkey(4));
+    // account list: [settlement(0), acct_a(1), acct_b(2)]
+    let tx = tx_info(
+        vec![settlement, acct_a, acct_b],
+        vec![],
+        vec![],
+        vec![compiled(0, vec![1, 2], vec![9, 9, 9])],
+        vec![],
+    );
+
+    let relevant = relevant_instructions(&tx, &settlement, &solflow);
+
+    assert_eq!(relevant.len(), 1);
+    assert_eq!(relevant[0].program, settlement);
+    assert_eq!(relevant[0].accounts, vec![acct_a, acct_b]);
+    assert_eq!(relevant[0].data, vec![9, 9, 9]);
+}
+
+#[test]
+fn settlement_cpi_in_inner_instructions_is_kept() {
+    let (settlement, solflow) = (pubkey(1), pubkey(2));
+    let (other_program, acct) = (pubkey(5), pubkey(3));
+    // account list: [other_program(0), settlement(1), acct(2)]. The settlement
+    // call is a CPI, so it only appears in the inner instructions.
+    let tx = tx_info(
+        vec![other_program, settlement, acct],
+        vec![],
+        vec![],
+        vec![compiled(0, vec![], vec![0])],
+        vec![InnerInstructions {
+            index: 0,
+            instructions: vec![inner(1, vec![2], vec![7])],
+        }],
+    );
+
+    let relevant = relevant_instructions(&tx, &settlement, &solflow);
+
+    assert_eq!(relevant.len(), 1);
+    assert_eq!(relevant[0].program, settlement);
+    assert_eq!(relevant[0].accounts, vec![acct]);
+    assert_eq!(relevant[0].data, vec![7]);
+}
+
+#[test]
+fn alt_loaded_program_is_resolved() {
+    let (settlement, solflow) = (pubkey(1), pubkey(2));
+    let (acct, readonly) = (pubkey(3), pubkey(6));
+    // static [acct], ALT writable [settlement], ALT readonly [readonly], so the
+    // full list is [acct(0), settlement(1), readonly(2)] and program_id_index 1
+    // resolves into the ALT-loaded region.
+    let tx = tx_info(
+        vec![acct],
+        vec![settlement],
+        vec![readonly],
+        vec![compiled(1, vec![0], vec![5])],
+        vec![],
+    );
+
+    assert_eq!(build_account_keys(&tx), vec![acct, settlement, readonly]);
+
+    let relevant = relevant_instructions(&tx, &settlement, &solflow);
+
+    assert_eq!(relevant.len(), 1);
+    assert_eq!(relevant[0].program, settlement);
+    assert_eq!(relevant[0].accounts, vec![acct]);
+}

--- a/crates/solana-indexer/src/indexer/decoder/tests.rs
+++ b/crates/solana-indexer/src/indexer/decoder/tests.rs
@@ -1,5 +1,5 @@
 use {
-    super::{RelevantInstruction, build_account_keys, filter_relevant, walk_instructions},
+    super::{build_account_keys, relevant_instructions},
     crate::types::wire::{
         CompiledInstruction,
         InnerInstruction,
@@ -64,16 +64,6 @@ fn tx_info(
         }),
         ..Default::default()
     }
-}
-
-fn relevant_instructions(
-    tx: &SubscribeUpdateTransactionInfo,
-    settlement: &Pubkey,
-    solflow: &Pubkey,
-) -> Vec<RelevantInstruction> {
-    let account_keys = build_account_keys(tx);
-    let instructions = walk_instructions(tx);
-    filter_relevant(&account_keys, &instructions, settlement, solflow)
 }
 
 #[test]

--- a/crates/solana-indexer/src/indexer/decoder/tests.rs
+++ b/crates/solana-indexer/src/indexer/decoder/tests.rs
@@ -66,151 +66,71 @@ fn tx_info(
     }
 }
 
+/// One realistic transaction that exercises the four things that can actually
+/// break: the account list is `static ++ ALT-writable ++ ALT-readonly` (so the
+/// ALT indices only resolve if the regions are concatenated in that order),
+/// settlement is reachable only as a CPI (so inner instructions must be
+/// walked), an untracked program is present (so the filter must drop it), and
+/// each kept instruction records its position.
 #[test]
-fn top_level_settlement_instruction_is_kept() {
-    let (settlement, solflow) = (pubkey(1), pubkey(2));
+fn resolves_settlement_and_solflow_across_top_level_and_cpi() {
+    let (settlement, solflow, router) = (pubkey(1), pubkey(2), pubkey(9));
     let (acct_a, acct_b) = (pubkey(3), pubkey(4));
-    // account list: [settlement(0), acct_a(1), acct_b(2)]
+    // Full list: [router(0), acct_a(1)] ++ [settlement(2)] ++ [solflow(3),
+    // acct_b(4)]
     let tx = tx_info(
-        vec![settlement, acct_a, acct_b],
-        vec![],
-        vec![],
-        vec![compiled(0, vec![1, 2], vec![9, 9, 9])],
-        vec![],
-    );
-
-    let relevant = relevant_instructions(&tx, &settlement, &solflow);
-
-    assert_eq!(relevant.len(), 1);
-    assert_eq!(relevant[0].program, settlement);
-    assert_eq!(relevant[0].instruction_index, 0);
-    assert_eq!(relevant[0].inner_index, None);
-    assert_eq!(relevant[0].accounts, vec![acct_a, acct_b]);
-    assert_eq!(relevant[0].data, vec![9, 9, 9]);
-}
-
-#[test]
-fn settlement_cpi_in_inner_instructions_is_kept() {
-    let (settlement, solflow) = (pubkey(1), pubkey(2));
-    let (other_program, acct) = (pubkey(5), pubkey(3));
-    // account list: [other_program(0), settlement(1), acct(2)]. The settlement
-    // call is a CPI, so it only appears in the inner instructions.
-    let tx = tx_info(
-        vec![other_program, settlement, acct],
-        vec![],
-        vec![],
-        vec![compiled(0, vec![], vec![0])],
+        vec![router, acct_a],
+        vec![settlement],
+        vec![solflow, acct_b],
+        // top-level: a router call (dropped) then a solflow call (kept, index 1)
+        vec![
+            compiled(0, vec![1], vec![0]),
+            compiled(3, vec![1, 4], vec![1, 2, 3]),
+        ],
+        // settlement invoked as a CPI under top-level instruction 0
         vec![InnerInstructions {
             index: 0,
-            instructions: vec![inner(1, vec![2], vec![7])],
+            instructions: vec![inner(2, vec![1], vec![7])],
         }],
     );
 
     let relevant = relevant_instructions(&tx, &settlement, &solflow);
 
-    assert_eq!(relevant.len(), 1);
-    assert_eq!(relevant[0].program, settlement);
-    assert_eq!(relevant[0].instruction_index, 0);
-    assert_eq!(relevant[0].inner_index, Some(0));
-    assert_eq!(relevant[0].accounts, vec![acct]);
-    assert_eq!(relevant[0].data, vec![7]);
-}
+    // router dropped; solflow (top-level) and settlement (CPI) kept, in that order.
+    assert_eq!(relevant.len(), 2);
 
-#[test]
-fn alt_loaded_program_is_resolved() {
-    let (settlement, solflow) = (pubkey(1), pubkey(2));
-    let (acct, readonly) = (pubkey(3), pubkey(6));
-    // static [acct], ALT writable [settlement], ALT readonly [readonly], so the
-    // full list is [acct(0), settlement(1), readonly(2)] and program_id_index 1
-    // resolves into the ALT-loaded region.
-    let tx = tx_info(
-        vec![acct],
-        vec![settlement],
-        vec![readonly],
-        vec![compiled(1, vec![0], vec![5])],
-        vec![],
-    );
-
-    assert_eq!(build_account_keys(&tx), vec![acct, settlement, readonly]);
-
-    let relevant = relevant_instructions(&tx, &settlement, &solflow);
-
-    assert_eq!(relevant.len(), 1);
-    assert_eq!(relevant[0].program, settlement);
-    assert_eq!(relevant[0].instruction_index, 0);
-    assert_eq!(relevant[0].inner_index, None);
-    assert_eq!(relevant[0].accounts, vec![acct]);
-}
-
-#[test]
-fn solflow_program_instruction_is_kept() {
-    let (settlement, solflow) = (pubkey(1), pubkey(2));
-    let (other_program, acct) = (pubkey(5), pubkey(3));
-    // account list: [other_program(0), solflow(1), acct(2)]. Two top-level
-    // instructions; only the second (index 1) targets a tracked program.
-    let tx = tx_info(
-        vec![other_program, solflow, acct],
-        vec![],
-        vec![],
-        vec![
-            compiled(0, vec![2], vec![0]),
-            compiled(1, vec![2], vec![1, 2, 3]),
-        ],
-        vec![],
-    );
-
-    let relevant = relevant_instructions(&tx, &settlement, &solflow);
-
-    assert_eq!(relevant.len(), 1);
     assert_eq!(relevant[0].program, solflow);
     assert_eq!(relevant[0].instruction_index, 1);
     assert_eq!(relevant[0].inner_index, None);
-    assert_eq!(relevant[0].accounts, vec![acct]);
+    assert_eq!(relevant[0].accounts, vec![acct_a, acct_b]);
     assert_eq!(relevant[0].data, vec![1, 2, 3]);
+
+    assert_eq!(relevant[1].program, settlement);
+    assert_eq!(relevant[1].instruction_index, 0);
+    assert_eq!(relevant[1].inner_index, Some(0));
+    assert_eq!(relevant[1].accounts, vec![acct_a]);
+    assert_eq!(relevant[1].data, vec![7]);
 }
 
+/// Malformed stream data must drop rather than panic: an out-of-range account
+/// index on a program-matched instruction, an out-of-range program index, and a
+/// wrong-length key that becomes the zero pubkey and matches nothing.
 #[test]
-fn instruction_with_out_of_range_program_index_is_dropped() {
+fn malformed_instructions_are_dropped_without_panicking() {
     let (settlement, solflow) = (pubkey(1), pubkey(2));
-    // account list has one entry (index 0); program_id_index 5 is out of range.
-    let tx = tx_info(
-        vec![settlement],
-        vec![],
-        vec![],
-        vec![compiled(5, vec![0], vec![0])],
-        vec![],
-    );
-
-    assert!(relevant_instructions(&tx, &settlement, &solflow).is_empty());
-}
-
-#[test]
-fn relevant_instruction_with_out_of_range_account_index_is_dropped() {
-    let (settlement, solflow) = (pubkey(1), pubkey(2));
-    // program resolves to settlement (index 0), but account index 9 is out of
-    // range, so the whole instruction is dropped.
-    let tx = tx_info(
-        vec![settlement],
-        vec![],
-        vec![],
-        vec![compiled(0, vec![9], vec![0])],
-        vec![],
-    );
-
-    assert!(relevant_instructions(&tx, &settlement, &solflow).is_empty());
-}
-
-#[test]
-fn wrong_length_account_key_is_zeroed_and_not_matched() {
-    let (settlement, solflow) = (pubkey(1), pubkey(2));
-    // A 5-byte static key at index 0 becomes the zero pubkey, keeping index
-    // alignment. An instruction naming it as its program matches no tracked
-    // program and is dropped.
+    // Account list: [settlement(0), <5-byte key -> zero pubkey>(1)].
     let tx = SubscribeUpdateTransactionInfo {
         transaction: Some(Transaction {
             message: Some(Message {
-                account_keys: vec![vec![1, 2, 3, 4, 5]],
-                instructions: vec![compiled(0, vec![], vec![0])],
+                account_keys: vec![key_bytes(settlement), vec![1, 2, 3, 4, 5]],
+                instructions: vec![
+                    // settlement matches, but account index 5 is out of range
+                    compiled(0, vec![5], vec![0]),
+                    // program index 9 is out of range
+                    compiled(9, vec![0], vec![0]),
+                    // program index 1 is the zeroed bad key, matching nothing
+                    compiled(1, vec![0], vec![0]),
+                ],
                 ..Default::default()
             }),
             ..Default::default()
@@ -218,6 +138,6 @@ fn wrong_length_account_key_is_zeroed_and_not_matched() {
         ..Default::default()
     };
 
-    assert_eq!(build_account_keys(&tx), vec![Pubkey::default()]);
+    assert_eq!(build_account_keys(&tx), vec![settlement, Pubkey::default()]);
     assert!(relevant_instructions(&tx, &settlement, &solflow).is_empty());
 }

--- a/crates/solana-indexer/src/indexer/decoder/tests.rs
+++ b/crates/solana-indexer/src/indexer/decoder/tests.rs
@@ -101,20 +101,21 @@ fn resolves_settlement_and_solflow_across_top_level_and_cpi() {
 
     let relevant = relevant_instructions(&tx, &settlement, &solflow);
 
-    // router dropped, solflow (top-level) and settlement (CPI) kept, in order.
+    // Execution order: top-level 0's settlement CPI runs before top-level 1's
+    // solflow call. The router at top-level 0 is dropped.
     assert_eq!(relevant.len(), 2);
 
-    assert_eq!(relevant[0].program_id, solflow);
-    assert_eq!(relevant[0].instruction_index, 1);
-    assert_eq!(relevant[0].inner_index, None);
-    assert_eq!(relevant[0].accounts, vec![1, 4]);
-    assert_eq!(relevant[0].data, Bytes::from(vec![1, 2, 3]));
+    assert_eq!(relevant[0].program_id, settlement);
+    assert_eq!(relevant[0].instruction_index, 0);
+    assert_eq!(relevant[0].inner_index, Some(0));
+    assert_eq!(relevant[0].accounts, vec![1]);
+    assert_eq!(relevant[0].data, Bytes::from(vec![7]));
 
-    assert_eq!(relevant[1].program_id, settlement);
-    assert_eq!(relevant[1].instruction_index, 0);
-    assert_eq!(relevant[1].inner_index, Some(0));
-    assert_eq!(relevant[1].accounts, vec![1]);
-    assert_eq!(relevant[1].data, Bytes::from(vec![7]));
+    assert_eq!(relevant[1].program_id, solflow);
+    assert_eq!(relevant[1].instruction_index, 1);
+    assert_eq!(relevant[1].inner_index, None);
+    assert_eq!(relevant[1].accounts, vec![1, 4]);
+    assert_eq!(relevant[1].data, Bytes::from(vec![1, 2, 3]));
 }
 
 /// A program index that does not resolve to a tracked program is dropped

--- a/crates/solana-indexer/src/indexer/decoder/tests.rs
+++ b/crates/solana-indexer/src/indexer/decoder/tests.rs
@@ -37,9 +37,9 @@ fn inner(program_id_index: u32, accounts: Vec<u8>, data: Vec<u8>) -> InnerInstru
     }
 }
 
-/// Build a transaction-update fixture from resolved pubkeys: the static account
-/// keys, the ALT-loaded writable and readonly addresses, the top-level
-/// instructions, and the inner-instruction groups.
+/// Build a transaction-update fixture: static account keys, ALT-loaded writable
+/// and readonly addresses, top-level instructions, and inner-instruction
+/// groups.
 fn tx_info(
     account_keys: Vec<Pubkey>,
     loaded_writable: Vec<Pubkey>,
@@ -66,12 +66,9 @@ fn tx_info(
     }
 }
 
-/// One realistic transaction that exercises the four things that can actually
-/// break: the account list is `static ++ ALT-writable ++ ALT-readonly` (so the
-/// ALT indices only resolve if the regions are concatenated in that order),
-/// settlement is reachable only as a CPI (so inner instructions must be
-/// walked), an untracked program is present (so the filter must drop it), and
-/// each kept instruction records its position.
+/// One realistic transaction: settlement reached only via a CPI, an untracked
+/// program that must be dropped, and ALT-loaded programs so the account-list
+/// order is exercised.
 #[test]
 fn resolves_settlement_and_solflow_across_top_level_and_cpi() {
     let (settlement, solflow, router) = (pubkey(1), pubkey(2), pubkey(9));
@@ -96,7 +93,7 @@ fn resolves_settlement_and_solflow_across_top_level_and_cpi() {
 
     let relevant = relevant_instructions(&tx, &settlement, &solflow);
 
-    // router dropped; solflow (top-level) and settlement (CPI) kept, in that order.
+    // router dropped, solflow (top-level) and settlement (CPI) kept, in order.
     assert_eq!(relevant.len(), 2);
 
     assert_eq!(relevant[0].program, solflow);
@@ -112,9 +109,8 @@ fn resolves_settlement_and_solflow_across_top_level_and_cpi() {
     assert_eq!(relevant[1].data, vec![7]);
 }
 
-/// Malformed stream data must drop rather than panic: an out-of-range account
-/// index on a program-matched instruction, an out-of-range program index, and a
-/// wrong-length key that becomes the zero pubkey and matches nothing.
+/// Malformed stream data must drop, not panic: out-of-range program and account
+/// indices, and a wrong-length key that becomes the zero pubkey.
 #[test]
 fn malformed_instructions_are_dropped_without_panicking() {
     let (settlement, solflow) = (pubkey(1), pubkey(2));

--- a/crates/solana-indexer/src/indexer/decoder/tests.rs
+++ b/crates/solana-indexer/src/indexer/decoder/tests.rs
@@ -83,6 +83,8 @@ fn top_level_settlement_instruction_is_kept() {
 
     assert_eq!(relevant.len(), 1);
     assert_eq!(relevant[0].program, settlement);
+    assert_eq!(relevant[0].instruction_index, 0);
+    assert_eq!(relevant[0].inner_index, None);
     assert_eq!(relevant[0].accounts, vec![acct_a, acct_b]);
     assert_eq!(relevant[0].data, vec![9, 9, 9]);
 }
@@ -108,6 +110,8 @@ fn settlement_cpi_in_inner_instructions_is_kept() {
 
     assert_eq!(relevant.len(), 1);
     assert_eq!(relevant[0].program, settlement);
+    assert_eq!(relevant[0].instruction_index, 0);
+    assert_eq!(relevant[0].inner_index, Some(0));
     assert_eq!(relevant[0].accounts, vec![acct]);
     assert_eq!(relevant[0].data, vec![7]);
 }
@@ -133,5 +137,87 @@ fn alt_loaded_program_is_resolved() {
 
     assert_eq!(relevant.len(), 1);
     assert_eq!(relevant[0].program, settlement);
+    assert_eq!(relevant[0].instruction_index, 0);
+    assert_eq!(relevant[0].inner_index, None);
     assert_eq!(relevant[0].accounts, vec![acct]);
+}
+
+#[test]
+fn solflow_program_instruction_is_kept() {
+    let (settlement, solflow) = (pubkey(1), pubkey(2));
+    let (other_program, acct) = (pubkey(5), pubkey(3));
+    // account list: [other_program(0), solflow(1), acct(2)]. Two top-level
+    // instructions; only the second (index 1) targets a tracked program.
+    let tx = tx_info(
+        vec![other_program, solflow, acct],
+        vec![],
+        vec![],
+        vec![
+            compiled(0, vec![2], vec![0]),
+            compiled(1, vec![2], vec![1, 2, 3]),
+        ],
+        vec![],
+    );
+
+    let relevant = relevant_instructions(&tx, &settlement, &solflow);
+
+    assert_eq!(relevant.len(), 1);
+    assert_eq!(relevant[0].program, solflow);
+    assert_eq!(relevant[0].instruction_index, 1);
+    assert_eq!(relevant[0].inner_index, None);
+    assert_eq!(relevant[0].accounts, vec![acct]);
+    assert_eq!(relevant[0].data, vec![1, 2, 3]);
+}
+
+#[test]
+fn instruction_with_out_of_range_program_index_is_dropped() {
+    let (settlement, solflow) = (pubkey(1), pubkey(2));
+    // account list has one entry (index 0); program_id_index 5 is out of range.
+    let tx = tx_info(
+        vec![settlement],
+        vec![],
+        vec![],
+        vec![compiled(5, vec![0], vec![0])],
+        vec![],
+    );
+
+    assert!(relevant_instructions(&tx, &settlement, &solflow).is_empty());
+}
+
+#[test]
+fn relevant_instruction_with_out_of_range_account_index_is_dropped() {
+    let (settlement, solflow) = (pubkey(1), pubkey(2));
+    // program resolves to settlement (index 0), but account index 9 is out of
+    // range, so the whole instruction is dropped.
+    let tx = tx_info(
+        vec![settlement],
+        vec![],
+        vec![],
+        vec![compiled(0, vec![9], vec![0])],
+        vec![],
+    );
+
+    assert!(relevant_instructions(&tx, &settlement, &solflow).is_empty());
+}
+
+#[test]
+fn wrong_length_account_key_is_zeroed_and_not_matched() {
+    let (settlement, solflow) = (pubkey(1), pubkey(2));
+    // A 5-byte static key at index 0 becomes the zero pubkey, keeping index
+    // alignment. An instruction naming it as its program matches no tracked
+    // program and is dropped.
+    let tx = SubscribeUpdateTransactionInfo {
+        transaction: Some(Transaction {
+            message: Some(Message {
+                account_keys: vec![vec![1, 2, 3, 4, 5]],
+                instructions: vec![compiled(0, vec![], vec![0])],
+                ..Default::default()
+            }),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    assert_eq!(build_account_keys(&tx), vec![Pubkey::default()]);
+    assert!(relevant_instructions(&tx, &settlement, &solflow).is_empty());
 }

--- a/crates/solana-indexer/src/indexer/decoder/tests.rs
+++ b/crates/solana-indexer/src/indexer/decoder/tests.rs
@@ -29,12 +29,17 @@ fn compiled(program_id_index: u32, accounts: Vec<u8>, data: Vec<u8>) -> Compiled
     }
 }
 
-fn inner(program_id_index: u32, accounts: Vec<u8>, data: Vec<u8>) -> InnerInstruction {
+fn inner(
+    program_id_index: u32,
+    accounts: Vec<u8>,
+    data: Vec<u8>,
+    stack_height: Option<u32>,
+) -> InnerInstruction {
     InnerInstruction {
         program_id_index,
         accounts,
         data,
-        stack_height: None,
+        stack_height,
     }
 }
 
@@ -88,7 +93,7 @@ fn resolves_settlement_and_solflow_across_top_level_and_cpi() {
         // settlement invoked as a CPI under top-level instruction 0
         vec![InnerInstructions {
             index: 0,
-            instructions: vec![inner(2, vec![1], vec![7])],
+            instructions: vec![inner(2, vec![1], vec![7], None)],
         }],
     );
 
@@ -107,13 +112,13 @@ fn resolves_settlement_and_solflow_across_top_level_and_cpi() {
 
     assert_eq!(relevant[0].program_id, settlement);
     assert_eq!(relevant[0].instruction_index, 0);
-    assert_eq!(relevant[0].inner_index, Some(0));
+    assert_eq!(relevant[0].inner_ix_path, vec![0]);
     assert_eq!(relevant[0].accounts, vec![1]);
     assert_eq!(relevant[0].data, Bytes::from(vec![7]));
 
     assert_eq!(relevant[1].program_id, solflow);
     assert_eq!(relevant[1].instruction_index, 1);
-    assert_eq!(relevant[1].inner_index, None);
+    assert!(relevant[1].inner_ix_path.is_empty());
     assert_eq!(relevant[1].accounts, vec![1, 4]);
     assert_eq!(relevant[1].data, Bytes::from(vec![1, 2, 3]));
 }
@@ -152,4 +157,70 @@ fn unresolvable_programs_dropped_account_indices_carried_through() {
     assert_eq!(relevant[0].program_id, settlement);
     assert_eq!(relevant[0].instruction_index, 2);
     assert_eq!(relevant[0].accounts, vec![5]);
+}
+
+/// CPIs nest deeper than one level. `stack_height` drives the per-level path,
+/// and a dropped (untracked) inner still advances the sibling counter, so kept
+/// siblings keep their true position.
+#[test]
+fn inner_ix_path_tracks_cpi_nesting_depth() {
+    let (settlement, solflow, router, other) = (pubkey(1), pubkey(2), pubkey(9), pubkey(8));
+    // static account list: [router(0), settlement(1), other(2), solflow(3),
+    // acct(4)]
+    let tx = tx_info(
+        vec![router, settlement, other, solflow, pubkey(4)],
+        vec![],
+        vec![],
+        // one top-level router call (dropped)
+        vec![compiled(0, vec![4], vec![0])],
+        vec![InnerInstructions {
+            index: 0,
+            instructions: vec![
+                inner(1, vec![4], vec![10], Some(2)), // settlement, depth 1 -> [0]     kept
+                inner(2, vec![4], vec![11], Some(3)), // other,      depth 2 -> [0, 0]  dropped
+                inner(1, vec![4], vec![12], Some(3)), // settlement, depth 2 -> [0, 1]  kept
+                inner(3, vec![4], vec![13], Some(2)), // solflow,    depth 1 -> [1]     kept
+            ],
+        }],
+    );
+
+    let relevant = relevant_instructions(&tx, &settlement, &solflow);
+    assert_eq!(relevant.len(), 3);
+
+    assert_eq!(relevant[0].program_id, settlement);
+    assert_eq!(relevant[0].inner_ix_path, vec![0]);
+    assert_eq!(relevant[0].data, Bytes::from(vec![10]));
+
+    // the dropped depth-2 CPI still advanced the counter, so this sibling is [0, 1]
+    assert_eq!(relevant[1].program_id, settlement);
+    assert_eq!(relevant[1].inner_ix_path, vec![0, 1]);
+    assert_eq!(relevant[1].data, Bytes::from(vec![12]));
+
+    // back to depth 1: the second direct CPI under the top-level
+    assert_eq!(relevant[2].program_id, solflow);
+    assert_eq!(relevant[2].inner_ix_path, vec![1]);
+    assert_eq!(relevant[2].data, Bytes::from(vec![13]));
+}
+
+/// A corrupt `stack_height` from the stream must not drive an unbounded path
+/// allocation: depth is clamped to `MAX_CPI_DEPTH`.
+#[test]
+fn corrupt_stack_height_is_clamped() {
+    let (settlement, solflow) = (pubkey(1), pubkey(2));
+    let tx = tx_info(
+        vec![pubkey(9), settlement], // [router(0), settlement(1)]
+        vec![],
+        vec![],
+        vec![compiled(0, vec![1], vec![0])], // top-level router, dropped
+        vec![InnerInstructions {
+            index: 0,
+            instructions: vec![inner(1, vec![1], vec![7], Some(10_000))],
+        }],
+    );
+
+    let relevant = relevant_instructions(&tx, &settlement, &solflow);
+    assert_eq!(relevant.len(), 1);
+    assert_eq!(relevant[0].program_id, settlement);
+    // depth 9999 clamped to 4, so the path is bounded, not 9999 elements
+    assert_eq!(relevant[0].inner_ix_path, vec![0, 0, 0, 0]);
 }

--- a/crates/solana-indexer/src/indexer/decoder/tests.rs
+++ b/crates/solana-indexer/src/indexer/decoder/tests.rs
@@ -9,6 +9,7 @@ use {
         Transaction,
         TransactionStatusMeta,
     },
+    bytes::Bytes,
     solana_sdk::pubkey::Pubkey,
 };
 
@@ -91,28 +92,37 @@ fn resolves_settlement_and_solflow_across_top_level_and_cpi() {
         }],
     );
 
+    // The ALT indices (2, 3) only resolve if the three regions are concatenated
+    // static, then writable, then readonly.
+    assert_eq!(
+        build_account_keys(&tx),
+        vec![router, acct_a, settlement, solflow, acct_b]
+    );
+
     let relevant = relevant_instructions(&tx, &settlement, &solflow);
 
     // router dropped, solflow (top-level) and settlement (CPI) kept, in order.
     assert_eq!(relevant.len(), 2);
 
-    assert_eq!(relevant[0].program, solflow);
+    assert_eq!(relevant[0].program_id, solflow);
     assert_eq!(relevant[0].instruction_index, 1);
     assert_eq!(relevant[0].inner_index, None);
-    assert_eq!(relevant[0].accounts, vec![acct_a, acct_b]);
-    assert_eq!(relevant[0].data, vec![1, 2, 3]);
+    assert_eq!(relevant[0].accounts, vec![1, 4]);
+    assert_eq!(relevant[0].data, Bytes::from(vec![1, 2, 3]));
 
-    assert_eq!(relevant[1].program, settlement);
+    assert_eq!(relevant[1].program_id, settlement);
     assert_eq!(relevant[1].instruction_index, 0);
     assert_eq!(relevant[1].inner_index, Some(0));
-    assert_eq!(relevant[1].accounts, vec![acct_a]);
-    assert_eq!(relevant[1].data, vec![7]);
+    assert_eq!(relevant[1].accounts, vec![1]);
+    assert_eq!(relevant[1].data, Bytes::from(vec![7]));
 }
 
-/// Malformed stream data must drop, not panic: out-of-range program and account
-/// indices, and a wrong-length key that becomes the zero pubkey.
+/// A program index that does not resolve to a tracked program is dropped
+/// (out of range, or a wrong-length key that becomes the zero pubkey). Account
+/// indices are carried through unresolved, so a bad one does not drop the
+/// instruction here.
 #[test]
-fn malformed_instructions_are_dropped_without_panicking() {
+fn unresolvable_programs_dropped_account_indices_carried_through() {
     let (settlement, solflow) = (pubkey(1), pubkey(2));
     // Account list: [settlement(0), <5-byte key -> zero pubkey>(1)].
     let tx = SubscribeUpdateTransactionInfo {
@@ -120,12 +130,12 @@ fn malformed_instructions_are_dropped_without_panicking() {
             message: Some(Message {
                 account_keys: vec![key_bytes(settlement), vec![1, 2, 3, 4, 5]],
                 instructions: vec![
-                    // settlement matches, but account index 5 is out of range
-                    compiled(0, vec![5], vec![0]),
-                    // program index 9 is out of range
+                    // program index 9 is out of range -> dropped
                     compiled(9, vec![0], vec![0]),
-                    // program index 1 is the zeroed bad key, matching nothing
+                    // program index 1 is the zeroed bad key -> untracked, dropped
                     compiled(1, vec![0], vec![0]),
+                    // settlement, with an out-of-range account index carried as-is
+                    compiled(0, vec![5], vec![7]),
                 ],
                 ..Default::default()
             }),
@@ -135,5 +145,10 @@ fn malformed_instructions_are_dropped_without_panicking() {
     };
 
     assert_eq!(build_account_keys(&tx), vec![settlement, Pubkey::default()]);
-    assert!(relevant_instructions(&tx, &settlement, &solflow).is_empty());
+
+    let relevant = relevant_instructions(&tx, &settlement, &solflow);
+    assert_eq!(relevant.len(), 1);
+    assert_eq!(relevant[0].program_id, settlement);
+    assert_eq!(relevant[0].instruction_index, 2);
+    assert_eq!(relevant[0].accounts, vec![5]);
 }

--- a/crates/solana-indexer/src/types/tx.rs
+++ b/crates/solana-indexer/src/types/tx.rs
@@ -31,9 +31,11 @@ pub(crate) struct ResolvedInstruction {
     /// Top-level instruction index. For a CPI, the top-level instruction it
     /// runs under.
     pub instruction_index: u32,
-    /// Position within the top-level instruction's inner list, or `None` for a
-    /// top-level instruction.
-    pub inner_index: Option<u32>,
+    /// Path to this instruction within the top-level instruction's CPI tree,
+    /// one sibling position per nesting level: empty for a top-level
+    /// instruction, `[0]` for its first CPI, `[0, 1]` for the second CPI made
+    /// by that first CPI. Reconstructed from `stack_height`.
+    pub inner_ix_path: Vec<u8>,
 }
 
 /// Per-decode-pass context: the reconstructed account list, the slot, the

--- a/crates/solana-indexer/src/types/tx.rs
+++ b/crates/solana-indexer/src/types/tx.rs
@@ -6,7 +6,7 @@
 //! `solana-sdk` or `solana-message` because the upstream types carry raw
 //! `program_id_index: u8` values, while these views resolve that index
 //! against the reconstructed `account_keys` list and tag each instruction
-//! with its source (`is_inner`) and position (`ix_index`).
+//! with its position in the transaction.
 
 use {
     crate::types::{
@@ -28,11 +28,12 @@ pub(crate) struct ResolvedInstruction {
     pub data: Bytes,
     /// Account indices into the reconstructed account list.
     pub accounts: Vec<u8>,
-    /// Index of this instruction within the transaction (outer or
-    /// inner).
-    pub ix_index: u16,
-    /// `true` for CPIs (inner instructions).
-    pub is_inner: bool,
+    /// Top-level instruction index. For a CPI, the top-level instruction it
+    /// runs under.
+    pub instruction_index: u32,
+    /// Position within the top-level instruction's inner list, or `None` for a
+    /// top-level instruction.
+    pub inner_index: Option<u32>,
 }
 
 /// Per-decode-pass context: the reconstructed account list, the slot, the

--- a/crates/solana-indexer/src/types/wire.rs
+++ b/crates/solana-indexer/src/types/wire.rs
@@ -21,6 +21,7 @@ pub use yellowstone_grpc_proto::{
     },
     solana::storage::confirmed_block::{
         CompiledInstruction,
+        InnerInstruction,
         InnerInstructions,
         Message,
         TokenBalance,


### PR DESCRIPTION
# Description
The decoder must find, in each streamed transaction, the instructions that call the settlement or SolFlow program, including CPIs made from another program. Solana names an instruction's program and accounts by index into the transaction's account list, and versioned transactions split that list across the static keys plus the address-lookup-table loaded writable and readonly addresses. This PR resolves those indices: rebuild the full account list, walk every instruction (top-level and inner), and keep the ones whose program resolves to a program we track.

# Changes
- `build_account_keys`: static keys, then ALT-loaded writable, then ALT-loaded readonly, concatenated in that fixed order (§6.3.1.a)
- `walk_instructions`: top-level instructions followed by inner/CPI instructions (§6.3.1.b)
- `filter_relevant`: resolve each instruction's program and accounts against the account list, keep only settlement/SolFlow, drop instructions with out-of-range index references (§6.3.1.c)
- `RelevantInstruction { program, accounts, data }`: the resolved unit PR 7's per-program dispatch will consume
- re-export `InnerInstruction` from `wire`

`run()` stays `unimplemented!()`. Instruction-data decoding and the persist path arrive in PR 7/8. No dependency on the settlement `interface` crate: this step is generic Solana transaction processing.

# How to test
New unit tests.
