### PR TITLE
Do not record streaming measurement for quotes

### DIFF
--- a/crates/configs/src/shared.rs
+++ b/crates/configs/src/shared.rs
@@ -29,8 +29,8 @@ const fn default_ethrpc_max_concurrent_requests() -> usize {
 
 fn default_log_filter() -> String {
     String::from(
-        "info,autopilot=debug,driver=debug,observe=info,orderbook=debug,solver=debug,shared=debug,\
-         cow_amm=debug",
+        "info,autopilot=debug,driver=debug,observe=info,observe::http_body=debug,orderbook=debug,\
+         solver=debug,shared=debug,cow_amm=debug",
     )
 }
 

--- a/crates/driver/src/infra/observe/metrics.rs
+++ b/crates/driver/src/infra/observe/metrics.rs
@@ -58,6 +58,15 @@ pub struct Metrics {
         )
     )]
     pub used_solve_time: prometheus::HistogramVec,
+
+    /// Time spent serializing and streaming the solve request body to each
+    /// solver, split by `phase`: `serialization` (isolated CPU cost) and
+    /// `total` (serialization plus solver transfer + optional gzip archival).
+    #[metric(
+        labels("solver", "phase"),
+        buckets(0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5)
+    )]
+    pub solve_request_body_time: prometheus::HistogramVec,
 }
 
 impl Metrics {

--- a/crates/driver/src/infra/observe/mod.rs
+++ b/crates/driver/src/infra/observe/mod.rs
@@ -338,6 +338,21 @@ pub fn solver_request(endpoint: &Url, req: impl AsRef<[u8]>) {
     tracing::trace!(%endpoint, %req, "sending request to solver");
 }
 
+/// Observe how long serializing and streaming the solve request body to a
+/// solver took, both the isolated serialization cost and the total including
+/// the solver transfer.
+pub fn serialized_solve_request(solver: &solver::Name, serialize: Duration, total: Duration) {
+    let metrics = metrics::get();
+    metrics
+        .solve_request_body_time
+        .with_label_values(&[solver.as_str(), "serialization"])
+        .observe(serialize.as_secs_f64());
+    metrics
+        .solve_request_body_time
+        .with_label_values(&[solver.as_str(), "total"])
+        .observe(total.as_secs_f64());
+}
+
 /// Observe that a response was received from the solver.
 pub fn solver_response(
     endpoint: &Url,

--- a/crates/driver/src/infra/solver/mod.rs
+++ b/crates/driver/src/infra/solver/mod.rs
@@ -408,12 +408,18 @@ impl Solver {
         // reports the timing once serialization finishes, independently of
         // whether the auction was archived.
         if auction.id().is_some() {
+            let solver = self.config.name.clone();
             tokio::spawn(async move {
                 if let Ok(measurements) = measurements.await {
                     observe::metrics::metrics().record_auction_overhead(
                         measurements.serialize,
                         "driver",
                         "serialize_request",
+                    );
+                    super::observe::serialized_solve_request(
+                        &solver,
+                        measurements.serialize,
+                        measurements.total,
                     );
                 }
             });

--- a/crates/driver/src/infra/solver/mod.rs
+++ b/crates/driver/src/infra/solver/mod.rs
@@ -392,16 +392,32 @@ impl Solver {
             .archives_enabled()
             .then(|| auction.id())
             .flatten();
-        let body: reqwest::Body = match archive_id {
+        let (body, measurements) = match archive_id {
             // Stream the request body while capturing a gzipped copy for S3, so
             // neither the request nor the archive holds the full JSON at once.
             Some(id) => {
-                let (body, compressed) = streaming::stream_body_and_gzip(auction_dto);
+                let (body, compressed, measurements) = streaming::stream_body_and_gzip(auction_dto);
                 self.persistence.archive_auction_gzipped(id, compressed);
-                body
+                (body, measurements)
             }
             None => streaming::stream_body(auction_dto),
         };
+
+        // Record the serialization overhead for real auctions only; quotes go
+        // through the same streaming path but would skew the metric. The stream
+        // reports the timing once serialization finishes, independently of
+        // whether the auction was archived.
+        if auction.id().is_some() {
+            tokio::spawn(async move {
+                if let Ok(measurements) = measurements.await {
+                    observe::metrics::metrics().record_auction_overhead(
+                        measurements.serialize,
+                        "driver",
+                        "serialize_request",
+                    );
+                }
+            });
+        }
 
         let timeout = match auction.deadline(self.timeouts()).solvers().remaining() {
             Ok(timeout) => timeout,

--- a/crates/driver/src/infra/solver/streaming/mod.rs
+++ b/crates/driver/src/infra/solver/streaming/mod.rs
@@ -6,10 +6,11 @@ use {
     best_effort_sink::BestEffortSink,
     bytes::Bytes,
     futures::StreamExt,
-    observe::{http_body::Measured, metrics::Metrics},
+    observe::http_body::Measured,
     std::{
         convert::Infallible,
         io::{BufWriter, Write},
+        time::Duration,
     },
     tee_writer::TeeWriter,
     timed_writer::Timed,
@@ -23,39 +24,53 @@ const CHUNK_SIZE: usize = 64 * 1024;
 /// the serializer produces the next; more only raises the memory ceiling.
 const CHANNEL_CAPACITY: usize = 2;
 
+/// Timing measurements captured while streaming a request body, delivered once
+/// serialization finishes. The caller decides what to do with them (e.g. expose
+/// the serialization overhead as a metric for real auctions but not quotes).
+pub struct Measurements {
+    /// Wall-clock serialization cost, isolated from the time spent blocked
+    /// writing to the sinks (solver transfer + gzip).
+    pub serialize: Duration,
+}
+
 /// Serializes `value` to JSON on a blocking thread, streaming it into the
 /// returned reqwest body. Backpressure from the body channel caps memory.
-pub fn stream_body<T>(value: T) -> reqwest::Body
+pub fn stream_body<T>(value: T) -> (reqwest::Body, oneshot::Receiver<Measurements>)
 where
     T: serde::Serialize + Send + 'static,
 {
-    // Set to None since this function is (at the time of writing)
-    // used only for quotes and we're not interested in measuring them
-    stream_into(value, std::io::sink(), None)
+    stream_into(value, std::io::sink())
 }
 
 /// Like [`stream_body`], but also gzips the same serialization in one pass. The
-/// receiver yields the compressed bytes once serialization finishes.
-pub fn stream_body_and_gzip<T>(value: T) -> (reqwest::Body, oneshot::Receiver<Bytes>)
+/// first receiver yields the compressed bytes once serialization finishes.
+pub fn stream_body_and_gzip<T>(
+    value: T,
+) -> (
+    reqwest::Body,
+    oneshot::Receiver<Bytes>,
+    oneshot::Receiver<Measurements>,
+)
 where
     T: serde::Serialize + Send + 'static,
 {
     let (gzip, compressed) = GzipCapture::new();
-    // The opposite of `stream_body`, we use this version for proper auctions
-    let body = stream_into(value, gzip, Some(observe::metrics::metrics()));
-    (body, compressed)
+    let (body, measurements) = stream_into(value, gzip);
+    (body, compressed, measurements)
 }
 
 /// Serializes `value` into a tee of the body channel and `secondary` on a
 /// blocking thread, then finalizes each sink. Serialization always runs to
 /// completion even if the request receiver drops, so the secondary sink (the
-/// gzip archive) is captured regardless of the request outcome.
-fn stream_into<T, S>(value: T, secondary: S, metrics: Option<&'static Metrics>) -> reqwest::Body
+/// gzip archive) is captured regardless of the request outcome. The returned
+/// receiver reports the timing [`Measurements`] once serialization finishes.
+fn stream_into<T, S>(value: T, secondary: S) -> (reqwest::Body, oneshot::Receiver<Measurements>)
 where
     T: serde::Serialize + Send + 'static,
     S: Write + Finalize + Send + 'static,
 {
     let (tx, rx) = mpsc::channel::<Bytes>(CHANNEL_CAPACITY);
+    let (measurements_tx, measurements_rx) = oneshot::channel();
     // E2E measurement of the body transfer time (includes serialization)
     let stream = Measured::new(ReceiverStream::new(rx)).map(Ok::<_, Infallible>);
     let body = reqwest::Body::wrap_stream(stream);
@@ -86,14 +101,12 @@ where
                 return;
             }
         };
-        if let Some(metrics) = metrics {
-            // Measure before `finalize` so the gzip finish cost stays out of the metric.
-            let serialize = start.elapsed().saturating_sub(timed.elapsed());
-            metrics.record_auction_overhead(serialize, "driver", "serialize_request");
-        }
+        // Measure before `finalize` so the gzip finish cost stays out of the metric.
+        let serialize = start.elapsed().saturating_sub(timed.elapsed());
+        let _ = measurements_tx.send(Measurements { serialize });
         timed.into_inner().finalize();
     });
-    body
+    (body, measurements_rx)
 }
 
 /// A [`Write`] that sends each block to the body channel, blocking when it's
@@ -210,7 +223,7 @@ mod tests {
         let value = json!({ "a": 1, "b": [1, 2, 3], "c": "hello" });
         // Keep `body` alive: dropping its receiver would abort serialization
         // before the gzip is captured.
-        let (_body, gzip_rx) = stream_body_and_gzip(value.clone());
+        let (_body, gzip_rx, _measurements) = stream_body_and_gzip(value.clone());
 
         let compressed = gzip_rx.await.unwrap();
         let mut decoded = Vec::new();
@@ -223,7 +236,7 @@ mod tests {
     #[tokio::test]
     async fn gzip_captured_even_if_request_body_dropped() {
         let value = json!({ "a": 1, "b": [1, 2, 3], "c": "hello" });
-        let (body, gzip_rx) = stream_body_and_gzip(value.clone());
+        let (body, gzip_rx, _measurements) = stream_body_and_gzip(value.clone());
         // The solver connection going away mid-stream must not skip the archive.
         drop(body);
 
@@ -233,5 +246,14 @@ mod tests {
             .read_to_end(&mut decoded)
             .unwrap();
         assert_eq!(decoded, serde_json::to_vec(&value).unwrap());
+    }
+
+    #[tokio::test]
+    async fn reports_measurements_once_serialization_finishes() {
+        let value = json!({ "a": 1, "b": [1, 2, 3], "c": "hello" });
+        // Keep `body` alive so serialization runs to completion.
+        let (_body, measurements) = stream_body(value);
+        // The receiver resolves, confirming the caller can pick up the timings.
+        measurements.await.unwrap();
     }
 }

--- a/crates/driver/src/infra/solver/streaming/mod.rs
+++ b/crates/driver/src/infra/solver/streaming/mod.rs
@@ -6,7 +6,7 @@ use {
     best_effort_sink::BestEffortSink,
     bytes::Bytes,
     futures::StreamExt,
-    observe::http_body::Measured,
+    observe::{http_body::Measured, metrics::Metrics},
     std::{
         convert::Infallible,
         io::{BufWriter, Write},
@@ -29,7 +29,9 @@ pub fn stream_body<T>(value: T) -> reqwest::Body
 where
     T: serde::Serialize + Send + 'static,
 {
-    stream_into(value, std::io::sink())
+    // Set to None since this function is (at the time of writing)
+    // used only for quotes and we're not interested in measuring them
+    stream_into(value, std::io::sink(), None)
 }
 
 /// Like [`stream_body`], but also gzips the same serialization in one pass. The
@@ -39,7 +41,8 @@ where
     T: serde::Serialize + Send + 'static,
 {
     let (gzip, compressed) = GzipCapture::new();
-    let body = stream_into(value, gzip);
+    // The opposite of `stream_body`, we use this version for proper auctions
+    let body = stream_into(value, gzip, Some(observe::metrics::metrics()));
     (body, compressed)
 }
 
@@ -47,7 +50,7 @@ where
 /// blocking thread, then finalizes each sink. Serialization always runs to
 /// completion even if the request receiver drops, so the secondary sink (the
 /// gzip archive) is captured regardless of the request outcome.
-fn stream_into<T, S>(value: T, secondary: S) -> reqwest::Body
+fn stream_into<T, S>(value: T, secondary: S, metrics: Option<&'static Metrics>) -> reqwest::Body
 where
     T: serde::Serialize + Send + 'static,
     S: Write + Finalize + Send + 'static,
@@ -83,13 +86,11 @@ where
                 return;
             }
         };
-        // Measure before `finalize` so the gzip finish cost stays out of the metric.
-        let serialize = start.elapsed().saturating_sub(timed.elapsed());
-        observe::metrics::metrics().record_auction_overhead(
-            serialize,
-            "driver",
-            "serialize_request",
-        );
+        if let Some(metrics) = metrics {
+            // Measure before `finalize` so the gzip finish cost stays out of the metric.
+            let serialize = start.elapsed().saturating_sub(timed.elapsed());
+            metrics.record_auction_overhead(serialize, "driver", "serialize_request");
+        }
         timed.into_inner().finalize();
     });
     body

--- a/crates/driver/src/infra/solver/streaming/mod.rs
+++ b/crates/driver/src/infra/solver/streaming/mod.rs
@@ -31,6 +31,9 @@ pub struct Measurements {
     /// Wall-clock serialization cost, isolated from the time spent blocked
     /// writing to the sinks (solver transfer + gzip).
     pub serialize: Duration,
+    /// Total wall-clock of the streaming task: serialization plus the time
+    /// spent blocked writing to the sinks (solver transfer + gzip).
+    pub total: Duration,
 }
 
 /// Serializes `value` to JSON on a blocking thread, streaming it into the
@@ -101,9 +104,10 @@ where
                 return;
             }
         };
-        // Measure before `finalize` so the gzip finish cost stays out of the metric.
-        let serialize = start.elapsed().saturating_sub(timed.elapsed());
-        let _ = measurements_tx.send(Measurements { serialize });
+        // Measure before `finalize` so the gzip finish cost stays out of the metrics.
+        let total = start.elapsed();
+        let serialize = total.saturating_sub(timed.elapsed());
+        let _ = measurements_tx.send(Measurements { serialize, total });
         timed.into_inner().finalize();
     });
     (body, measurements_rx)

--- a/crates/shared/src/arguments.rs
+++ b/crates/shared/src/arguments.rs
@@ -48,8 +48,8 @@ macro_rules! logging_args_with_default_filter {
 
 logging_args_with_default_filter!(
     LoggingArguments,
-    "info,autopilot=debug,driver=debug,observe=info,orderbook=debug,solver=debug,shared=debug,\
-     cow_amm=debug"
+    "info,autopilot=debug,driver=debug,observe=info,observe::http_body=debug,orderbook=debug,\
+     solver=debug,shared=debug,cow_amm=debug"
 );
 
 #[derive(Debug, clap::Parser)]


### PR DESCRIPTION
# Description
With the new streaming measurements we started recording quotes too, this skews the metrics, the PR fixes it.
It also brings back the http_body logging that was lost when moved to the observe crate.

# Changes

* Add metrics parameter that enables the metrics recording
* Add the http_body filter to the default log filter

## How to test
Grafana