### PR TITLE
Emit quoteRequested event

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7127,6 +7127,7 @@ dependencies = [
  "database",
  "eth-domain-types",
  "ethrpc",
+ "event-bus-dto",
  "futures",
  "gas-price-estimation",
  "hex-literal",

--- a/crates/app-data/src/app_data.rs
+++ b/crates/app-data/src/app_data.rs
@@ -299,6 +299,24 @@ pub fn parse(full_app_data: &[u8]) -> Result<ProtocolAppData, serde_json::Error>
     Ok(parsed)
 }
 
+/// Extracts the `appCode` from a full app-data document, if present.
+///
+/// `appCode` sits at the document root, next to (not inside) the protocol
+/// `metadata`, so it is not part of [`ProtocolAppData`] and callers that want
+/// it — e.g. for analytics — parse it separately with this helper. Returns
+/// `None` for absent or malformed app data.
+pub fn app_code(full_app_data: &[u8]) -> Option<String> {
+    #[derive(Deserialize)]
+    struct AppCode {
+        #[serde(rename = "appCode")]
+        app_code: Option<String>,
+    }
+
+    serde_json::from_slice::<AppCode>(full_app_data)
+        .ok()?
+        .app_code
+}
+
 /// The root app data JSON object.
 ///
 /// App data JSON is organised in an object of the form
@@ -550,6 +568,17 @@ mod tests {
     #[test]
     fn empty_is_valid() {
         assert_app_data!(EMPTY, ProtocolAppData::default());
+    }
+
+    #[test]
+    fn extracts_app_code() {
+        assert_eq!(
+            app_code(br#"{"appCode": "CoW Swap", "version": "0.9.0"}"#),
+            Some("CoW Swap".to_string()),
+        );
+        assert_eq!(app_code(EMPTY.as_bytes()), None);
+        assert_eq!(app_code(br#"{"version": "0.9.0"}"#), None);
+        assert_eq!(app_code(b"not json"), None);
     }
 
     #[test]

--- a/crates/event-bus-dto/schemas/events.json
+++ b/crates/event-bus-dto/schemas/events.json
@@ -183,7 +183,7 @@
         "type": "object"
       },
       "QuoteRequestedEvent": {
-        "description": "Emitted when the orderbook starts computing a quote (\"calculating quote\"),\nbefore any price estimation runs. Carries the request context that partner\nand quote analysis care about — notably the `appCode` and the token symbols\n— which are not present on the per-estimator [`crate::PriceEstimateEvent`].",
+        "description": "Emitted for a validated quote request, just before price estimation runs.\nCarries the request context that partner and quote analysis care about —\nnotably the `appCode` and the token symbols — which are not present on the\nper-estimator [`crate::PriceEstimateEvent`].",
         "properties": {
           "appCode": {
             "description": "`appCode` from the order's app-data document, if present.",

--- a/crates/event-bus-dto/schemas/events.json
+++ b/crates/event-bus-dto/schemas/events.json
@@ -138,5 +138,121 @@
     ],
     "title": "Envelope",
     "type": "object"
+  },
+  "quoteRequested": {
+    "$defs": {
+      "OrderKind": {
+        "enum": [
+          "sell",
+          "buy"
+        ],
+        "type": "string"
+      },
+      "PriceQuality": {
+        "enum": [
+          "fast",
+          "optimal",
+          "verified"
+        ],
+        "type": "string"
+      },
+      "QueryFields": {
+        "properties": {
+          "buyToken": {
+            "description": "Hex-encoded buy token address.",
+            "type": "string"
+          },
+          "inAmount": {
+            "description": "Decimal-encoded input amount (interpretation depends on `kind`).",
+            "type": "string"
+          },
+          "kind": {
+            "$ref": "#/$defs/OrderKind"
+          },
+          "sellToken": {
+            "description": "Hex-encoded sell token address.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "sellToken",
+          "buyToken",
+          "inAmount",
+          "kind"
+        ],
+        "type": "object"
+      },
+      "QuoteRequestedEvent": {
+        "description": "Emitted when the orderbook starts computing a quote (\"calculating quote\"),\nbefore any price estimation runs. Carries the request context that partner\nand quote analysis care about — notably the `appCode` and the token symbols\n— which are not present on the per-estimator [`crate::PriceEstimateEvent`].",
+        "properties": {
+          "appCode": {
+            "description": "`appCode` from the order's app-data document, if present.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "buyTokenSymbol": {
+            "description": "Symbol of the buy token, if known.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "from": {
+            "description": "Caller address (hex-encoded, including the `0x` prefix).",
+            "type": "string"
+          },
+          "priceQuality": {
+            "$ref": "#/$defs/PriceQuality"
+          },
+          "query": {
+            "$ref": "#/$defs/QueryFields"
+          },
+          "sellTokenSymbol": {
+            "description": "Symbol of the sell token, if known.",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "query",
+          "from",
+          "priceQuality"
+        ],
+        "type": "object"
+      }
+    },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "JSON envelope wrapping every event published to the bus. Consumers can\nrely on `version` to evolve their parsers, on `timestamp` for ordering,\nand on `requestId` to correlate events emitted while serving a single\ninbound request (e.g. all the price estimates and the resulting quote of\none quote request share the same `requestId`).",
+    "properties": {
+      "body": {
+        "$ref": "#/$defs/QuoteRequestedEvent"
+      },
+      "requestId": {
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "timestamp": {
+        "description": "RFC3339 timestamp (millisecond precision, UTC) of when the event was\npublished.",
+        "format": "date-time",
+        "type": "string"
+      },
+      "version": {
+        "const": "v1",
+        "type": "string"
+      }
+    },
+    "required": [
+      "version",
+      "timestamp",
+      "body"
+    ],
+    "title": "Envelope",
+    "type": "object"
   }
 }

--- a/crates/event-bus-dto/src/lib.rs
+++ b/crates/event-bus-dto/src/lib.rs
@@ -11,11 +11,13 @@
 
 pub mod envelope;
 pub mod price_estimate;
+pub mod query;
 pub mod quote_requested;
 
 pub use {
     envelope::{ENVELOPE_VERSION, Envelope},
     price_estimate::PriceEstimateEvent,
+    query::{OrderKind, QueryFields},
     quote_requested::QuoteRequestedEvent,
 };
 use {schemars::JsonSchema, serde::Serialize};

--- a/crates/event-bus-dto/src/lib.rs
+++ b/crates/event-bus-dto/src/lib.rs
@@ -11,10 +11,12 @@
 
 pub mod envelope;
 pub mod price_estimate;
+pub mod quote_requested;
 
 pub use {
     envelope::{ENVELOPE_VERSION, Envelope},
     price_estimate::PriceEstimateEvent,
+    quote_requested::QuoteRequestedEvent,
 };
 use {schemars::JsonSchema, serde::Serialize};
 
@@ -30,8 +32,14 @@ pub trait Event: Serialize + JsonSchema {
 /// CLI and any other place that needs to enumerate the full set of events
 /// (e.g. tests that pin the wire format).
 pub fn schemas() -> Vec<(&'static str, schemars::Schema)> {
-    vec![(
-        PriceEstimateEvent::SUBJECT,
-        schemars::schema_for!(Envelope<PriceEstimateEvent>),
-    )]
+    vec![
+        (
+            PriceEstimateEvent::SUBJECT,
+            schemars::schema_for!(Envelope<PriceEstimateEvent>),
+        ),
+        (
+            QuoteRequestedEvent::SUBJECT,
+            schemars::schema_for!(Envelope<QuoteRequestedEvent>),
+        ),
+    ]
 }

--- a/crates/event-bus-dto/src/price_estimate.rs
+++ b/crates/event-bus-dto/src/price_estimate.rs
@@ -1,4 +1,8 @@
-use {crate::Event, schemars::JsonSchema, serde::Serialize};
+use {
+    crate::{Event, query::QueryFields},
+    schemars::JsonSchema,
+    serde::Serialize,
+};
 
 #[derive(Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
@@ -19,25 +23,6 @@ impl Event for PriceEstimateEvent {
 }
 
 #[derive(Serialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct QueryFields {
-    /// Hex-encoded sell token address.
-    pub sell_token: String,
-    /// Hex-encoded buy token address.
-    pub buy_token: String,
-    /// Decimal-encoded input amount (interpretation depends on `kind`).
-    pub in_amount: String,
-    pub kind: OrderKind,
-}
-
-#[derive(Serialize, JsonSchema)]
-#[serde(rename_all = "lowercase")]
-pub enum OrderKind {
-    Sell,
-    Buy,
-}
-
-#[derive(Serialize, JsonSchema)]
 #[serde(untagged)]
 pub enum EstimateResult {
     #[serde(rename_all = "camelCase")]
@@ -55,7 +40,7 @@ pub enum EstimateResult {
 
 #[cfg(test)]
 mod tests {
-    use {super::*, serde_json::json};
+    use {super::*, crate::query::OrderKind, serde_json::json};
 
     #[test]
     fn matches_wire_format() {

--- a/crates/event-bus-dto/src/query.rs
+++ b/crates/event-bus-dto/src/query.rs
@@ -1,10 +1,13 @@
 use {schemars::JsonSchema, serde::Serialize};
 
-// The token query shared by quote-related events. `QuoteRequestedEvent` and
-// `PriceEstimateEvent` emitted for the same request carry an identical query,
-// and consumers correlate them by the envelope's `requestId` expecting the
-// exact same shape. Keeping a single definition here guarantees the two can't
-// drift apart.
+// The token query shared by quote-related events, kept in one place so the
+// `QuoteRequestedEvent` and `PriceEstimateEvent` for the same trade can't drift
+// apart.
+//
+// Note that `requestId` doesn't uniquely identify a query: a `/quote` may also
+// trigger up to 2 native-price estimations (token -> native token), each
+// emitting `priceEstimate` events under the same `requestId`. Consumers must
+// compare the query fields, not just `requestId`.
 #[derive(Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct QueryFields {

--- a/crates/event-bus-dto/src/query.rs
+++ b/crates/event-bus-dto/src/query.rs
@@ -1,0 +1,25 @@
+use {schemars::JsonSchema, serde::Serialize};
+
+// The token query shared by quote-related events. `QuoteRequestedEvent` and
+// `PriceEstimateEvent` emitted for the same request carry an identical query,
+// and consumers correlate them by the envelope's `requestId` expecting the
+// exact same shape. Keeping a single definition here guarantees the two can't
+// drift apart.
+#[derive(Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct QueryFields {
+    /// Hex-encoded sell token address.
+    pub sell_token: String,
+    /// Hex-encoded buy token address.
+    pub buy_token: String,
+    /// Decimal-encoded input amount (interpretation depends on `kind`).
+    pub in_amount: String,
+    pub kind: OrderKind,
+}
+
+#[derive(Serialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum OrderKind {
+    Sell,
+    Buy,
+}

--- a/crates/event-bus-dto/src/quote_requested.rs
+++ b/crates/event-bus-dto/src/quote_requested.rs
@@ -1,9 +1,13 @@
-use {crate::Event, schemars::JsonSchema, serde::Serialize};
+use {
+    crate::{Event, query::QueryFields},
+    schemars::JsonSchema,
+    serde::Serialize,
+};
 
-/// Emitted when the orderbook starts computing a quote ("calculating quote"),
-/// before any price estimation runs. Carries the request context that partner
-/// and quote analysis care about — notably the `appCode` and the token symbols
-/// — which are not present on the per-estimator [`crate::PriceEstimateEvent`].
+/// Emitted for a validated quote request, just before price estimation runs.
+/// Carries the request context that partner and quote analysis care about —
+/// notably the `appCode` and the token symbols — which are not present on the
+/// per-estimator [`crate::PriceEstimateEvent`].
 #[derive(Serialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct QuoteRequestedEvent {
@@ -27,25 +31,6 @@ impl Event for QuoteRequestedEvent {
 }
 
 #[derive(Serialize, JsonSchema)]
-#[serde(rename_all = "camelCase")]
-pub struct QueryFields {
-    /// Hex-encoded sell token address.
-    pub sell_token: String,
-    /// Hex-encoded buy token address.
-    pub buy_token: String,
-    /// Decimal-encoded input amount (interpretation depends on `kind`).
-    pub in_amount: String,
-    pub kind: OrderKind,
-}
-
-#[derive(Serialize, JsonSchema)]
-#[serde(rename_all = "lowercase")]
-pub enum OrderKind {
-    Sell,
-    Buy,
-}
-
-#[derive(Serialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum PriceQuality {
     Fast,
@@ -55,7 +40,7 @@ pub enum PriceQuality {
 
 #[cfg(test)]
 mod tests {
-    use {super::*, serde_json::json};
+    use {super::*, crate::query::OrderKind, serde_json::json};
 
     #[test]
     fn matches_wire_format() {

--- a/crates/event-bus-dto/src/quote_requested.rs
+++ b/crates/event-bus-dto/src/quote_requested.rs
@@ -1,0 +1,113 @@
+use {crate::Event, schemars::JsonSchema, serde::Serialize};
+
+/// Emitted when the orderbook starts computing a quote ("calculating quote"),
+/// before any price estimation runs. Carries the request context that partner
+/// and quote analysis care about — notably the `appCode` and the token symbols
+/// — which are not present on the per-estimator [`crate::PriceEstimateEvent`].
+#[derive(Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct QuoteRequestedEvent {
+    pub query: QueryFields,
+    /// Caller address (hex-encoded, including the `0x` prefix).
+    pub from: String,
+    /// `appCode` from the order's app-data document, if present.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub app_code: Option<String>,
+    /// Symbol of the sell token, if known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sell_token_symbol: Option<String>,
+    /// Symbol of the buy token, if known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub buy_token_symbol: Option<String>,
+    pub price_quality: PriceQuality,
+}
+
+impl Event for QuoteRequestedEvent {
+    const SUBJECT: &'static str = "quoteRequested";
+}
+
+#[derive(Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct QueryFields {
+    /// Hex-encoded sell token address.
+    pub sell_token: String,
+    /// Hex-encoded buy token address.
+    pub buy_token: String,
+    /// Decimal-encoded input amount (interpretation depends on `kind`).
+    pub in_amount: String,
+    pub kind: OrderKind,
+}
+
+#[derive(Serialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum OrderKind {
+    Sell,
+    Buy,
+}
+
+#[derive(Serialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum PriceQuality {
+    Fast,
+    Optimal,
+    Verified,
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, serde_json::json};
+
+    #[test]
+    fn matches_wire_format() {
+        let event = QuoteRequestedEvent {
+            query: QueryFields {
+                sell_token: "0x01".into(),
+                buy_token: "0x02".into(),
+                in_amount: "100".into(),
+                kind: OrderKind::Sell,
+            },
+            from: "0x0000000000000000000000000000000000000000".into(),
+            app_code: Some("CoW Swap".into()),
+            sell_token_symbol: Some("WETH".into()),
+            buy_token_symbol: Some("USDC".into()),
+            price_quality: PriceQuality::Optimal,
+        };
+        assert_eq!(
+            serde_json::to_value(&event).unwrap(),
+            json!({
+                "query": {
+                    "sellToken": "0x01",
+                    "buyToken": "0x02",
+                    "inAmount": "100",
+                    "kind": "sell",
+                },
+                "from": "0x0000000000000000000000000000000000000000",
+                "appCode": "CoW Swap",
+                "sellTokenSymbol": "WETH",
+                "buyTokenSymbol": "USDC",
+                "priceQuality": "optimal",
+            }),
+        );
+    }
+
+    #[test]
+    fn omits_missing_optionals() {
+        let event = QuoteRequestedEvent {
+            query: QueryFields {
+                sell_token: "0x01".into(),
+                buy_token: "0x02".into(),
+                in_amount: "100".into(),
+                kind: OrderKind::Buy,
+            },
+            from: "0x0000000000000000000000000000000000000000".into(),
+            app_code: None,
+            sell_token_symbol: None,
+            buy_token_symbol: None,
+            price_quality: PriceQuality::Fast,
+        };
+        let value = serde_json::to_value(&event).unwrap();
+        assert!(value.get("appCode").is_none());
+        assert!(value.get("sellTokenSymbol").is_none());
+        assert!(value.get("buyTokenSymbol").is_none());
+    }
+}

--- a/crates/model/src/quote.rs
+++ b/crates/model/src/quote.rs
@@ -168,6 +168,22 @@ impl Default for OrderQuoteSide {
     }
 }
 
+impl OrderQuoteSide {
+    /// Returns the order kind together with the corresponding input amount: the
+    /// sell amount (before or after fee) for sell orders, and the buy amount
+    /// after fee for buy orders.
+    pub fn kind_and_amount(&self) -> (OrderKind, NonZeroU256) {
+        match self {
+            OrderQuoteSide::Sell {
+                sell_amount: SellAmount::BeforeFee { value } | SellAmount::AfterFee { value },
+            } => (OrderKind::Sell, *value),
+            OrderQuoteSide::Buy {
+                buy_amount_after_fee,
+            } => (OrderKind::Buy, *buy_amount_after_fee),
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Validity {
     To(u32),

--- a/crates/orderbook/Cargo.toml
+++ b/crates/orderbook/Cargo.toml
@@ -35,6 +35,7 @@ const-hex = { workspace = true }
 contracts = { workspace = true }
 database = { workspace = true }
 eth-domain-types = { workspace = true }
+event-bus-dto = { workspace = true }
 ethrpc = { workspace = true }
 futures = { workspace = true }
 gas-price-estimation = { workspace = true }

--- a/crates/orderbook/Cargo.toml
+++ b/crates/orderbook/Cargo.toml
@@ -35,8 +35,8 @@ const-hex = { workspace = true }
 contracts = { workspace = true }
 database = { workspace = true }
 eth-domain-types = { workspace = true }
-event-bus-dto = { workspace = true }
 ethrpc = { workspace = true }
+event-bus-dto = { workspace = true }
 futures = { workspace = true }
 gas-price-estimation = { workspace = true }
 hex-literal = { workspace = true }

--- a/crates/orderbook/src/quoter.rs
+++ b/crates/orderbook/src/quoter.rs
@@ -4,11 +4,9 @@ use {
     bigdecimal::{BigDecimal, FromPrimitive},
     chrono::{TimeZone, Utc},
     configs::{fee_factor::FeeFactor, orderbook::VolumeFeeConfig},
-    event_bus_dto::quote_requested::{
-        OrderKind as DtoOrderKind,
-        PriceQuality as DtoPriceQuality,
-        QueryFields,
-        QuoteRequestedEvent,
+    event_bus_dto::{
+        query::{OrderKind as DtoOrderKind, QueryFields},
+        quote_requested::{PriceQuality as DtoPriceQuality, QuoteRequestedEvent},
     },
     futures::stream::{BoxStream, StreamExt},
     model::{
@@ -251,18 +249,21 @@ impl QuoteHandler {
             .order_validator
             .validate_app_data(&request.app_data, &full_app_data_override)?;
 
+        let order = PreOrderData::from(request);
+        // Capture valid_to once so the value validated here is the exact value
+        // returned in the response (and, for streaming, shared by all events).
+        let valid_to = order.valid_to;
+        self.order_validator.partial_validate(order).await?;
+
+        // Emit only after validation succeeds so every `quoteRequested` event
+        // is followed by the `priceEstimate` events of the same request,
+        // keeping the two correlatable by request id without orphans.
         emit_quote_requested_event(
             request,
             sell_token_symbol,
             buy_token_symbol,
             &app_data.inner.document,
         );
-
-        let order = PreOrderData::from(request);
-        // Capture valid_to once so the value validated here is the exact value
-        // returned in the response (and, for streaming, shared by all events).
-        let valid_to = order.valid_to;
-        self.order_validator.partial_validate(order).await?;
 
         Ok((
             QuoteParameters {
@@ -313,6 +314,8 @@ fn emit_quote_requested_event(
             kind,
         },
         from: request.from.to_string(),
+        // Deliberate second parse: `appCode` lives at the document root, not in
+        // the already-parsed `ProtocolAppData`. Cheap given the 8KB app-data cap.
         app_code: ::app_data::app_code(document.as_bytes()),
         sell_token_symbol,
         buy_token_symbol,

--- a/crates/orderbook/src/quoter.rs
+++ b/crates/orderbook/src/quoter.rs
@@ -10,15 +10,8 @@ use {
     },
     futures::stream::{BoxStream, StreamExt},
     model::{
-        order::OrderCreationAppData,
-        quote::{
-            OrderQuote,
-            OrderQuoteRequest,
-            OrderQuoteResponse,
-            OrderQuoteSide,
-            PriceQuality,
-            SellAmount,
-        },
+        order::{OrderCreationAppData, OrderKind},
+        quote::{OrderQuote, OrderQuoteRequest, OrderQuoteResponse, OrderQuoteSide, PriceQuality},
     },
     price_estimation::{PriceEstimationError, Verification},
     shared::{
@@ -255,9 +248,12 @@ impl QuoteHandler {
         let valid_to = order.valid_to;
         self.order_validator.partial_validate(order).await?;
 
-        // Emit only after validation succeeds so every `quoteRequested` event
-        // is followed by the `priceEstimate` events of the same request,
-        // keeping the two correlatable by request id without orphans.
+        // Emit only after validation succeeds so we don't announce requests
+        // that never reach the estimator (invalid app-data / order data return
+        // early above). This is best-effort correlation, not a guarantee: if
+        // every estimator errors, (at the time of writing) price estimation emits no
+        // `priceEstimate` events, so a `quoteRequested` can still end up without follow
+        // up none following.
         emit_quote_requested_event(
             request,
             sell_token_symbol,
@@ -294,23 +290,17 @@ fn emit_quote_requested_event(
     buy_token_symbol: Option<String>,
     document: &str,
 ) {
-    let (in_amount, kind) = match request.side {
-        OrderQuoteSide::Sell { sell_amount } => {
-            let value = match sell_amount {
-                SellAmount::BeforeFee { value } | SellAmount::AfterFee { value } => value,
-            };
-            (value.to_string(), DtoOrderKind::Sell)
-        }
-        OrderQuoteSide::Buy {
-            buy_amount_after_fee,
-        } => (buy_amount_after_fee.to_string(), DtoOrderKind::Buy),
+    let (kind, in_amount) = request.side.kind_and_amount();
+    let kind = match kind {
+        OrderKind::Sell => DtoOrderKind::Sell,
+        OrderKind::Buy => DtoOrderKind::Buy,
     };
 
     let event = QuoteRequestedEvent {
         query: QueryFields {
             sell_token: request.sell_token.to_string(),
             buy_token: request.buy_token.to_string(),
-            in_amount,
+            in_amount: in_amount.to_string(),
             kind,
         },
         from: request.from.to_string(),

--- a/crates/orderbook/src/quoter.rs
+++ b/crates/orderbook/src/quoter.rs
@@ -4,10 +4,23 @@ use {
     bigdecimal::{BigDecimal, FromPrimitive},
     chrono::{TimeZone, Utc},
     configs::{fee_factor::FeeFactor, orderbook::VolumeFeeConfig},
+    event_bus_dto::quote_requested::{
+        OrderKind as DtoOrderKind,
+        PriceQuality as DtoPriceQuality,
+        QueryFields,
+        QuoteRequestedEvent,
+    },
     futures::stream::{BoxStream, StreamExt},
     model::{
         order::OrderCreationAppData,
-        quote::{OrderQuote, OrderQuoteRequest, OrderQuoteResponse, OrderQuoteSide, PriceQuality},
+        quote::{
+            OrderQuote,
+            OrderQuoteRequest,
+            OrderQuoteResponse,
+            OrderQuoteSide,
+            PriceQuality,
+            SellAmount,
+        },
     },
     price_estimation::{PriceEstimationError, Verification},
     shared::{
@@ -238,6 +251,13 @@ impl QuoteHandler {
             .order_validator
             .validate_app_data(&request.app_data, &full_app_data_override)?;
 
+        emit_quote_requested_event(
+            request,
+            sell_token_symbol,
+            buy_token_symbol,
+            &app_data.inner.document,
+        );
+
         let order = PreOrderData::from(request);
         // Capture valid_to once so the value validated here is the exact value
         // returned in the response (and, for streaming, shared by all events).
@@ -261,6 +281,48 @@ impl QuoteHandler {
             valid_to,
         ))
     }
+}
+
+/// Publishes a "calculating quote" event on the event bus so downstream
+/// analytics can correlate quote requests with their price estimates via the
+/// envelope's request id. Carries the app code and token symbols, which the
+/// per-estimator `priceEstimate` events don't have.
+fn emit_quote_requested_event(
+    request: &OrderQuoteRequest,
+    sell_token_symbol: Option<String>,
+    buy_token_symbol: Option<String>,
+    document: &str,
+) {
+    let (in_amount, kind) = match request.side {
+        OrderQuoteSide::Sell { sell_amount } => {
+            let value = match sell_amount {
+                SellAmount::BeforeFee { value } | SellAmount::AfterFee { value } => value,
+            };
+            (value.to_string(), DtoOrderKind::Sell)
+        }
+        OrderQuoteSide::Buy {
+            buy_amount_after_fee,
+        } => (buy_amount_after_fee.to_string(), DtoOrderKind::Buy),
+    };
+
+    let event = QuoteRequestedEvent {
+        query: QueryFields {
+            sell_token: request.sell_token.to_string(),
+            buy_token: request.buy_token.to_string(),
+            in_amount,
+            kind,
+        },
+        from: request.from.to_string(),
+        app_code: ::app_data::app_code(document.as_bytes()),
+        sell_token_symbol,
+        buy_token_symbol,
+        price_quality: match request.price_quality {
+            PriceQuality::Fast => DtoPriceQuality::Fast,
+            PriceQuality::Optimal => DtoPriceQuality::Optimal,
+            PriceQuality::Verified => DtoPriceQuality::Verified,
+        },
+    };
+    observe::event_bus::publish_event(event);
 }
 
 fn build_order_quote_response(

--- a/crates/price-estimation/src/competition/quote.rs
+++ b/crates/price-estimation/src/competition/quote.rs
@@ -10,11 +10,9 @@ use {
     },
     alloy::primitives::{Address, U256},
     anyhow::Context as _,
-    event_bus_dto::price_estimate::{
-        EstimateResult,
-        OrderKind as DtoOrderKind,
-        PriceEstimateEvent,
-        QueryFields,
+    event_bus_dto::{
+        price_estimate::{EstimateResult, PriceEstimateEvent},
+        query::{OrderKind as DtoOrderKind, QueryFields},
     },
     futures::future::{BoxFuture, FutureExt, TryFutureExt},
     model::order::OrderKind,

--- a/crates/shared/src/order_quoting.rs
+++ b/crates/shared/src/order_quoting.rs
@@ -49,16 +49,7 @@ impl QuoteParameters {
         default_quote_timeout: std::time::Duration,
         max_quote_timeout: std::time::Duration,
     ) -> price_estimation::Query {
-        let (kind, in_amount) = match self.side {
-            OrderQuoteSide::Sell {
-                sell_amount:
-                    SellAmount::BeforeFee { value: sell_amount }
-                    | SellAmount::AfterFee { value: sell_amount },
-            } => (OrderKind::Sell, sell_amount),
-            OrderQuoteSide::Buy {
-                buy_amount_after_fee,
-            } => (OrderKind::Buy, buy_amount_after_fee),
-        };
+        let (kind, in_amount) = self.side.kind_and_amount();
 
         let timeout = self
             .timeout


### PR DESCRIPTION
# Description
Starts emitting the `quoteRequested` event. Requested by analytics to better track partner behavior.

Context: https://nomevlabs.slack.com/archives/C0B2X0Q7ERK/p1782315064424599

Related to [BE-41](https://linear.app/cowswap/issue/BE-41/emit-calculating-quote-events)

# Changes

* Added new event — `quoteRequested`
* Update generated schema
* Start emitting the event

## How to test
Deploy to staging, check for events in the queue, you can find them using `nats -s localhost:4222 stream view bnb-events --subject=event.56.quoteRequested`, assuming you port forwarded one of the nats servers. The event should look like:
```
[6801470] Subject: event.56.quoteRequested Received: 2026-07-06 15:56:50
{"version":"v1","timestamp":"2026-07-06T14:56:50.551377776Z","requestId":"a8d09ffc809e7f6f2038a6ad1d3347bf","body":{"query":{"sellToken":"0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c","buyToken":"0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d","inAmount":"1000000000000000000","kind":"sell"},"from":"0x09fBAD1EA29c36Dfe4F8F7bAA87c5eDf85E0d9f3","appCode":"CoW Swap","sellTokenSymbol":"WBNB","buyTokenSymbol":"USDC","priceQuality":"optimal"}}
```
 