### PR TITLE
Emit quoteComputed event

### DIFF
--- a/crates/event-bus-dto/schemas/events.json
+++ b/crates/event-bus-dto/schemas/events.json
@@ -139,6 +139,67 @@
     "title": "Envelope",
     "type": "object"
   },
+  "quoteComputed": {
+    "$defs": {
+      "QuoteComputedEvent": {
+        "description": "Emitted once the orderbook has finished computing a quote (\"finished\ncomputing quote\"). Its main job is correlation: the envelope's `requestId`\nties it back to the [`crate::QuoteRequestedEvent`] and the per-estimator\n[`crate::PriceEstimateEvent`]s of the same request, while `quoteId` links\nforward to the resulting order via the `quotes` table.",
+        "properties": {
+          "appCode": {
+            "description": "`appCode` from the order's app-data document, if present.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "quoteId": {
+            "description": "Database id of the stored quote. Absent for `fast` quotes, which are\nnot persisted.",
+            "format": "int64",
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "verified": {
+            "description": "Whether the quote was verified by simulation.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "verified"
+        ],
+        "type": "object"
+      }
+    },
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "JSON envelope wrapping every event published to the bus. Consumers can\nrely on `version` to evolve their parsers, on `timestamp` for ordering,\nand on `requestId` to correlate events emitted while serving a single\ninbound request (e.g. all the price estimates and the resulting quote of\none quote request share the same `requestId`).",
+    "properties": {
+      "body": {
+        "$ref": "#/$defs/QuoteComputedEvent"
+      },
+      "requestId": {
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "timestamp": {
+        "description": "RFC3339 timestamp (millisecond precision, UTC) of when the event was\npublished.",
+        "format": "date-time",
+        "type": "string"
+      },
+      "version": {
+        "const": "v1",
+        "type": "string"
+      }
+    },
+    "required": [
+      "version",
+      "timestamp",
+      "body"
+    ],
+    "title": "Envelope",
+    "type": "object"
+  },
   "quoteRequested": {
     "$defs": {
       "OrderKind": {

--- a/crates/event-bus-dto/src/lib.rs
+++ b/crates/event-bus-dto/src/lib.rs
@@ -12,12 +12,14 @@
 pub mod envelope;
 pub mod price_estimate;
 pub mod query;
+pub mod quote_computed;
 pub mod quote_requested;
 
 pub use {
     envelope::{ENVELOPE_VERSION, Envelope},
     price_estimate::PriceEstimateEvent,
     query::{OrderKind, QueryFields},
+    quote_computed::QuoteComputedEvent,
     quote_requested::QuoteRequestedEvent,
 };
 use {schemars::JsonSchema, serde::Serialize};
@@ -29,19 +31,22 @@ pub trait Event: Serialize + JsonSchema {
     const SUBJECT: &'static str;
 }
 
+/// Pairs each event's NATS subject with the JSON schema of its full
+/// [`Envelope`]-wrapped wire format. Listing an event type here is all that's
+/// needed to include it in [`schemas`].
+macro_rules! event_schemas {
+    ($($event:ty),+ $(,)?) => {
+        vec![$((
+            <$event as Event>::SUBJECT,
+            schemars::schema_for!(Envelope<$event>),
+        )),+]
+    };
+}
+
 /// One entry per known event type, mapping the NATS subject to the JSON schema
 /// of the full [`Envelope`]-wrapped wire format consumers receive. Drives the
 /// CLI and any other place that needs to enumerate the full set of events
 /// (e.g. tests that pin the wire format).
 pub fn schemas() -> Vec<(&'static str, schemars::Schema)> {
-    vec![
-        (
-            PriceEstimateEvent::SUBJECT,
-            schemars::schema_for!(Envelope<PriceEstimateEvent>),
-        ),
-        (
-            QuoteRequestedEvent::SUBJECT,
-            schemars::schema_for!(Envelope<QuoteRequestedEvent>),
-        ),
-    ]
+    event_schemas![PriceEstimateEvent, QuoteRequestedEvent, QuoteComputedEvent]
 }

--- a/crates/event-bus-dto/src/quote_computed.rs
+++ b/crates/event-bus-dto/src/quote_computed.rs
@@ -1,0 +1,59 @@
+use {crate::Event, schemars::JsonSchema, serde::Serialize};
+
+/// Emitted once the orderbook has finished computing a quote ("finished
+/// computing quote"). Its main job is correlation: the envelope's `requestId`
+/// ties it back to the [`crate::QuoteRequestedEvent`] and the per-estimator
+/// [`crate::PriceEstimateEvent`]s of the same request, while `quoteId` links
+/// forward to the resulting order via the `quotes` table.
+#[derive(Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct QuoteComputedEvent {
+    /// Database id of the stored quote. Absent for `fast` quotes, which are
+    /// not persisted.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub quote_id: Option<i64>,
+    /// `appCode` from the order's app-data document, if present.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub app_code: Option<String>,
+    /// Whether the quote was verified by simulation.
+    pub verified: bool,
+}
+
+impl Event for QuoteComputedEvent {
+    const SUBJECT: &'static str = "quoteComputed";
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, serde_json::json};
+
+    #[test]
+    fn matches_wire_format() {
+        let event = QuoteComputedEvent {
+            quote_id: Some(42),
+            app_code: Some("CoW Swap".into()),
+            verified: true,
+        };
+        assert_eq!(
+            serde_json::to_value(&event).unwrap(),
+            json!({
+                "quoteId": 42,
+                "appCode": "CoW Swap",
+                "verified": true,
+            }),
+        );
+    }
+
+    #[test]
+    fn omits_missing_optionals() {
+        let event = QuoteComputedEvent {
+            quote_id: None,
+            app_code: None,
+            verified: false,
+        };
+        let value = serde_json::to_value(&event).unwrap();
+        assert!(value.get("quoteId").is_none());
+        assert!(value.get("appCode").is_none());
+        assert_eq!(value.get("verified"), Some(&json!(false)));
+    }
+}

--- a/crates/orderbook/src/quoter.rs
+++ b/crates/orderbook/src/quoter.rs
@@ -166,13 +166,19 @@ impl QuoteHandler {
         request: &OrderQuoteRequest,
     ) -> Result<BoxStream<'static, Result<OrderQuoteResponse, OrderQuoteError>>, OrderQuoteError>
     {
-        let (params, valid_to) = self.build_quote_params(request).await?;
-
+        // Resolve the streaming quoter before `build_quote_params` so a
+        // misconfigured endpoint fails fast without emitting a `quoteRequested`
+        // event that could never be followed by a `quoteComputed`.
         let streaming = self.streaming_quoter.clone().ok_or_else(|| {
             OrderQuoteError::CalculateQuote(
                 anyhow::anyhow!("streaming quoter not configured").into(),
             )
         })?;
+
+        let (params, valid_to) = self.build_quote_params(request).await?;
+        // Captured before `params` is consumed below; the document isn't
+        // available on the response.
+        let app_code = ::app_data::app_code(params.verification.app_data.as_bytes());
 
         let inner = streaming.calculate_quote_stream(params).await?;
 
@@ -207,6 +213,14 @@ impl QuoteHandler {
                 match response {
                     Ok(response) => {
                         any_ok = true;
+                        // One event per streamed quote so streaming requests get a
+                        // `quoteComputed` counterpart to their `quoteRequested`, just
+                        // like the one-shot endpoint.
+                        observe::event_bus::publish_event(QuoteComputedEvent {
+                            quote_id: response.id,
+                            app_code: app_code.clone(),
+                            verified: response.verified,
+                        });
                         yield Ok(response);
                     }
                     Err(err) => tracing::debug!(%err, "dropping unconvertible streamed quote"),

--- a/crates/orderbook/src/quoter.rs
+++ b/crates/orderbook/src/quoter.rs
@@ -6,6 +6,7 @@ use {
     configs::{fee_factor::FeeFactor, orderbook::VolumeFeeConfig},
     event_bus_dto::{
         query::{OrderKind as DtoOrderKind, QueryFields},
+        quote_computed::QuoteComputedEvent,
         quote_requested::{PriceQuality as DtoPriceQuality, QuoteRequestedEvent},
     },
     futures::stream::{BoxStream, StreamExt},
@@ -119,6 +120,9 @@ impl QuoteHandler {
         request: &OrderQuoteRequest,
     ) -> Result<OrderQuoteResponse, OrderQuoteError> {
         let (params, valid_to) = self.build_quote_params(request).await?;
+        // Captured before `params` is consumed below; the document isn't
+        // available on the response.
+        let app_code = ::app_data::app_code(params.verification.app_data.as_bytes());
 
         let quote = match request.price_quality {
             PriceQuality::Optimal | PriceQuality::Verified => {
@@ -149,6 +153,11 @@ impl QuoteHandler {
 
         let response = build_order_quote_response(request, &quote, &adjusted, quote.id, valid_to)?;
         tracing::debug!(?response, "finished computing quote");
+        observe::event_bus::publish_event(QuoteComputedEvent {
+            quote_id: response.id,
+            app_code,
+            verified: response.verified,
+        });
         Ok(response)
     }
 


### PR DESCRIPTION
# Description
Starts emitting the `quoteComputed` event. As requested by Nitish.

Context: https://nomevlabs.slack.com/archives/C0B2X0Q7ERK/p1782315064424599

Related to [BE-43](https://linear.app/cowswap/issue/BE-43/add-finished-computing-quote-events)

# Changes

* Added new event — `quoteComputed`
* Update generated schema
* Start emitting the event

## How to test

Ran on staging, event looks like
```
[6927305] Subject: event.56.quoteComputed Received: 2026-07-07 15:48:59
{"version":"v1","timestamp":"2026-07-07T14:48:59.375243086Z","requestId":"8fd96f0c07d907fe6bdafda349d11112","body":{"quoteId":3011584,"appCode":"CoW Swap","verified":true}}
```