### PR TITLE
feat(simulator): opt-in state-override stream for pAMM-aware settlement simulation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4542,6 +4542,7 @@ dependencies = [
  "axum 0.8.8",
  "balance-overrides",
  "bigdecimal",
+ "chain",
  "chrono",
  "clap",
  "configs",
@@ -4553,6 +4554,7 @@ dependencies = [
  "eth-domain-types",
  "ethrpc",
  "futures",
+ "gas-price-estimation",
  "hex-literal",
  "itertools 0.14.0",
  "liquidity-sources",
@@ -9293,6 +9295,7 @@ dependencies = [
  "testlib",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-tungstenite",
  "tracing",
  "url",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,6 +145,7 @@ time = "0.3.47"
 token-info = { path = "crates/token-info" }
 tokio = { version = "1.38.0", features = ["tracing"] }
 tokio-stream = { version = "0.1.15", features = ["sync"] }
+tokio-tungstenite = { version = "0.28", default-features = false }
 toml = "0.8.14"
 tower = "0.5"
 tower-http = "0.6"

--- a/crates/configs/src/price_estimation.rs
+++ b/crates/configs/src/price_estimation.rs
@@ -109,6 +109,14 @@ pub struct PriceEstimation {
     #[serde(default)]
     pub tenderly: Option<crate::simulator::TenderlyConfig>,
 
+    /// Optional background websocket stream of eth_call-style state override
+    /// sets, applied during quote/trade verification simulation. Same wire
+    /// format and semantics as the driver's
+    /// `[simulator.state-override-stream]`. When absent, no stream task is
+    /// spawned and behavior is unchanged.
+    #[serde(default)]
+    pub state_override_stream: Option<crate::simulator::StateOverrideStream>,
+
     /// The CoinGecko native price configuration.
     pub coin_gecko: Option<CoinGeckoConfig>,
 
@@ -120,6 +128,7 @@ impl Default for PriceEstimation {
     fn default() -> Self {
         Self {
             tenderly: Default::default(),
+            state_override_stream: Default::default(),
             price_estimation_rate_limiter: None,
             amount_to_estimate_prices_with: None,
             one_inch: Default::default(),

--- a/crates/configs/src/simulator.rs
+++ b/crates/configs/src/simulator.rs
@@ -33,15 +33,13 @@ pub struct Config {
 
     /// Optional background websocket stream of eth_call-style state override
     /// sets, applied on top of latest state during settlement gas estimation.
-    /// When absent, no stream task is spawned and behavior is unchanged.
     #[serde(default)]
     pub state_override_stream: Option<StateOverrideStream>,
 }
 
 /// Configuration for a background websocket stream delivering eth_call-style
-/// state override sets (the standard Ethereum State Override Set wire format),
-/// so live-quote venues (e.g. pAMMs) simulate against current in-memory state
-/// rather than stale previous-block state.
+/// state overrides, so live-quote venues (e.g. pAMMs) simulate against current
+/// in-memory state rather than stale previous-block state.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct StateOverrideStream {

--- a/crates/configs/src/simulator.rs
+++ b/crates/configs/src/simulator.rs
@@ -51,19 +51,10 @@ pub struct StateOverrideStream {
     /// Ignore the snapshot if the last frame is older than this.
     #[serde(with = "humantime_serde", default = "default_override_max_age")]
     pub max_age: Duration,
-
-    /// Ignore the snapshot if its block number lags the current head by more
-    /// than this many blocks.
-    #[serde(default = "default_override_max_block_lag")]
-    pub max_block_lag: u64,
 }
 
 const fn default_override_max_age() -> Duration {
     Duration::from_secs(3)
-}
-
-const fn default_override_max_block_lag() -> u64 {
-    1
 }
 
 fn default_ethrpc_batch_delay() -> Duration {
@@ -258,7 +249,6 @@ mod tests {
         let stream = config.state_override_stream.unwrap();
         assert_eq!(stream.ws_url.as_str(), "wss://example.com/stream");
         assert_eq!(stream.max_age, Duration::from_secs(3));
-        assert_eq!(stream.max_block_lag, 1);
     }
 
     #[test]
@@ -267,12 +257,10 @@ mod tests {
         [state-override-stream]
         ws-url = "wss://example.com/stream"
         max-age = "5s"
-        max-block-lag = 2
         "#;
         let config: Config = toml::from_str(toml).unwrap();
         let stream = config.state_override_stream.unwrap();
         assert_eq!(stream.max_age, Duration::from_secs(5));
-        assert_eq!(stream.max_block_lag, 2);
     }
 
     #[test]

--- a/crates/configs/src/simulator.rs
+++ b/crates/configs/src/simulator.rs
@@ -30,6 +30,40 @@ pub struct Config {
     /// - tenderly (using TenderlyConfig)
     #[serde(default)]
     pub kind: SimulatorKind,
+
+    /// Optional background websocket stream of eth_call-style state override
+    /// sets, applied on top of latest state during settlement gas estimation.
+    /// When absent, no stream task is spawned and behavior is unchanged.
+    #[serde(default)]
+    pub state_override_stream: Option<StateOverrideStream>,
+}
+
+/// Configuration for a background websocket stream delivering eth_call-style
+/// state override sets (the standard Ethereum State Override Set wire format),
+/// so live-quote venues (e.g. pAMMs) simulate against current in-memory state
+/// rather than stale previous-block state.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct StateOverrideStream {
+    /// Websocket URL pushing JSON frames of eth_call-style state overrides.
+    pub ws_url: Url,
+
+    /// Ignore the snapshot if the last frame is older than this.
+    #[serde(with = "humantime_serde", default = "default_override_max_age")]
+    pub max_age: Duration,
+
+    /// Ignore the snapshot if its block number lags the current head by more
+    /// than this many blocks.
+    #[serde(default = "default_override_max_block_lag")]
+    pub max_block_lag: u64,
+}
+
+const fn default_override_max_age() -> Duration {
+    Duration::from_secs(3)
+}
+
+const fn default_override_max_block_lag() -> u64 {
+    1
 }
 
 fn default_ethrpc_batch_delay() -> Duration {
@@ -206,5 +240,48 @@ mod tests {
             }
             _ => panic!("Config should be of type Tenderly"),
         };
+    }
+
+    #[test]
+    fn deserialize_state_override_stream_absent_by_default() {
+        let config: Config = toml::from_str("").unwrap();
+        assert!(config.state_override_stream.is_none());
+    }
+
+    #[test]
+    fn deserialize_state_override_stream_with_defaults() {
+        let toml = r#"
+        [state-override-stream]
+        ws-url = "wss://example.com/stream"
+        "#;
+        let config: Config = toml::from_str(toml).unwrap();
+        let stream = config.state_override_stream.unwrap();
+        assert_eq!(stream.ws_url.as_str(), "wss://example.com/stream");
+        assert_eq!(stream.max_age, Duration::from_secs(3));
+        assert_eq!(stream.max_block_lag, 1);
+    }
+
+    #[test]
+    fn deserialize_state_override_stream_full() {
+        let toml = r#"
+        [state-override-stream]
+        ws-url = "wss://example.com/stream"
+        max-age = "5s"
+        max-block-lag = 2
+        "#;
+        let config: Config = toml::from_str(toml).unwrap();
+        let stream = config.state_override_stream.unwrap();
+        assert_eq!(stream.max_age, Duration::from_secs(5));
+        assert_eq!(stream.max_block_lag, 2);
+    }
+
+    #[test]
+    fn deserialize_state_override_stream_rejects_unknown_fields() {
+        let toml = r#"
+        [state-override-stream]
+        ws-url = "wss://example.com/stream"
+        bogus = true
+        "#;
+        assert!(toml::from_str::<Config>(toml).is_err());
     }
 }

--- a/crates/configs/src/simulator.rs
+++ b/crates/configs/src/simulator.rs
@@ -54,7 +54,7 @@ pub struct StateOverrideStream {
 }
 
 const fn default_override_max_age() -> Duration {
-    Duration::from_secs(3)
+    Duration::from_secs(5)
 }
 
 fn default_ethrpc_batch_delay() -> Duration {
@@ -248,7 +248,7 @@ mod tests {
         let config: Config = toml::from_str(toml).unwrap();
         let stream = config.state_override_stream.unwrap();
         assert_eq!(stream.ws_url.as_str(), "wss://example.com/stream");
-        assert_eq!(stream.max_age, Duration::from_secs(3));
+        assert_eq!(stream.max_age, Duration::from_secs(5));
     }
 
     #[test]

--- a/crates/driver/example.toml
+++ b/crates/driver/example.toml
@@ -120,4 +120,3 @@ max-order-age = "1m"
 # # >=1.13, reth, nethermind, recent erigon, anvil).
 # ws-url = "wss://eu.rpc.titanbuilder.xyz/ws/pamm_quote_stream"
 # max-age = "3s"        # ignore the snapshot if the last frame is older than this
-# max-block-lag = 1     # ignore the snapshot if its block number lags head by more than this

--- a/crates/driver/example.toml
+++ b/crates/driver/example.toml
@@ -112,11 +112,9 @@ max-order-age = "1m"
 # api-key = "..."
 # http_timeout = "10s"
 
-# [simulator.state-override-stream] # Optional background websocket stream of
-# # eth_call-style state override sets (standard Ethereum State Override Set wire
-# # format), so live-quote venues (e.g. pAMMs) simulate against current in-memory
-# # state. When absent, no stream task is spawned and behavior is unchanged.
-# # Requires a node supporting eth_estimateGas state/block overrides (geth
-# # >=1.13, reth, nethermind, recent erigon, anvil).
+# Optional background websocket stream of # eth_call-style state overrides,
+# so live-quote venues (e.g. pAMMs) simulate against current in-memory state.
+# When absent, no stream task is spawned and behavior is unchanged.
+# [simulator.state-override-stream]
 # ws-url = "wss://eu.rpc.titanbuilder.xyz/ws/pamm_quote_stream"
-# max-age = "5s"        # ignore the snapshot if the last frame is older than this
+# max-age = "5s" # ignore the snapshot if the last frame is older than this

--- a/crates/driver/example.toml
+++ b/crates/driver/example.toml
@@ -119,4 +119,4 @@ max-order-age = "1m"
 # # Requires a node supporting eth_estimateGas state/block overrides (geth
 # # >=1.13, reth, nethermind, recent erigon, anvil).
 # ws-url = "wss://eu.rpc.titanbuilder.xyz/ws/pamm_quote_stream"
-# max-age = "3s"        # ignore the snapshot if the last frame is older than this
+# max-age = "5s"        # ignore the snapshot if the last frame is older than this

--- a/crates/driver/example.toml
+++ b/crates/driver/example.toml
@@ -111,3 +111,13 @@ max-order-age = "1m"
 # base-url = "https://api.liquorice.tech/"
 # api-key = "..."
 # http_timeout = "10s"
+
+# [simulator.state-override-stream] # Optional background websocket stream of
+# # eth_call-style state override sets (standard Ethereum State Override Set wire
+# # format), so live-quote venues (e.g. pAMMs) simulate against current in-memory
+# # state. When absent, no stream task is spawned and behavior is unchanged.
+# # Requires a node supporting eth_estimateGas state/block overrides (geth
+# # >=1.13, reth, nethermind, recent erigon, anvil).
+# ws-url = "wss://eu.rpc.titanbuilder.xyz/ws/pamm_quote_stream"
+# max-age = "3s"        # ignore the snapshot if the last frame is older than this
+# max-block-lag = 1     # ignore the snapshot if its block number lags head by more than this

--- a/crates/driver/src/domain/competition/solution/settlement.rs
+++ b/crates/driver/src/domain/competition/solution/settlement.rs
@@ -350,14 +350,11 @@ async fn partial_access_list_for(
     if !trade.order().buys_eth() || !trade.order().pays_to_contract(eth).await? {
         return Ok(None);
     }
-    let tx = eth::Tx {
-        from: solution.solver().address(),
-        to: trade.order().receiver(),
-        value: 1.into(),
-        input: Default::default(),
-        access_list: Default::default(),
-    };
-    Ok(Some(RequiredAccessList(simulator.access_list(&tx).await?)))
+    Ok(Some(RequiredAccessList(
+        simulator
+            .access_list_for_eth_transfer(solution.solver().address(), trade.order().receiver())
+            .await?,
+    )))
 }
 
 /// Should the interactions be internalized?

--- a/crates/driver/src/run.rs
+++ b/crates/driver/src/run.rs
@@ -162,7 +162,6 @@ fn simulator(
     eth: simulator::Ethereum,
     http_factory: &HttpClientFactory,
 ) -> Simulator {
-    let block_time = eth.chain().block_time_in_ms();
     let block_stream = eth.current_block().clone();
     let mut simulator = match &config.simulator {
         configs::simulator::Config {
@@ -182,11 +181,8 @@ fn simulator(
         simulator.disable_gas(gas);
     }
     if let Some(cfg) = &config.simulator.state_override_stream {
-        simulator.set_simulation_overrides(simulator::state_override_stream::spawn(
-            cfg,
-            block_stream,
-            block_time,
-        ));
+        simulator
+            .set_simulation_overrides(simulator::state_override_stream::spawn(cfg, block_stream));
     }
 
     simulator

--- a/crates/driver/src/run.rs
+++ b/crates/driver/src/run.rs
@@ -162,6 +162,8 @@ fn simulator(
     eth: simulator::Ethereum,
     http_factory: &HttpClientFactory,
 ) -> Simulator {
+    let block_time = eth.chain().block_time_in_ms();
+    let block_stream = eth.current_block().clone();
     let mut simulator = match &config.simulator {
         configs::simulator::Config {
             kind: configs::simulator::SimulatorKind::Tenderly(config),
@@ -178,6 +180,13 @@ fn simulator(
     }
     if let Some(gas) = config.disable_gas_simulation {
         simulator.disable_gas(gas);
+    }
+    if let Some(cfg) = &config.simulator.state_override_stream {
+        simulator.set_simulation_overrides(simulator::state_override_stream::spawn(
+            cfg,
+            block_stream,
+            block_time,
+        ));
     }
 
     simulator

--- a/crates/e2e/Cargo.toml
+++ b/crates/e2e/Cargo.toml
@@ -36,6 +36,7 @@ autopilot = { workspace = true, features = ["test-util"] }
 axum = { workspace = true }
 balance-overrides = { workspace = true }
 bigdecimal = { workspace = true }
+chain = { workspace = true }
 chrono = { workspace = true }
 clap = { workspace = true }
 configs = { workspace = true, features = ["test-util"] }
@@ -47,6 +48,7 @@ driver = { workspace = true }
 eth-domain-types = { workspace = true }
 ethrpc = { workspace = true, features = ["test-util"] }
 futures = { workspace = true }
+gas-price-estimation = { workspace = true }
 hex-literal = { workspace = true }
 itertools = { workspace = true }
 liquidity-sources = { workspace = true }

--- a/crates/e2e/tests/e2e/main.rs
+++ b/crates/e2e/tests/e2e/main.rs
@@ -41,6 +41,7 @@ mod refunder;
 mod replace_order;
 mod smart_contract_orders;
 mod solver_competition;
+mod state_override;
 mod submission;
 mod token_metadata;
 mod tracking_insufficient_funds;

--- a/crates/e2e/tests/e2e/state_override.rs
+++ b/crates/e2e/tests/e2e/state_override.rs
@@ -3,7 +3,6 @@ use {
         primitives::{Address, B256, U256, address, hex, map::B256Map},
         providers::{Provider, ProviderBuilder},
         rpc::types::{
-            BlockOverrides,
             TransactionRequest,
             state::{AccountOverride, StateOverride},
         },
@@ -83,45 +82,18 @@ async fn local_node_estimate_gas_state_override() {
     let contract = deploy().await;
     let eth = ethereum().await;
 
-    let without = eth.estimate_gas(gate_call(contract), None, None).await;
+    let without = eth.estimate_gas(gate_call(contract), None).await;
     assert!(
         without.is_err(),
         "gate() should revert without the slot-0 override, got {without:?}",
     );
 
     let with = eth
-        .estimate_gas(gate_call(contract), Some(slot0_override(contract)), None)
+        .estimate_gas(gate_call(contract), Some(slot0_override(contract)))
         .await;
     assert!(
         with.is_ok(),
         "gate() should succeed with the slot-0 override, got {with:?}",
-    );
-
-    node.kill().await;
-}
-
-#[tokio::test]
-#[ignore = "requires anvil; run via `just test-e2e local_node_estimate_gas_block_overrides`"]
-async fn local_node_estimate_gas_block_overrides() {
-    let mut node = Node::new().await;
-    let contract = deploy().await;
-    let eth = ethereum().await;
-
-    let block_overrides = BlockOverrides {
-        number: Some(U256::from(42)),
-        time: Some(17),
-        ..Default::default()
-    };
-    let with_state_and_block = eth
-        .estimate_gas(
-            gate_call(contract),
-            Some(slot0_override(contract)),
-            Some(block_overrides),
-        )
-        .await;
-    assert!(
-        with_state_and_block.is_ok(),
-        "estimate_gas should accept block overrides, got {with_state_and_block:?}",
     );
 
     node.kill().await;

--- a/crates/e2e/tests/e2e/state_override.rs
+++ b/crates/e2e/tests/e2e/state_override.rs
@@ -1,35 +1,31 @@
 use {
     alloy::{
-        primitives::{Address, B256, U256, address, hex, map::B256Map},
-        providers::{Provider, ProviderBuilder},
+        primitives::{Address, B256, Bytes, TxKind, U256, b256, bytes, map::B256Map},
+        providers::Provider,
         rpc::types::{
             TransactionRequest,
             state::{AccountOverride, StateOverride},
         },
     },
     chain::Chain,
-    e2e::nodes::{NODE_HOST, Node},
-    ethrpc::Web3,
+    e2e::setup::run_test,
+    ethrpc::{AlloyProvider, Web3},
     gas_price_estimation::FakeGasPriceEstimator,
     simulator::Ethereum,
-    std::{str::FromStr, sync::Arc},
+    std::sync::Arc,
 };
 
 /// Runtime bytecode of a contract that reverts in `gate()` (selector
 /// `0x7a0ebc88`) unless storage slot 0 is nonzero. Compiled with forge.
-const SLOT_GATE_INIT: &str = "0x6080604052348015600e575f5ffd5b506101238061001c5f395ff3fe6080604052348015600e575f5ffd5b50600436106026575f3560e01c80637a0ebc8814602a575b5f5ffd5b60306032565b005b5f5f5490505f5f1b81036078576040517f08c379a0000000000000000000000000000000000000000000000000000000008152600401606f9060d1565b60405180910390fd5b50565b5f82825260208201905092915050565b7f736c6f74207a65726f00000000000000000000000000000000000000000000005f82015250565b5f60bd600983607b565b915060c682608b565b602082019050919050565b5f6020820190508181035f83015260e68160b3565b905091905056fea2646970667358221220538cd705c3b870d0412519ce867cae3b5484bd1b0acf57a8ec779199e45097ec64736f6c634300081c0033";
-const GATE_SELECTOR: &str = "0x7a0ebc88";
-const DEFAULT_SENDER: Address = address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
-const SLOT_0: &str = "0x0000000000000000000000000000000000000000000000000000000000000000";
+const SLOT_GATE_INIT: Bytes = bytes!("6080604052348015600e575f5ffd5b506101238061001c5f395ff3fe6080604052348015600e575f5ffd5b50600436106026575f3560e01c80637a0ebc8814602a575b5f5ffd5b60306032565b005b5f5f5490505f5f1b81036078576040517f08c379a0000000000000000000000000000000000000000000000000000000008152600401606f9060d1565b60405180910390fd5b50565b5f82825260208201905092915050565b7f736c6f74207a65726f00000000000000000000000000000000000000000000005f82015250565b5f60bd600983607b565b915060c682608b565b602082019050919050565b5f6020820190508181035f83015260e68160b3565b905091905056fea2646970667358221220538cd705c3b870d0412519ce867cae3b5484bd1b0acf57a8ec779199e45097ec64736f6c634300081c0033");
+const GATE_SELECTOR: Bytes = bytes!("7a0ebc88");
+const SLOT_0: B256 = b256!("0x0000000000000000000000000000000000000000000000000000000000000000");
 
-async fn deploy() -> Address {
-    let provider = ProviderBuilder::new().connect_http(NODE_HOST.parse().unwrap());
+async fn deploy(provider: &AlloyProvider) -> Address {
     let tx = TransactionRequest {
-        from: Some(DEFAULT_SENDER),
-        input: hex::decode(SLOT_GATE_INIT.trim_start_matches("0x"))
-            .unwrap()
-            .into(),
+        input: SLOT_GATE_INIT.into(),
         gas: Some(0x200000),
+        to: Some(TxKind::Create),
         ..Default::default()
     };
     let pending = provider.send_transaction(tx).await.unwrap();
@@ -39,19 +35,16 @@ async fn deploy() -> Address {
 
 fn gate_call(to: Address) -> TransactionRequest {
     TransactionRequest {
-        from: Some(DEFAULT_SENDER),
         to: Some(to.into()),
-        input: hex::decode(GATE_SELECTOR.trim_start_matches("0x"))
-            .unwrap()
-            .into(),
+        input: GATE_SELECTOR.into(),
         ..Default::default()
     }
 }
 
-fn slot0_override(contract: Address) -> StateOverride {
+fn unlock_override(contract: Address) -> StateOverride {
     let mut override_map = StateOverride::default();
     let mut diff = B256Map::default();
-    diff.insert(B256::from_str(SLOT_0).unwrap(), B256::from(U256::from(1)));
+    diff.insert(SLOT_0, B256::with_last_byte(1));
     override_map.insert(
         contract,
         AccountOverride {
@@ -62,8 +55,7 @@ fn slot0_override(contract: Address) -> StateOverride {
     override_map
 }
 
-async fn ethereum() -> Ethereum {
-    let web3 = Web3::new_from_url(NODE_HOST);
+async fn ethereum(web3: Web3) -> Ethereum {
     let block_stream = ethrpc::block_stream::mock_single_block(Default::default());
     Ethereum::new(
         web3,
@@ -76,25 +68,29 @@ async fn ethereum() -> Ethereum {
 }
 
 #[tokio::test]
-#[ignore = "requires anvil; run via `just test-e2e local_node_estimate_gas_state_override`"]
+#[ignore]
 async fn local_node_estimate_gas_state_override() {
-    let mut node = Node::new().await;
-    let contract = deploy().await;
-    let eth = ethereum().await;
+    run_test(estimate_gas_state_override).await;
+}
 
-    let without = eth.estimate_gas(gate_call(contract), None).await;
+async fn estimate_gas_state_override(web3: Web3) {
+    let gated_contract = deploy(&web3.provider).await;
+    let eth = ethereum(web3).await;
+
+    let without = eth.estimate_gas(gate_call(gated_contract), None).await;
     assert!(
         without.is_err(),
         "gate() should revert without the slot-0 override, got {without:?}",
     );
 
     let with = eth
-        .estimate_gas(gate_call(contract), Some(slot0_override(contract)))
+        .estimate_gas(
+            gate_call(gated_contract),
+            Some(unlock_override(gated_contract)),
+        )
         .await;
     assert!(
         with.is_ok(),
         "gate() should succeed with the slot-0 override, got {with:?}",
     );
-
-    node.kill().await;
 }

--- a/crates/e2e/tests/e2e/state_override.rs
+++ b/crates/e2e/tests/e2e/state_override.rs
@@ -1,56 +1,29 @@
 use {
     alloy::{
-        primitives::{Address, B256, Bytes, TxKind, U256, b256, bytes, map::B256Map},
-        providers::Provider,
-        rpc::types::{
-            TransactionRequest,
-            state::{AccountOverride, StateOverride},
-        },
+        primitives::{Address, B256, U256},
+        rpc::types::state::{AccountOverride, StateOverride},
+        sol,
     },
     chain::Chain,
     e2e::setup::run_test,
-    ethrpc::{AlloyProvider, Web3},
+    ethrpc::Web3,
     gas_price_estimation::FakeGasPriceEstimator,
     simulator::Ethereum,
     std::sync::Arc,
 };
 
-/// Runtime bytecode of a contract that reverts in `gate()` (selector
-/// `0x7a0ebc88`) unless storage slot 0 is nonzero. Compiled with forge.
-const SLOT_GATE_INIT: Bytes = bytes!("6080604052348015600e575f5ffd5b506101238061001c5f395ff3fe6080604052348015600e575f5ffd5b50600436106026575f3560e01c80637a0ebc8814602a575b5f5ffd5b60306032565b005b5f5f5490505f5f1b81036078576040517f08c379a0000000000000000000000000000000000000000000000000000000008152600401606f9060d1565b60405180910390fd5b50565b5f82825260208201905092915050565b7f736c6f74207a65726f00000000000000000000000000000000000000000000005f82015250565b5f60bd600983607b565b915060c682608b565b602082019050919050565b5f6020820190508181035f83015260e68160b3565b905091905056fea2646970667358221220538cd705c3b870d0412519ce867cae3b5484bd1b0acf57a8ec779199e45097ec64736f6c634300081c0033");
-const GATE_SELECTOR: Bytes = bytes!("7a0ebc88");
-const SLOT_0: B256 = b256!("0x0000000000000000000000000000000000000000000000000000000000000000");
-
-async fn deploy(provider: &AlloyProvider) -> Address {
-    let tx = TransactionRequest {
-        input: SLOT_GATE_INIT.into(),
-        gas: Some(0x200000),
-        to: Some(TxKind::Create),
-        ..Default::default()
-    };
-    let pending = provider.send_transaction(tx).await.unwrap();
-    let receipt = pending.get_receipt().await.unwrap();
-    receipt.contract_address.unwrap()
-}
-
-fn gate_call(to: Address) -> TransactionRequest {
-    TransactionRequest {
-        to: Some(to.into()),
-        input: GATE_SELECTOR.into(),
-        ..Default::default()
+sol! {
+    #[sol(rpc, bytecode="6080604052348015600e575f5ffd5b506101238061001c5f395ff3fe6080604052348015600e575f5ffd5b50600436106026575f3560e01c80637a0ebc8814602a575b5f5ffd5b60306032565b005b5f5f5490505f5f1b81036078576040517f08c379a0000000000000000000000000000000000000000000000000000000008152600401606f9060d1565b60405180910390fd5b50565b5f82825260208201905092915050565b7f736c6f74207a65726f00000000000000000000000000000000000000000000005f82015250565b5f60bd600983607b565b915060c682608b565b602082019050919050565b5f6020820190508181035f83015260e68160b3565b905091905056fea2646970667358221220538cd705c3b870d0412519ce867cae3b5484bd1b0acf57a8ec779199e45097ec64736f6c634300081c0033")]
+    contract Gate {
+        function gate() { /*revert if slot_0 is 0*/ }
     }
 }
 
 fn unlock_override(contract: Address) -> StateOverride {
     let mut override_map = StateOverride::default();
-    let mut diff = B256Map::default();
-    diff.insert(SLOT_0, B256::with_last_byte(1));
     override_map.insert(
         contract,
-        AccountOverride {
-            state_diff: Some(diff),
-            ..Default::default()
-        },
+        AccountOverride::default().with_state_diff([(B256::ZERO, B256::with_last_byte(1))]),
     );
     override_map
 }
@@ -74,20 +47,21 @@ async fn local_node_estimate_gas_state_override() {
 }
 
 async fn estimate_gas_state_override(web3: Web3) {
-    let gated_contract = deploy(&web3.provider).await;
+    let gated_contract = Gate::GateInstance::deploy(web3.provider.clone())
+        .await
+        .unwrap();
+
     let eth = ethereum(web3).await;
 
-    let without = eth.estimate_gas(gate_call(gated_contract), None).await;
+    let gated_call = gated_contract.gate().into_transaction_request();
+    let without = eth.estimate_gas(gated_call.clone(), None).await;
     assert!(
         without.is_err(),
         "gate() should revert without the slot-0 override, got {without:?}",
     );
 
     let with = eth
-        .estimate_gas(
-            gate_call(gated_contract),
-            Some(unlock_override(gated_contract)),
-        )
+        .estimate_gas(gated_call, Some(unlock_override(*gated_contract.address())))
         .await;
     assert!(
         with.is_ok(),

--- a/crates/e2e/tests/e2e/state_override.rs
+++ b/crates/e2e/tests/e2e/state_override.rs
@@ -1,0 +1,128 @@
+use {
+    alloy::{
+        primitives::{Address, B256, U256, address, hex, map::B256Map},
+        providers::{Provider, ProviderBuilder},
+        rpc::types::{
+            BlockOverrides,
+            TransactionRequest,
+            state::{AccountOverride, StateOverride},
+        },
+    },
+    chain::Chain,
+    e2e::nodes::{NODE_HOST, Node},
+    ethrpc::Web3,
+    gas_price_estimation::FakeGasPriceEstimator,
+    simulator::Ethereum,
+    std::{str::FromStr, sync::Arc},
+};
+
+/// Runtime bytecode of a contract that reverts in `gate()` (selector
+/// `0x7a0ebc88`) unless storage slot 0 is nonzero. Compiled with forge.
+const SLOT_GATE_INIT: &str = "0x6080604052348015600e575f5ffd5b506101238061001c5f395ff3fe6080604052348015600e575f5ffd5b50600436106026575f3560e01c80637a0ebc8814602a575b5f5ffd5b60306032565b005b5f5f5490505f5f1b81036078576040517f08c379a0000000000000000000000000000000000000000000000000000000008152600401606f9060d1565b60405180910390fd5b50565b5f82825260208201905092915050565b7f736c6f74207a65726f00000000000000000000000000000000000000000000005f82015250565b5f60bd600983607b565b915060c682608b565b602082019050919050565b5f6020820190508181035f83015260e68160b3565b905091905056fea2646970667358221220538cd705c3b870d0412519ce867cae3b5484bd1b0acf57a8ec779199e45097ec64736f6c634300081c0033";
+const GATE_SELECTOR: &str = "0x7a0ebc88";
+const DEFAULT_SENDER: Address = address!("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+const SLOT_0: &str = "0x0000000000000000000000000000000000000000000000000000000000000000";
+
+async fn deploy() -> Address {
+    let provider = ProviderBuilder::new().connect_http(NODE_HOST.parse().unwrap());
+    let tx = TransactionRequest {
+        from: Some(DEFAULT_SENDER),
+        input: hex::decode(SLOT_GATE_INIT.trim_start_matches("0x"))
+            .unwrap()
+            .into(),
+        gas: Some(0x200000),
+        ..Default::default()
+    };
+    let pending = provider.send_transaction(tx).await.unwrap();
+    let receipt = pending.get_receipt().await.unwrap();
+    receipt.contract_address.unwrap()
+}
+
+fn gate_call(to: Address) -> TransactionRequest {
+    TransactionRequest {
+        from: Some(DEFAULT_SENDER),
+        to: Some(to.into()),
+        input: hex::decode(GATE_SELECTOR.trim_start_matches("0x"))
+            .unwrap()
+            .into(),
+        ..Default::default()
+    }
+}
+
+fn slot0_override(contract: Address) -> StateOverride {
+    let mut override_map = StateOverride::default();
+    let mut diff = B256Map::default();
+    diff.insert(B256::from_str(SLOT_0).unwrap(), B256::from(U256::from(1)));
+    override_map.insert(
+        contract,
+        AccountOverride {
+            state_diff: Some(diff),
+            ..Default::default()
+        },
+    );
+    override_map
+}
+
+async fn ethereum() -> Ethereum {
+    let web3 = Web3::new_from_url(NODE_HOST);
+    let block_stream = ethrpc::block_stream::mock_single_block(Default::default());
+    Ethereum::new(
+        web3,
+        Chain::Mainnet,
+        configs::simulator::Addresses::default(),
+        Arc::new(FakeGasPriceEstimator::default()),
+        block_stream,
+        U256::from(30_000_000),
+    )
+}
+
+#[tokio::test]
+#[ignore = "requires anvil; run via `just test-e2e local_node_estimate_gas_state_override`"]
+async fn local_node_estimate_gas_state_override() {
+    let mut node = Node::new().await;
+    let contract = deploy().await;
+    let eth = ethereum().await;
+
+    let without = eth.estimate_gas(gate_call(contract), None, None).await;
+    assert!(
+        without.is_err(),
+        "gate() should revert without the slot-0 override, got {without:?}",
+    );
+
+    let with = eth
+        .estimate_gas(gate_call(contract), Some(slot0_override(contract)), None)
+        .await;
+    assert!(
+        with.is_ok(),
+        "gate() should succeed with the slot-0 override, got {with:?}",
+    );
+
+    node.kill().await;
+}
+
+#[tokio::test]
+#[ignore = "requires anvil; run via `just test-e2e local_node_estimate_gas_block_overrides`"]
+async fn local_node_estimate_gas_block_overrides() {
+    let mut node = Node::new().await;
+    let contract = deploy().await;
+    let eth = ethereum().await;
+
+    let block_overrides = BlockOverrides {
+        number: Some(U256::from(42)),
+        time: Some(17),
+        ..Default::default()
+    };
+    let with_state_and_block = eth
+        .estimate_gas(
+            gate_call(contract),
+            Some(slot0_override(contract)),
+            Some(block_overrides),
+        )
+        .await;
+    assert!(
+        with_state_and_block.is_ok(),
+        "estimate_gas should accept block overrides, got {with_state_and_block:?}",
+    );
+
+    node.kill().await;
+}

--- a/crates/price-estimation/src/factory.rs
+++ b/crates/price-estimation/src/factory.rs
@@ -119,13 +119,10 @@ impl<'a> PriceEstimatorFactory<'a> {
         });
         let settlement_contract =
             GPv2Settlement::GPv2Settlement::new(network.settlement, web3.provider.clone());
-        let simulation_overrides = args.state_override_stream.as_ref().map(|cfg| {
-            simulator::state_override_stream::spawn(
-                cfg,
-                network.block_stream.clone(),
-                network.chain.block_time_in_ms(),
-            )
-        });
+        let simulation_overrides = args
+            .state_override_stream
+            .as_ref()
+            .map(|cfg| simulator::state_override_stream::spawn(cfg, network.block_stream.clone()));
         let simulator = SettlementSimulator::new(
             settlement_contract,
             network.flash_loan_router,

--- a/crates/price-estimation/src/factory.rs
+++ b/crates/price-estimation/src/factory.rs
@@ -27,7 +27,7 @@ use {
     number::nonzero::NonZeroU256,
     rate_limit::RateLimiter,
     reqwest::Url,
-    simulator::{simulation_builder::SettlementSimulator, tenderly},
+    simulator::{self, simulation_builder::SettlementSimulator, tenderly},
     std::{collections::HashMap, num::NonZeroUsize, sync::Arc},
     token_info::TokenInfoFetching,
 };
@@ -119,6 +119,13 @@ impl<'a> PriceEstimatorFactory<'a> {
         });
         let settlement_contract =
             GPv2Settlement::GPv2Settlement::new(network.settlement, web3.provider.clone());
+        let simulation_overrides = args.state_override_stream.as_ref().map(|cfg| {
+            simulator::state_override_stream::spawn(
+                cfg,
+                network.block_stream.clone(),
+                network.chain.block_time_in_ms(),
+            )
+        });
         let simulator = SettlementSimulator::new(
             settlement_contract,
             network.flash_loan_router,
@@ -128,6 +135,7 @@ impl<'a> PriceEstimatorFactory<'a> {
             balance_overrides,
             network.block_stream.clone(),
             tenderly.clone(),
+            simulation_overrides,
         )
         .await?;
 

--- a/crates/simulator/Cargo.toml
+++ b/crates/simulator/Cargo.toml
@@ -41,10 +41,10 @@ serde-ext = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true }
 thiserror = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt", "sync", "time"] }
+tokio-tungstenite = { workspace = true, features = ["connect", "rustls-tls-webpki-roots"] }
 tracing = { workspace = true }
 url = { workspace = true }
-tokio = { workspace = true, features = ["sync", "time", "rt", "macros"] }
-tokio-tungstenite = { workspace = true, features = ["connect", "rustls-tls-webpki-roots"] }
 
 [dev-dependencies]
 mockall = { workspace = true }

--- a/crates/simulator/Cargo.toml
+++ b/crates/simulator/Cargo.toml
@@ -43,11 +43,12 @@ serde_with = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 url = { workspace = true }
+tokio = { workspace = true, features = ["sync", "time", "rt", "macros"] }
+tokio-tungstenite = { workspace = true, features = ["connect", "rustls-tls-webpki-roots"] }
 
 [dev-dependencies]
 mockall = { workspace = true }
 testlib = { workspace = true }
-tokio = { workspace = true }
 
 [features]
 test-util = ["dep:mockall"]

--- a/crates/simulator/src/encoding.rs
+++ b/crates/simulator/src/encoding.rs
@@ -499,13 +499,10 @@ pub(crate) async fn finish_simulation_builder(
         && let Some(stream) = builder.simulator.0.simulation_overrides.as_ref()
         && let Some(state_overrides) = stream.current()
     {
-        for (account, state) in state_overrides.iter() {
+        for (account, state) in state_overrides {
             builder
                 .account_override_requests
-                .push(AccountOverrideRequest::Custom {
-                    account: *account,
-                    state: state.clone(),
-                });
+                .push(AccountOverrideRequest::Custom { account, state });
         }
     }
 

--- a/crates/simulator/src/encoding.rs
+++ b/crates/simulator/src/encoding.rs
@@ -491,10 +491,14 @@ pub(crate) async fn finish_simulation_builder(
         None => return Err(BuildError::NoSolver),
     };
 
-    // Streamed overrides are appended as Custom requests so
-    // build_final_state_overrides' merge arbitrates against the verifier's own.
-    // Only latest-block simulations get overrides; historical-block sims replay
-    // against a pinned block whose pAMM state is not the live stream's.
+    // We only apply the latest state override of propAMMs when simulating
+    // on the tip of the chain. When simulating on any older blocks we don't
+    // have historic data. Block builders might not update the propAMM state
+    // if nobody uses it in a block so it's theoretically possible that the
+    // propAMM state when simulated on historic blocks is slightly different
+    // from what you would have gotten if you actually traded with the propAMM
+    // on that block but we can't do anything about it and most likely the
+    // price is close enough to not affect the simulation.
     if matches!(builder.block, Block::Latest)
         && let Some(stream) = builder.simulator.0.simulation_overrides.as_ref()
         && let Some(state_overrides) = stream.current()

--- a/crates/simulator/src/encoding.rs
+++ b/crates/simulator/src/encoding.rs
@@ -490,6 +490,27 @@ pub(crate) async fn finish_simulation_builder(
         }
         None => return Err(BuildError::NoSolver),
     };
+
+    // Streamed overrides are appended as Custom requests so
+    // build_final_state_overrides' merge arbitrates against the verifier's own.
+    // Only latest-block simulations get overrides; historical-block sims have no
+    // head timestamp to derive next-block overrides from.
+    let mut block_overrides = None;
+    if matches!(builder.block, Block::Latest)
+        && let Some(stream) = builder.simulator.0.simulation_overrides.as_ref()
+        && let Some(set) = stream.current()
+    {
+        block_overrides = Some(set.block_overrides);
+        for (account, state) in set.state_overrides.iter() {
+            builder
+                .account_override_requests
+                .push(AccountOverrideRequest::Custom {
+                    account: *account,
+                    state: state.clone(),
+                });
+        }
+    }
+
     let (state_overrides, state_override_errors) = build_final_state_overrides(
         builder.account_override_requests,
         builder.simulator.0.state_overrides.as_ref(),
@@ -503,6 +524,7 @@ pub(crate) async fn finish_simulation_builder(
         to,
         calldata,
         state_overrides,
+        block_overrides,
         block,
         simulator: builder.simulator,
         failed_state_overrides: state_override_errors,

--- a/crates/simulator/src/encoding.rs
+++ b/crates/simulator/src/encoding.rs
@@ -493,15 +493,13 @@ pub(crate) async fn finish_simulation_builder(
 
     // Streamed overrides are appended as Custom requests so
     // build_final_state_overrides' merge arbitrates against the verifier's own.
-    // Only latest-block simulations get overrides; historical-block sims have no
-    // head timestamp to derive next-block overrides from.
-    let mut block_overrides = None;
+    // Only latest-block simulations get overrides; historical-block sims replay
+    // against a pinned block whose pAMM state is not the live stream's.
     if matches!(builder.block, Block::Latest)
         && let Some(stream) = builder.simulator.0.simulation_overrides.as_ref()
-        && let Some(set) = stream.current()
+        && let Some(state_overrides) = stream.current()
     {
-        block_overrides = Some(set.block_overrides);
-        for (account, state) in set.state_overrides.iter() {
+        for (account, state) in state_overrides.iter() {
             builder
                 .account_override_requests
                 .push(AccountOverrideRequest::Custom {
@@ -524,7 +522,6 @@ pub(crate) async fn finish_simulation_builder(
         to,
         calldata,
         state_overrides,
-        block_overrides,
         block,
         simulator: builder.simulator,
         failed_state_overrides: state_override_errors,

--- a/crates/simulator/src/ethereum/mod.rs
+++ b/crates/simulator/src/ethereum/mod.rs
@@ -2,7 +2,7 @@ use {
     crate::ethereum::contracts::Contracts,
     alloy_primitives::U256,
     alloy_provider::{Provider, network::TransactionBuilder},
-    alloy_rpc_types::TransactionRequest,
+    alloy_rpc_types::{BlockOverrides, TransactionRequest, state::StateOverride},
     anyhow::{Result, anyhow},
     chain::Chain,
     eth_domain_types::AccessList,
@@ -120,7 +120,12 @@ impl Ethereum {
             .into())
     }
 
-    pub async fn estimate_gas<T>(&self, tx: T) -> Result<eth_domain_types::Gas, Error>
+    pub async fn estimate_gas<T>(
+        &self,
+        tx: T,
+        overrides: Option<StateOverride>,
+        block_overrides: Option<BlockOverrides>,
+    ) -> Result<eth_domain_types::Gas, Error>
     where
         T: Into<TransactionRequest>,
     {
@@ -130,10 +135,15 @@ impl Ethereum {
             _ => tx,
         };
 
+        // `None` omits the RPC params entirely (byte-identical to today).
+        // Requires a node supporting eth_estimateGas state/block overrides
+        // (geth >=1.13, reth, nethermind, recent erigon, anvil).
         let estimated_gas = self
             .web3
             .provider
             .estimate_gas(tx)
+            .overrides_opt(overrides)
+            .with_block_overrides_opt(block_overrides)
             .pending()
             .await
             .map_err(Error::Rpc)?

--- a/crates/simulator/src/ethereum/mod.rs
+++ b/crates/simulator/src/ethereum/mod.rs
@@ -2,7 +2,7 @@ use {
     crate::ethereum::contracts::Contracts,
     alloy_primitives::U256,
     alloy_provider::{Provider, network::TransactionBuilder},
-    alloy_rpc_types::{BlockOverrides, TransactionRequest, state::StateOverride},
+    alloy_rpc_types::{TransactionRequest, state::StateOverride},
     anyhow::{Result, anyhow},
     chain::Chain,
     eth_domain_types::AccessList,
@@ -124,7 +124,6 @@ impl Ethereum {
         &self,
         tx: T,
         overrides: Option<StateOverride>,
-        block_overrides: Option<BlockOverrides>,
     ) -> Result<eth_domain_types::Gas, Error>
     where
         T: Into<TransactionRequest>,
@@ -135,15 +134,14 @@ impl Ethereum {
             _ => tx,
         };
 
-        // `None` omits the RPC params entirely (byte-identical to today).
-        // Requires a node supporting eth_estimateGas state/block overrides
+        // `None` omits the RPC param entirely (byte-identical to today).
+        // Requires a node supporting eth_estimateGas state overrides
         // (geth >=1.13, reth, nethermind, recent erigon, anvil).
         let estimated_gas = self
             .web3
             .provider
             .estimate_gas(tx)
             .overrides_opt(overrides)
-            .with_block_overrides_opt(block_overrides)
             .pending()
             .await
             .map_err(Error::Rpc)?

--- a/crates/simulator/src/ethereum/mod.rs
+++ b/crates/simulator/src/ethereum/mod.rs
@@ -134,9 +134,6 @@ impl Ethereum {
             _ => tx,
         };
 
-        // `None` omits the RPC param entirely (byte-identical to today).
-        // Requires a node supporting eth_estimateGas state overrides
-        // (geth >=1.13, reth, nethermind, recent erigon, anvil).
         let estimated_gas = self
             .web3
             .provider

--- a/crates/simulator/src/lib.rs
+++ b/crates/simulator/src/lib.rs
@@ -8,6 +8,7 @@ mod utils;
 
 use {
     crate::state_override_stream::SimulationOverrides,
+    alloy_primitives::Address,
     eth_domain_types::{self as eth, AccessList, Tx},
     http_client::HttpClientFactory,
     observe::future::Measure,
@@ -76,16 +77,28 @@ impl Simulator {
         self.simulation_overrides = Some(overrides);
     }
 
-    /// Simulate the access list needed by a transaction. If the transaction
-    /// already has an access list, the returned access list will be a
-    /// superset of the existing one.
-    pub async fn access_list(&self, tx: &Tx) -> Result<AccessList, Error> {
+    /// Computes access list for sending native eth to the given receiver.
+    /// This access list may be needed to make sending ETH to smart contract
+    /// wallets possible.
+    pub async fn access_list_for_eth_transfer(
+        &self,
+        from: Address,
+        to: Address,
+    ) -> Result<AccessList, Error> {
+        let tx = eth::Tx {
+            from,
+            to,
+            value: 1.into(),
+            input: Default::default(),
+            access_list: Default::default(),
+        };
         if self.disable_access_lists {
-            return Ok(tx.access_list.clone());
+            return Ok(Default::default());
         }
         let block = self.eth.current_block().borrow().number.into();
         let access_list = match &self.inner {
             Inner::Tenderly(tenderly) => {
+                // function assumes `from` has the needed ETH so no state overrides are needed
                 tenderly
                     .simulate(tx.clone(), block, None, tenderly::GenerateAccessList::Yes)
                     .await

--- a/crates/simulator/src/lib.rs
+++ b/crates/simulator/src/lib.rs
@@ -107,14 +107,10 @@ impl Simulator {
             return Ok(gas);
         }
         let block: eth::BlockNo = self.eth.current_block().borrow().number.into();
-        let (state_overrides, block_overrides) = match self
+        let state_overrides = self
             .simulation_overrides
             .as_ref()
-            .and_then(|overrides| overrides.current())
-        {
-            Some(set) => (Some(set.state_overrides), Some(set.block_overrides)),
-            None => (None, None),
-        };
+            .and_then(|overrides| overrides.current());
         Ok(match &self.inner {
             Inner::Tenderly(tenderly) => {
                 tenderly
@@ -131,7 +127,7 @@ impl Simulator {
             }
             Inner::Ethereum => self
                 .eth
-                .estimate_gas(tx.clone(), state_overrides, block_overrides)
+                .estimate_gas(tx.clone(), state_overrides)
                 .await
                 .map_err(with(tx, block))?,
         })

--- a/crates/simulator/src/lib.rs
+++ b/crates/simulator/src/lib.rs
@@ -2,10 +2,12 @@ pub mod encoding;
 pub mod ethereum;
 pub mod report;
 pub mod simulation_builder;
+pub mod state_override_stream;
 pub mod tenderly;
 mod utils;
 
 use {
+    crate::state_override_stream::SimulationOverrides,
     eth_domain_types::{self as eth, AccessList, Tx},
     http_client::HttpClientFactory,
     observe::future::Measure,
@@ -18,6 +20,7 @@ pub struct Simulator {
     eth: Ethereum,
     disable_access_lists: bool,
     disable_gas: Option<eth::Gas>,
+    simulation_overrides: Option<SimulationOverrides>,
 }
 
 #[derive(Debug, Clone)]
@@ -42,6 +45,7 @@ impl Simulator {
             eth,
             disable_access_lists: false,
             disable_gas: None,
+            simulation_overrides: None,
         }
     }
 
@@ -52,6 +56,7 @@ impl Simulator {
             eth,
             disable_access_lists: false,
             disable_gas: None,
+            simulation_overrides: None,
         }
     }
 
@@ -67,6 +72,10 @@ impl Simulator {
         self.disable_gas = Some(fixed_gas);
     }
 
+    pub fn set_simulation_overrides(&mut self, overrides: SimulationOverrides) {
+        self.simulation_overrides = Some(overrides);
+    }
+
     /// Simulate the access list needed by a transaction. If the transaction
     /// already has an access list, the returned access list will be a
     /// superset of the existing one.
@@ -78,7 +87,7 @@ impl Simulator {
         let access_list = match &self.inner {
             Inner::Tenderly(tenderly) => {
                 tenderly
-                    .simulate(tx.clone(), block, tenderly::GenerateAccessList::Yes)
+                    .simulate(tx.clone(), block, None, tenderly::GenerateAccessList::Yes)
                     .await
                     .map_err(with(tx.clone(), block))?
                     .access_list
@@ -97,11 +106,24 @@ impl Simulator {
         if let Some(gas) = self.disable_gas {
             return Ok(gas);
         }
-        let block = self.eth.current_block().borrow().number.into();
+        let block: eth::BlockNo = self.eth.current_block().borrow().number.into();
+        let (state_overrides, block_overrides) = match self
+            .simulation_overrides
+            .as_ref()
+            .and_then(|overrides| overrides.current())
+        {
+            Some(set) => (Some(set.state_overrides), Some(set.block_overrides)),
+            None => (None, None),
+        };
         Ok(match &self.inner {
             Inner::Tenderly(tenderly) => {
                 tenderly
-                    .simulate(tx.clone(), block, tenderly::GenerateAccessList::No)
+                    .simulate(
+                        tx.clone(),
+                        block,
+                        state_overrides,
+                        tenderly::GenerateAccessList::No,
+                    )
                     .measure("tenderly_simulate_gas")
                     .await
                     .map_err(with(tx, block))?
@@ -109,7 +131,7 @@ impl Simulator {
             }
             Inner::Ethereum => self
                 .eth
-                .estimate_gas(tx.clone())
+                .estimate_gas(tx.clone(), state_overrides, block_overrides)
                 .await
                 .map_err(with(tx, block))?,
         })

--- a/crates/simulator/src/simulation_builder.rs
+++ b/crates/simulator/src/simulation_builder.rs
@@ -3,7 +3,6 @@ use {
     alloy_primitives::{Address, B256, Bytes, U256, address, b256, keccak256},
     alloy_provider::{DynProvider, Provider, ext::DebugApi},
     alloy_rpc_types::{
-        BlockOverrides,
         TransactionRequest,
         state::{AccountOverride, StateOverride},
         trace::geth::{CallConfig, GethDebugTracingCallOptions, GethDebugTracingOptions},
@@ -440,7 +439,6 @@ pub struct EthCallInputs {
     pub to: Address,
     pub calldata: Bytes,
     pub state_overrides: StateOverride,
-    pub block_overrides: Option<BlockOverrides>,
     pub simulator: SettlementSimulator,
     pub block: u64,
     pub failed_state_overrides: Vec<AccountOverrideRequest>,
@@ -466,7 +464,6 @@ impl EthCallInputs {
             .clone()
             .call(self.as_transaction_request())
             .overrides(self.state_overrides.clone())
-            .with_block_overrides_opt(self.block_overrides.clone())
             .block(self.block.into())
             .await
     }
@@ -478,12 +475,9 @@ impl EthCallInputs {
     pub async fn simulation_report(
         &self,
     ) -> Result<report::SimulationReport, RpcError<alloy_transport::TransportErrorKind>> {
-        let mut trace_options = GethDebugTracingCallOptions::default()
+        let trace_options = GethDebugTracingCallOptions::default()
             .with_tracing_options(GethDebugTracingOptions::call_tracer(CallConfig::default()))
             .with_state_overrides(self.state_overrides.clone());
-        if let Some(block_overrides) = self.block_overrides.clone() {
-            trace_options = trace_options.with_block_overrides(block_overrides);
-        }
         let trace = self
             .simulator
             .0

--- a/crates/simulator/src/simulation_builder.rs
+++ b/crates/simulator/src/simulation_builder.rs
@@ -3,6 +3,7 @@ use {
     alloy_primitives::{Address, B256, Bytes, U256, address, b256, keccak256},
     alloy_provider::{DynProvider, Provider, ext::DebugApi},
     alloy_rpc_types::{
+        BlockOverrides,
         TransactionRequest,
         state::{AccountOverride, StateOverride},
         trace::geth::{CallConfig, GethDebugTracingCallOptions, GethDebugTracingOptions},
@@ -41,6 +42,7 @@ pub(crate) struct Inner {
     pub(crate) chain_id: u64,
     pub(crate) current_block: CurrentBlockWatcher,
     pub(crate) tenderly: Option<Arc<dyn tenderly::Api>>,
+    pub(crate) simulation_overrides: Option<crate::state_override_stream::SimulationOverrides>,
 }
 
 impl SettlementSimulator {
@@ -54,6 +56,7 @@ impl SettlementSimulator {
         state_overrides: Arc<dyn StateOverriding>,
         current_block: CurrentBlockWatcher,
         tenderly: Option<Arc<dyn tenderly::Api>>,
+        simulation_overrides: Option<crate::state_override_stream::SimulationOverrides>,
     ) -> Result<Self> {
         let authenticator = settlement.authenticator().call().await?;
         let vault_relayer = Address(settlement.vaultRelayer().call().await?.0);
@@ -74,6 +77,7 @@ impl SettlementSimulator {
             chain_id,
             current_block,
             tenderly,
+            simulation_overrides,
         })))
     }
 
@@ -436,6 +440,7 @@ pub struct EthCallInputs {
     pub to: Address,
     pub calldata: Bytes,
     pub state_overrides: StateOverride,
+    pub block_overrides: Option<BlockOverrides>,
     pub simulator: SettlementSimulator,
     pub block: u64,
     pub failed_state_overrides: Vec<AccountOverrideRequest>,
@@ -461,6 +466,7 @@ impl EthCallInputs {
             .clone()
             .call(self.as_transaction_request())
             .overrides(self.state_overrides.clone())
+            .with_block_overrides_opt(self.block_overrides.clone())
             .block(self.block.into())
             .await
     }
@@ -472,6 +478,12 @@ impl EthCallInputs {
     pub async fn simulation_report(
         &self,
     ) -> Result<report::SimulationReport, RpcError<alloy_transport::TransportErrorKind>> {
+        let mut trace_options = GethDebugTracingCallOptions::default()
+            .with_tracing_options(GethDebugTracingOptions::call_tracer(CallConfig::default()))
+            .with_state_overrides(self.state_overrides.clone());
+        if let Some(block_overrides) = self.block_overrides.clone() {
+            trace_options = trace_options.with_block_overrides(block_overrides);
+        }
         let trace = self
             .simulator
             .0
@@ -480,11 +492,7 @@ impl EthCallInputs {
             .debug_trace_call_callframe(
                 self.as_transaction_request(),
                 self.block.into(),
-                GethDebugTracingCallOptions::default()
-                    .with_tracing_options(GethDebugTracingOptions::call_tracer(
-                        CallConfig::default(),
-                    ))
-                    .with_state_overrides(self.state_overrides.clone()),
+                trace_options,
             )
             .await?;
 

--- a/crates/simulator/src/state_override_stream.rs
+++ b/crates/simulator/src/state_override_stream.rs
@@ -1,0 +1,623 @@
+//! Background websocket stream of eth_call-style state overrides for
+//! live-quote venues whose current price lives in maker memory rather than
+//! committed on-chain state (e.g. Titan propAMMs). Applied on top of latest
+//! state during settlement gas estimation and trade verification so pAMM
+//! routes simulate against their current in-memory state instead of stale
+//! previous-block state.
+
+use {
+    alloy_primitives::{Address, U256},
+    alloy_rpc_types::{BlockOverrides, state::StateOverride},
+    configs::simulator::StateOverrideStream as Config,
+    ethrpc::block_stream::CurrentBlockWatcher,
+    futures::{SinkExt, StreamExt},
+    prometheus::{IntCounter, IntCounterVec, IntGauge},
+    serde::Deserialize,
+    std::{
+        collections::BTreeMap,
+        sync::Arc,
+        time::{Duration, Instant},
+    },
+    tokio::sync::watch,
+    tracing::{debug, warn},
+};
+
+#[derive(Clone)]
+struct Snapshot {
+    overrides: StateOverride,
+    block_number: u64,
+    received_at: Option<Instant>,
+}
+
+#[derive(Clone)]
+pub struct SimulationOverrides(Arc<Inner>);
+
+struct Inner {
+    snapshots: watch::Receiver<Snapshot>,
+    current_block: CurrentBlockWatcher,
+    max_age: Duration,
+    max_block_lag: u64,
+    block_time: Duration,
+}
+
+#[derive(Clone)]
+pub struct SimulationOverrideSet {
+    pub state_overrides: StateOverride,
+    pub block_overrides: BlockOverrides,
+}
+
+impl std::fmt::Debug for SimulationOverrides {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SimulationOverrides")
+            .field("max_age", &self.0.max_age)
+            .field("max_block_lag", &self.0.max_block_lag)
+            .field("block_time", &self.0.block_time)
+            .finish()
+    }
+}
+
+impl SimulationOverrides {
+    /// Returns `None` (callers omit the RPC override params entirely) when the
+    /// stream is stale or unconfigured.
+    ///
+    /// The frame `timestamp` is the producer wall clock, not block time, so the
+    /// next-block timestamp is derived from the head block's timestamp plus the
+    /// chain block time.
+    pub fn current(&self) -> Option<SimulationOverrideSet> {
+        let snapshot = self.0.snapshots.borrow();
+        let received_at = snapshot.received_at?;
+        if received_at.elapsed() > self.0.max_age {
+            Metrics::get().record_override_result(OverrideResult::Stale);
+            return None;
+        }
+        let (current_block_number, current_block_timestamp) = {
+            let info = self.0.current_block.borrow();
+            (info.number, info.timestamp)
+        };
+        if snapshot.block_number + self.0.max_block_lag < current_block_number {
+            Metrics::get().record_override_result(OverrideResult::Stale);
+            return None;
+        }
+        if snapshot.overrides.is_empty() {
+            Metrics::get().record_override_result(OverrideResult::Stale);
+            return None;
+        }
+        Metrics::get().record_override_result(OverrideResult::Applied);
+        let block_overrides = BlockOverrides {
+            number: Some(U256::from(current_block_number + 1)),
+            time: Some(current_block_timestamp + self.0.block_time.as_secs()),
+            ..Default::default()
+        };
+        Some(SimulationOverrideSet {
+            state_overrides: snapshot.overrides.clone(),
+            block_overrides,
+        })
+    }
+}
+
+#[derive(prometheus_metric_storage::MetricStorage)]
+struct Metrics {
+    /// Total state-override frames received from the websocket.
+    frames_received: IntCounter,
+    /// Frames that failed to parse.
+    parse_failures: IntCounter,
+    /// Reconnect attempts.
+    reconnects: IntCounter,
+    /// Cross-venue override conflicts (no longer incremented; latest frame
+    /// wins per account via insert, but kept for metric stability).
+    merge_conflicts: IntCounter,
+    /// Accounts in the merged state-override snapshot.
+    venue_count: IntGauge,
+    /// Gas simulations by whether overrides were applied.
+    #[metric(labels("result"))]
+    simulations_with_overrides: IntCounterVec,
+}
+
+impl Metrics {
+    fn get() -> &'static Metrics {
+        Metrics::instance(observe::metrics::get_storage_registry()).unwrap()
+    }
+
+    fn record_override_result(&self, result: OverrideResult) {
+        self.simulations_with_overrides
+            .with_label_values(&[result.as_str()])
+            .inc();
+    }
+}
+
+enum OverrideResult {
+    Applied,
+    Stale,
+}
+
+impl OverrideResult {
+    const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Applied => "applied",
+            Self::Stale => "stale",
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+#[serde(rename_all = "camelCase")]
+struct Frame {
+    slot: Option<u64>,
+    block_number: Option<u64>,
+    #[serde(default)]
+    timestamp: Option<u128>,
+    // Venue keys are addresses flattened alongside the metadata fields above;
+    // unknown non-address keys (e.g. future schema additions) are skipped by
+    // the address parse inside the deserializer.
+    #[serde(flatten, deserialize_with = "deserialize_venue_overrides")]
+    venues: BTreeMap<Address, VenueUpdate>,
+}
+
+#[derive(Debug, Deserialize)]
+struct VenueUpdate {
+    #[serde(rename = "stateOverride", alias = "state_override")]
+    state_override: StateOverride,
+}
+
+fn deserialize_venue_overrides<'de, D>(
+    deserializer: D,
+) -> Result<BTreeMap<Address, VenueUpdate>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    struct Vis;
+
+    impl<'de> serde::de::Visitor<'de> for Vis {
+        type Value = BTreeMap<Address, VenueUpdate>;
+
+        fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            f.write_str("a map of venue address overrides")
+        }
+
+        fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+        where
+            A: serde::de::MapAccess<'de>,
+        {
+            let mut out = BTreeMap::new();
+            while let Some(key) = map.next_key::<String>()? {
+                let Ok(address) = key.parse::<Address>() else {
+                    let _: serde_json::Value = map.next_value()?;
+                    continue;
+                };
+                out.insert(address, map.next_value::<VenueUpdate>()?);
+            }
+            Ok(out)
+        }
+    }
+
+    deserializer.deserialize_map(Vis)
+}
+
+pub fn spawn(
+    cfg: &Config,
+    current_block: CurrentBlockWatcher,
+    block_time: Duration,
+) -> SimulationOverrides {
+    let (sender, receiver) = watch::channel(Snapshot {
+        overrides: StateOverride::default(),
+        block_number: 0,
+        received_at: None,
+    });
+
+    let ws_url = cfg.ws_url.clone();
+    tokio::spawn(async move {
+        run_stream(ws_url, sender).await;
+    });
+
+    SimulationOverrides(Arc::new(Inner {
+        snapshots: receiver,
+        current_block,
+        max_age: cfg.max_age,
+        max_block_lag: cfg.max_block_lag,
+        block_time,
+    }))
+}
+
+async fn run_stream(ws_url: url::Url, sender: watch::Sender<Snapshot>) {
+    let mut backoff = Duration::from_millis(250);
+    let mut overrides = StateOverride::default();
+    let mut last_block_number = 0u64;
+
+    loop {
+        match tokio_tungstenite::connect_async(ws_url.as_str()).await {
+            Ok((ws_stream, _)) => {
+                backoff = Duration::from_millis(250);
+                let (mut write, mut read) = ws_stream.split();
+                debug!(url = %ws_url, "state-override stream connected");
+
+                while let Some(message) = read.next().await {
+                    let message = match message {
+                        Ok(message) => message,
+                        Err(err) => {
+                            warn!(?err, "state-override stream read error");
+                            break;
+                        }
+                    };
+
+                    if !message.is_text() && !message.is_binary() {
+                        continue;
+                    }
+
+                    Metrics::get().frames_received.inc();
+                    match serde_json::from_slice::<Frame>(&message.into_data()) {
+                        Ok(frame) => {
+                            if let Some(block_number) = frame.block_number {
+                                last_block_number = block_number;
+                            }
+                            apply_frame(&mut overrides, frame);
+                            publish(&overrides, last_block_number, &sender);
+                        }
+                        Err(err) => {
+                            Metrics::get().parse_failures.inc();
+                            debug!(?err, "state-override stream frame parse error");
+                        }
+                    }
+                }
+
+                let _ = write.close().await;
+            }
+            Err(err) => {
+                warn!(?err, url = %ws_url, "state-override stream connect failed");
+            }
+        }
+
+        Metrics::get().reconnects.inc();
+        debug!(?backoff, "state-override stream reconnecting");
+        tokio::time::sleep(backoff).await;
+        backoff = (backoff * 2).min(Duration::from_secs(15));
+    }
+}
+
+// Each frame's stateOverride is a full per-venue snapshot, not a delta, so
+// accounts are inserted directly (latest frame wins per account).
+fn apply_frame(overrides: &mut StateOverride, frame: Frame) {
+    for update in frame.venues.into_values() {
+        for (account, account_override) in update.state_override {
+            overrides.insert(account, account_override);
+        }
+    }
+}
+
+fn publish(overrides: &StateOverride, block_number: u64, sender: &watch::Sender<Snapshot>) {
+    Metrics::get().venue_count.set(overrides.len() as i64);
+    let _ = sender.send(Snapshot {
+        overrides: overrides.clone(),
+        block_number,
+        received_at: Some(Instant::now()),
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        alloy_primitives::{B256, address},
+        alloy_rpc_types::state::AccountOverride,
+        ethrpc::block_stream::BlockInfo,
+        futures::StreamExt,
+        std::time::Duration,
+        tokio::time::timeout,
+        tokio_tungstenite::tungstenite::Message,
+    };
+
+    fn block(number: u64, timestamp: u64) -> (watch::Sender<BlockInfo>, CurrentBlockWatcher) {
+        let (tx, rx) = watch::channel(BlockInfo {
+            number,
+            timestamp,
+            ..Default::default()
+        });
+        (tx, rx)
+    }
+
+    fn frame_with(
+        venue: Address,
+        account: Address,
+        balance: Option<U256>,
+        slot: Option<B256>,
+    ) -> Frame {
+        let mut account_override = AccountOverride::default();
+        if let Some(balance) = balance {
+            account_override.balance = Some(balance);
+        }
+        if let Some(slot) = slot {
+            let mut diff = alloy_primitives::map::B256Map::default();
+            diff.insert(slot, B256::ZERO);
+            account_override.state_diff = Some(diff);
+        }
+        let mut state_override = StateOverride::default();
+        state_override.insert(account, account_override);
+        let mut venues = BTreeMap::new();
+        venues.insert(venue, VenueUpdate { state_override });
+        Frame {
+            slot: None,
+            block_number: None,
+            timestamp: None,
+            venues,
+        }
+    }
+
+    #[test]
+    fn frame_parses_verbatim_titan_sample() {
+        let sample = r#"{
+            "slot": 14285824,
+            "blockNumber": 25051224,
+            "timestamp": 1778253913749564761,
+            "future-metadata": "ignored",
+            "0x1111111111111111111111111111111111111111": {
+                "stateOverride": {
+                    "0x2222222222222222222222222222222222222222": {
+                        "balance": "0x0",
+                        "nonce": "0x1",
+                        "stateDiff": { "0x0000000000000000000000000000000000000000000000000000000000000001": "0x0000000000000000000000000000000000000000000000000000000000000000" }
+                    }
+                }
+            },
+            "not-an-address": { "stateOverride": {} }
+        }"#;
+        let frame: Frame = serde_json::from_str(sample).unwrap();
+        assert_eq!(frame.block_number, Some(25051224));
+        // Non-address top-level keys ("future-metadata", "not-an-address")
+        // are skipped by the venue deserializer.
+        assert_eq!(frame.venues.len(), 1);
+
+        let venue = address!("1111111111111111111111111111111111111111");
+        let account = address!("2222222222222222222222222222222222222222");
+        let update = frame.venues.get(&venue).unwrap();
+        let override_entry = update.state_override.get(&account).unwrap();
+        assert_eq!(override_entry.nonce, Some(1));
+        assert!(override_entry.state_diff.is_some());
+    }
+
+    #[test]
+    fn apply_frame_replaces_per_venue_state() {
+        let venue = address!("1111111111111111111111111111111111111111");
+        let account = address!("2222222222222222222222222222222222222222");
+
+        let mut overrides = StateOverride::default();
+        apply_frame(
+            &mut overrides,
+            frame_with(venue, account, None, Some(B256::ZERO)),
+        );
+        assert!(overrides.get(&account).unwrap().state_diff.is_some());
+        assert!(overrides.get(&account).unwrap().balance.is_none());
+
+        apply_frame(
+            &mut overrides,
+            frame_with(venue, account, Some(U256::ZERO), None),
+        );
+        assert_eq!(overrides.get(&account).unwrap().balance, Some(U256::ZERO));
+        assert!(overrides.get(&account).unwrap().state_diff.is_none());
+    }
+
+    #[test]
+    fn apply_frame_merges_disjoint_accounts() {
+        let venue_a = address!("1111111111111111111111111111111111111111");
+        let venue_b = address!("3333333333333333333333333333333333333333");
+        let account_a = address!("2222222222222222222222222222222222222222");
+        let account_b = address!("4444444444444444444444444444444444444444");
+
+        let mut overrides = StateOverride::default();
+        apply_frame(
+            &mut overrides,
+            frame_with(venue_a, account_a, None, Some(B256::ZERO)),
+        );
+        apply_frame(
+            &mut overrides,
+            frame_with(venue_b, account_b, None, Some(B256::ZERO)),
+        );
+        assert!(overrides.contains_key(&account_a));
+        assert!(overrides.contains_key(&account_b));
+    }
+
+    #[test]
+    fn apply_frame_conflict_latest_wins() {
+        let venue_a = address!("1111111111111111111111111111111111111111");
+        let venue_b = address!("3333333333333333333333333333333333333333");
+        let shared = address!("2222222222222222222222222222222222222222");
+
+        let mut overrides = StateOverride::default();
+        apply_frame(
+            &mut overrides,
+            frame_with(venue_a, shared, Some(U256::from(1)), None),
+        );
+        apply_frame(
+            &mut overrides,
+            frame_with(venue_b, shared, Some(U256::from(2)), None),
+        );
+        assert_eq!(overrides.get(&shared).unwrap().balance, Some(U256::from(2)));
+    }
+
+    fn handle(
+        receiver: watch::Receiver<Snapshot>,
+        block_rx: CurrentBlockWatcher,
+        max_age: Duration,
+    ) -> SimulationOverrides {
+        SimulationOverrides(Arc::new(Inner {
+            snapshots: receiver,
+            current_block: block_rx,
+            max_age,
+            max_block_lag: 1,
+            block_time: Duration::from_secs(12),
+        }))
+    }
+
+    fn non_empty_snapshot(block_number: u64, received_at: Instant) -> Snapshot {
+        let mut overrides = StateOverride::default();
+        overrides.insert(
+            address!("1111111111111111111111111111111111111111"),
+            AccountOverride::default(),
+        );
+        Snapshot {
+            overrides,
+            block_number,
+            received_at: Some(received_at),
+        }
+    }
+
+    #[test]
+    fn staleness_gates_return_none() {
+        // Stale by age.
+        let (_sender, receiver) = watch::channel(non_empty_snapshot(
+            100,
+            Instant::now() - Duration::from_millis(100),
+        ));
+        let (_, block_rx) = block(100, 1000);
+        assert!(
+            handle(receiver, block_rx, Duration::from_millis(50))
+                .current()
+                .is_none()
+        );
+
+        // Stale by block lag: snapshot block 100, head block 105, max lag 1.
+        let (_sender, receiver) = watch::channel(non_empty_snapshot(100, Instant::now()));
+        let (_, block_rx) = block(105, 1000);
+        assert!(
+            handle(receiver, block_rx, Duration::from_secs(30))
+                .current()
+                .is_none()
+        );
+
+        // Stale because the merged overrides are empty.
+        let (sender, receiver) = watch::channel(Snapshot {
+            overrides: StateOverride::default(),
+            block_number: 100,
+            received_at: Some(Instant::now()),
+        });
+        let (_, block_rx) = block(100, 1000);
+        let h = handle(receiver, block_rx, Duration::from_secs(30));
+        sender
+            .send(Snapshot {
+                overrides: StateOverride::default(),
+                block_number: 100,
+                received_at: Some(Instant::now()),
+            })
+            .unwrap();
+        assert!(h.current().is_none());
+    }
+
+    #[tokio::test]
+    async fn reconnect_and_accumulate_against_in_process_server() {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let server_url: url::Url = format!("ws://{addr}").parse().unwrap();
+        let account = address!("2222222222222222222222222222222222222222");
+        let first = r#"{"blockNumber":10,"0x1111111111111111111111111111111111111111":{"stateOverride":{"0x2222222222222222222222222222222222222222":{"balance":"0x1"}}}}"#;
+        let second = r#"{"blockNumber":11,"0x1111111111111111111111111111111111111111":{"stateOverride":{"0x2222222222222222222222222222222222222222":{"balance":"0x2"}}}}"#;
+
+        let server_handle = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let ws = tokio_tungstenite::accept_async(stream).await.unwrap();
+            let (mut write, _read) = ws.split();
+            write.send(Message::Text(first.into())).await.unwrap();
+            write.send(Message::Text(second.into())).await.unwrap();
+            write.close().await.unwrap();
+        });
+
+        let (_, block_rx) = block(11, 1000);
+        let cfg = Config {
+            ws_url: server_url,
+            max_age: Duration::from_secs(30),
+            max_block_lag: 100,
+        };
+        let handle = spawn(&cfg, block_rx, Duration::from_secs(12));
+
+        let _ = server_handle.await;
+
+        let got = timeout(Duration::from_secs(2), async {
+            loop {
+                if let Some(set) = handle.current()
+                    && let Some(account_override) = set.state_overrides.get(&account)
+                    && account_override.balance == Some(U256::from(2))
+                    && set.block_overrides.number == Some(U256::from(12))
+                    && set.block_overrides.time == Some(1012)
+                {
+                    return;
+                }
+                tokio::time::sleep(Duration::from_millis(20)).await;
+            }
+        })
+        .await;
+        assert!(got.is_ok(), "did not observe merged overrides in time");
+    }
+
+    // Real frames captured from wss://eu.rpc.titanbuilder.xyz/ws/pamm_quote_stream.
+    const FERMI_FRAME: &str = r#"{"slot":14711587,"blockNumber":25475333,"timestamp":1783363067584411872,"0xb1076fe3ab5e28005c7c323bac5ac06a680d452e":{"stateOverride":{"0xa048e0c08b7acb48363711800ac9d49de8e58d13":{"balance":"0x10848dc44f1e140","nonce":"0x42ee"},"0x14e870f0a7c764ca71289952006d6bf130058927":{"balance":"0x10aaf167cb7dbea","nonce":"0x23da"},"0x69939a6c590c9cd0bf8efbe9b3df2cdac4a4906b":{"balance":"0x88ecb0471d376e","nonce":"0x2fad"},"0xfc42be9494f1af6b03adad71811c62ada2d6f3c3":{"balance":"0x10e7e3c0b4f8ba0","nonce":"0x1d99"},"0xda7afeed01fe625cf15d187a19f94b45f00b8c5f":{"balance":"0x0","nonce":"0x1","stateDiff":{"0x6d3af688dd77e4167e6ad8613dea4a162f5e340043b2c026e3d2b5b40d12c92d":"0x6a4bf5fb010000000000000000000000000000000000000000000029cdbee960","0x9a965d2bccf7f891d58fe85acac20d9de58c11ac1d222dfff7973a09ad71143a":"0x6a4bf5fb010000000000000000000000000000000000000000000029c8581698","0xe25ff9533ce41163d3738b63c7d954cd7449a0ba0dd0dac8db25ae29536b4961":"0x6a4bf5fb010000000000000000000000000000000000000000000029cdbee960","0x939ee2e42000f154d3be2302ab4d3cb916e4b2852ef6a0caa2fd76c417120248":"0x6a4bf5fb010000000000000000000000000000000000000000000029c8581698"}}}}}"#;
+    const OTHER_FRAME: &str = r#"{"slot":14711587,"blockNumber":25475333,"timestamp":1783363067506613546,"0x28d9ccedf1b7ac9b3f090f4f0292837de87c1d39":{"stateOverride":{"0x28d9ccedf1b7ac9b3f090f4f0292837de87c1d39":{"balance":"0x0","nonce":"0x1","stateDiff":{"0xe3ffa73f3a3b56e693c2ed775464cb3fbe78307b000000000000000000000000":"0x5d393a1348485d39e6f3484885cda948444485cd9644363600019f38b8de3300"}},"0xe3ffa73f3a3b56e693c2ed775464cb3fbe78307b":{"balance":"0x12e8705b8c388ab1","nonce":"0xdda1"}}}}"#;
+
+    #[test]
+    fn parses_real_titan_frames() {
+        let fermi: Frame = serde_json::from_str(FERMI_FRAME).unwrap();
+        assert_eq!(fermi.block_number, Some(25475333));
+        assert_eq!(fermi.slot, Some(14711587));
+        assert_eq!(fermi.venues.len(), 1);
+
+        let mut overrides = StateOverride::default();
+        apply_frame(&mut overrides, fermi);
+        assert_eq!(overrides.len(), 5);
+
+        let venue_account = address!("da7afeed01fe625cf15d187a19f94b45f00b8c5f");
+        let entry = overrides.get(&venue_account).unwrap();
+        assert_eq!(entry.balance, Some(U256::ZERO));
+        assert_eq!(entry.nonce, Some(1));
+        let diff = entry.state_diff.as_ref().unwrap();
+        assert_eq!(diff.len(), 4);
+        let slot: alloy_primitives::B256 =
+            "0x6d3af688dd77e4167e6ad8613dea4a162f5e340043b2c026e3d2b5b40d12c92d"
+                .parse()
+                .unwrap();
+        assert!(diff.contains_key(&slot));
+    }
+
+    #[test]
+    fn accumulates_real_frames_across_venues() {
+        let mut overrides = StateOverride::default();
+        apply_frame(&mut overrides, serde_json::from_str(FERMI_FRAME).unwrap());
+        apply_frame(&mut overrides, serde_json::from_str(OTHER_FRAME).unwrap());
+
+        assert_eq!(overrides.len(), 7);
+        assert!(overrides.contains_key(&address!("da7afeed01fe625cf15d187a19f94b45f00b8c5f")));
+        assert!(overrides.contains_key(&address!("e3ffa73f3a3b56e693c2ed775464cb3fbe78307b")));
+    }
+
+    #[test]
+    fn current_yields_next_block_overrides_for_real_data() {
+        let (block_tx, block_rx) = block(25475333, 1783363000);
+        let (_sender, receiver) = watch::channel(Snapshot {
+            overrides: {
+                let mut m = StateOverride::default();
+                apply_frame(&mut m, serde_json::from_str(FERMI_FRAME).unwrap());
+                m
+            },
+            block_number: 25475333,
+            received_at: Some(Instant::now()),
+        });
+        let handle = SimulationOverrides(Arc::new(Inner {
+            snapshots: receiver,
+            current_block: block_rx,
+            max_age: Duration::from_secs(30),
+            max_block_lag: 1,
+            block_time: Duration::from_secs(12),
+        }));
+
+        let set = handle.current().unwrap();
+        assert_eq!(set.block_overrides.number, Some(U256::from(25475334)));
+        assert_eq!(set.block_overrides.time, Some(1783363012));
+        assert_eq!(set.state_overrides.len(), 5);
+
+        block_tx
+            .send(BlockInfo {
+                number: 25475335,
+                timestamp: 1783363000,
+                ..Default::default()
+            })
+            .unwrap();
+        assert!(handle.current().is_none());
+    }
+}

--- a/crates/simulator/src/state_override_stream.rs
+++ b/crates/simulator/src/state_override_stream.rs
@@ -126,8 +126,8 @@ struct Frame {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct VenueUpdate {
-    #[serde(rename = "stateOverride", alias = "state_override")]
     state_override: StateOverride,
 }
 

--- a/crates/simulator/src/state_override_stream.rs
+++ b/crates/simulator/src/state_override_stream.rs
@@ -115,13 +115,9 @@ impl OverrideResult {
 }
 
 #[derive(Debug, Deserialize)]
-#[allow(dead_code)]
 #[serde(rename_all = "camelCase")]
 struct Frame {
-    slot: Option<u64>,
     block_number: Option<u64>,
-    #[serde(default)]
-    timestamp: Option<u128>,
     // Venue keys are addresses flattened alongside the metadata fields above;
     // unknown non-address keys (e.g. future schema additions) are skipped by
     // the address parse inside the deserializer.
@@ -155,9 +151,9 @@ where
             A: serde::de::MapAccess<'de>,
         {
             let mut out = BTreeMap::new();
-            while let Some(key) = map.next_key::<String>()? {
+            while let Some(key) = map.next_key::<&str>()? {
                 let Ok(address) = key.parse::<Address>() else {
-                    let _: serde_json::Value = map.next_value()?;
+                    map.next_value::<serde::de::IgnoredAny>()?;
                     continue;
                 };
                 out.insert(address, map.next_value::<VenueUpdate>()?);
@@ -304,9 +300,7 @@ mod tests {
         let mut venues = BTreeMap::new();
         venues.insert(venue, VenueUpdate { state_override });
         Frame {
-            slot: None,
             block_number: None,
-            timestamp: None,
             venues,
         }
     }
@@ -519,7 +513,6 @@ mod tests {
     fn parses_real_titan_frames() {
         let fermi: Frame = serde_json::from_str(FERMI_FRAME).unwrap();
         assert_eq!(fermi.block_number, Some(25475333));
-        assert_eq!(fermi.slot, Some(14711587));
         assert_eq!(fermi.venues.len(), 1);
 
         let mut overrides = StateOverride::default();

--- a/crates/simulator/src/state_override_stream.rs
+++ b/crates/simulator/src/state_override_stream.rs
@@ -22,6 +22,7 @@ use {
     tracing::{debug, warn},
 };
 
+/// State overrides delivered some point in time.
 #[derive(Clone)]
 struct Snapshot {
     overrides: StateOverride,
@@ -65,52 +66,8 @@ impl SimulationOverrides {
             Metrics::get().record_override_result(OverrideResult::Stale);
             return None;
         }
-        Metrics::get().record_override_result(OverrideResult::Applied);
+        Metrics::get().record_override_result(OverrideResult::Fresh);
         Some(snapshot.overrides.clone())
-    }
-}
-
-#[derive(prometheus_metric_storage::MetricStorage)]
-struct Metrics {
-    /// Total state-override frames received from the websocket.
-    frames_received: IntCounter,
-    /// Frames that failed to parse.
-    parse_failures: IntCounter,
-    /// Reconnect attempts.
-    reconnects: IntCounter,
-    /// Cross-venue override conflicts (no longer incremented; latest frame
-    /// wins per account via insert, but kept for metric stability).
-    merge_conflicts: IntCounter,
-    /// Accounts in the merged state-override snapshot.
-    venue_count: IntGauge,
-    /// Gas simulations by whether overrides were applied.
-    #[metric(labels("result"))]
-    simulations_with_overrides: IntCounterVec,
-}
-
-impl Metrics {
-    fn get() -> &'static Metrics {
-        Metrics::instance(observe::metrics::get_storage_registry()).unwrap()
-    }
-
-    fn record_override_result(&self, result: OverrideResult) {
-        self.simulations_with_overrides
-            .with_label_values(&[result.as_str()])
-            .inc();
-    }
-}
-
-enum OverrideResult {
-    Applied,
-    Stale,
-}
-
-impl OverrideResult {
-    const fn as_str(&self) -> &'static str {
-        match self {
-            Self::Applied => "applied",
-            Self::Stale => "stale",
-        }
     }
 }
 
@@ -165,6 +122,8 @@ where
     deserializer.deserialize_map(Vis)
 }
 
+/// Spawns a new background task that streams state override updates
+/// into the return [`SimulationOverrides`] instance.
 pub fn spawn(cfg: &Config, current_block: CurrentBlockWatcher) -> SimulationOverrides {
     let (sender, receiver) = watch::channel(Snapshot {
         overrides: StateOverride::default(),
@@ -251,11 +210,58 @@ fn apply_frame(overrides: &mut StateOverride, frame: Frame) {
 
 fn publish(overrides: &StateOverride, block_number: u64, sender: &watch::Sender<Snapshot>) {
     Metrics::get().venue_count.set(overrides.len() as i64);
-    let _ = sender.send(Snapshot {
+    let snapshot = Snapshot {
         overrides: overrides.clone(),
         block_number,
         received_at: Some(Instant::now()),
-    });
+    };
+    if let Err(err) = sender.send(snapshot) {
+        tracing::warn!(?err, "receiver of state override updates dropped");
+    }
+}
+
+#[derive(prometheus_metric_storage::MetricStorage)]
+struct Metrics {
+    /// Total state-override frames received from the websocket.
+    frames_received: IntCounter,
+    /// Frames that failed to parse.
+    parse_failures: IntCounter,
+    /// Reconnect attempts.
+    reconnects: IntCounter,
+    /// Cross-venue override conflicts (no longer incremented; latest frame
+    /// wins per account via insert, but kept for metric stability).
+    merge_conflicts: IntCounter,
+    /// Accounts in the merged state-override snapshot.
+    venue_count: IntGauge,
+    /// Gas simulations by whether overrides were applied.
+    #[metric(labels("result"))]
+    simulations_with_overrides: IntCounterVec,
+}
+
+impl Metrics {
+    fn get() -> &'static Metrics {
+        Metrics::instance(observe::metrics::get_storage_registry()).unwrap()
+    }
+
+    fn record_override_result(&self, result: OverrideResult) {
+        self.simulations_with_overrides
+            .with_label_values(&[result.as_str()])
+            .inc();
+    }
+}
+
+enum OverrideResult {
+    Fresh,
+    Stale,
+}
+
+impl OverrideResult {
+    const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Fresh => "fresh",
+            Self::Stale => "stale",
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/simulator/src/state_override_stream.rs
+++ b/crates/simulator/src/state_override_stream.rs
@@ -6,8 +6,8 @@
 //! previous-block state.
 
 use {
-    alloy_primitives::{Address, U256},
-    alloy_rpc_types::{BlockOverrides, state::StateOverride},
+    alloy_primitives::Address,
+    alloy_rpc_types::state::StateOverride,
     configs::simulator::StateOverrideStream as Config,
     ethrpc::block_stream::CurrentBlockWatcher,
     futures::{SinkExt, StreamExt},
@@ -36,42 +36,27 @@ struct Inner {
     snapshots: watch::Receiver<Snapshot>,
     current_block: CurrentBlockWatcher,
     max_age: Duration,
-    block_time: Duration,
-}
-
-#[derive(Clone)]
-pub struct SimulationOverrideSet {
-    pub state_overrides: StateOverride,
-    pub block_overrides: BlockOverrides,
 }
 
 impl std::fmt::Debug for SimulationOverrides {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SimulationOverrides")
             .field("max_age", &self.0.max_age)
-            .field("block_time", &self.0.block_time)
             .finish()
     }
 }
 
 impl SimulationOverrides {
-    /// Returns `None` (callers omit the RPC override params entirely) when the
-    /// stream is stale or unconfigured.
-    ///
-    /// The frame `timestamp` is the producer wall clock, not block time, so the
-    /// next-block timestamp is derived from the head block's timestamp plus the
-    /// chain block time.
-    pub fn current(&self) -> Option<SimulationOverrideSet> {
+    /// Returns the live state overrides, or `None` (callers omit the RPC
+    /// override param entirely) when the stream is stale or unconfigured.
+    pub fn current(&self) -> Option<StateOverride> {
         let snapshot = self.0.snapshots.borrow();
         let received_at = snapshot.received_at?;
         if received_at.elapsed() > self.0.max_age {
             Metrics::get().record_override_result(OverrideResult::Stale);
             return None;
         }
-        let (current_block_number, current_block_timestamp) = {
-            let info = self.0.current_block.borrow();
-            (info.number, info.timestamp)
-        };
+        let current_block_number = self.0.current_block.borrow().number;
         if snapshot.block_number != current_block_number {
             Metrics::get().record_override_result(OverrideResult::Stale);
             return None;
@@ -81,15 +66,7 @@ impl SimulationOverrides {
             return None;
         }
         Metrics::get().record_override_result(OverrideResult::Applied);
-        let block_overrides = BlockOverrides {
-            number: Some(U256::from(current_block_number + 1)),
-            time: Some(current_block_timestamp + self.0.block_time.as_secs()),
-            ..Default::default()
-        };
-        Some(SimulationOverrideSet {
-            state_overrides: snapshot.overrides.clone(),
-            block_overrides,
-        })
+        Some(snapshot.overrides.clone())
     }
 }
 
@@ -192,11 +169,7 @@ where
     deserializer.deserialize_map(Vis)
 }
 
-pub fn spawn(
-    cfg: &Config,
-    current_block: CurrentBlockWatcher,
-    block_time: Duration,
-) -> SimulationOverrides {
+pub fn spawn(cfg: &Config, current_block: CurrentBlockWatcher) -> SimulationOverrides {
     let (sender, receiver) = watch::channel(Snapshot {
         overrides: StateOverride::default(),
         block_number: 0,
@@ -212,7 +185,6 @@ pub fn spawn(
         snapshots: receiver,
         current_block,
         max_age: cfg.max_age,
-        block_time,
     }))
 }
 
@@ -294,7 +266,7 @@ fn publish(overrides: &StateOverride, block_number: u64, sender: &watch::Sender<
 mod tests {
     use {
         super::*,
-        alloy_primitives::{B256, address},
+        alloy_primitives::{B256, U256, address},
         alloy_rpc_types::state::AccountOverride,
         ethrpc::block_stream::BlockInfo,
         futures::StreamExt,
@@ -439,7 +411,6 @@ mod tests {
             snapshots: receiver,
             current_block: block_rx,
             max_age,
-            block_time: Duration::from_secs(12),
         }))
     }
 
@@ -521,17 +492,15 @@ mod tests {
             ws_url: server_url,
             max_age: Duration::from_secs(30),
         };
-        let handle = spawn(&cfg, block_rx, Duration::from_secs(12));
+        let handle = spawn(&cfg, block_rx);
 
         let _ = server_handle.await;
 
         let got = timeout(Duration::from_secs(2), async {
             loop {
-                if let Some(set) = handle.current()
-                    && let Some(account_override) = set.state_overrides.get(&account)
+                if let Some(overrides) = handle.current()
+                    && let Some(account_override) = overrides.get(&account)
                     && account_override.balance == Some(U256::from(2))
-                    && set.block_overrides.number == Some(U256::from(12))
-                    && set.block_overrides.time == Some(1012)
                 {
                     return;
                 }
@@ -582,7 +551,7 @@ mod tests {
     }
 
     #[test]
-    fn current_yields_next_block_overrides_for_real_data() {
+    fn current_yields_state_overrides_for_real_data() {
         let (block_tx, block_rx) = block(25475333, 1783363000);
         let (_sender, receiver) = watch::channel(Snapshot {
             overrides: {
@@ -597,13 +566,10 @@ mod tests {
             snapshots: receiver,
             current_block: block_rx,
             max_age: Duration::from_secs(30),
-            block_time: Duration::from_secs(12),
         }));
 
-        let set = handle.current().unwrap();
-        assert_eq!(set.block_overrides.number, Some(U256::from(25475334)));
-        assert_eq!(set.block_overrides.time, Some(1783363012));
-        assert_eq!(set.state_overrides.len(), 5);
+        let overrides = handle.current().unwrap();
+        assert_eq!(overrides.len(), 5);
 
         block_tx
             .send(BlockInfo {

--- a/crates/simulator/src/state_override_stream.rs
+++ b/crates/simulator/src/state_override_stream.rs
@@ -36,7 +36,6 @@ struct Inner {
     snapshots: watch::Receiver<Snapshot>,
     current_block: CurrentBlockWatcher,
     max_age: Duration,
-    max_block_lag: u64,
     block_time: Duration,
 }
 
@@ -50,7 +49,6 @@ impl std::fmt::Debug for SimulationOverrides {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SimulationOverrides")
             .field("max_age", &self.0.max_age)
-            .field("max_block_lag", &self.0.max_block_lag)
             .field("block_time", &self.0.block_time)
             .finish()
     }
@@ -74,7 +72,7 @@ impl SimulationOverrides {
             let info = self.0.current_block.borrow();
             (info.number, info.timestamp)
         };
-        if snapshot.block_number + self.0.max_block_lag < current_block_number {
+        if snapshot.block_number != current_block_number {
             Metrics::get().record_override_result(OverrideResult::Stale);
             return None;
         }
@@ -214,7 +212,6 @@ pub fn spawn(
         snapshots: receiver,
         current_block,
         max_age: cfg.max_age,
-        max_block_lag: cfg.max_block_lag,
         block_time,
     }))
 }
@@ -442,7 +439,6 @@ mod tests {
             snapshots: receiver,
             current_block: block_rx,
             max_age,
-            max_block_lag: 1,
             block_time: Duration::from_secs(12),
         }))
     }
@@ -474,7 +470,7 @@ mod tests {
                 .is_none()
         );
 
-        // Stale by block lag: snapshot block 100, head block 105, max lag 1.
+        // Stale by block mismatch: snapshot block 100, head block 105.
         let (_sender, receiver) = watch::channel(non_empty_snapshot(100, Instant::now()));
         let (_, block_rx) = block(105, 1000);
         assert!(
@@ -524,7 +520,6 @@ mod tests {
         let cfg = Config {
             ws_url: server_url,
             max_age: Duration::from_secs(30),
-            max_block_lag: 100,
         };
         let handle = spawn(&cfg, block_rx, Duration::from_secs(12));
 
@@ -602,7 +597,6 @@ mod tests {
             snapshots: receiver,
             current_block: block_rx,
             max_age: Duration::from_secs(30),
-            max_block_lag: 1,
             block_time: Duration::from_secs(12),
         }));
 

--- a/crates/simulator/src/tenderly/mod.rs
+++ b/crates/simulator/src/tenderly/mod.rs
@@ -68,12 +68,19 @@ impl Tenderly {
         &self,
         tx: T,
         block: BlockNo,
+        overrides: Option<StateOverride>,
         generate_access_list: GenerateAccessList,
     ) -> Result<Simulation, Error>
     where
         T: Into<TransactionRequest>,
     {
         let tx = tx.into();
+        // Strip nonce: Tenderly's StateObject::try_from rejects it, and pAMM
+        // frames always carry it. Contract nonces only matter for CREATE.
+        let mut overrides = overrides.unwrap_or_default();
+        for account_override in overrides.values_mut() {
+            account_override.nonce = None;
+        }
         let request = dto::Request {
             generate_access_list: match generate_access_list {
                 GenerateAccessList::Yes => Some(true),
@@ -81,12 +88,7 @@ impl Tenderly {
             },
             save_if_fails: self.save_if_fails.then_some(true),
             save: self.save.then_some(true),
-            ..prepare_request(
-                self.eth.chain().id().to_string(),
-                &tx,
-                Default::default(),
-                block,
-            )?
+            ..prepare_request(self.eth.chain().id().to_string(), &tx, overrides, block)?
         };
 
         Ok(self

--- a/crates/simulator/tests/aave_replay.rs
+++ b/crates/simulator/tests/aave_replay.rs
@@ -166,6 +166,7 @@ async fn build_replay_simulation(rpc_url: &str, full_app_data: &str) -> EthCallI
         balance_overrider,
         block_stream,
         None,
+        None,
     )
     .await
     .expect("failed to create SettlementSimulator");
@@ -276,6 +277,7 @@ async fn build_naturally_failing_replay_simulation(
         30_000_000u64,
         balance_overrider,
         block_stream,
+        None,
         None,
     )
     .await


### PR DESCRIPTION
## Problem

Titan's propAMMs (pAMMs) hold their live prices in maker quote streams. The CoW driver simulates every solver solution before scoring (gas estimation via `eth_estimateGas` against a plain node), and the trade verifier simulates proposed quotes the same way — both without any state overrides.

Titan publishes a public pAMM state stream: eth_call-style state-override sets over websocket (`wss://{eu,ap,us}.rpc.titanbuilder.xyz/ws/pamm_quote_stream`, no auth, ~100–400 ms cadence), plus an HTTP snapshot method `titan_getPammStateOverrides`. Without applying the overrides, a node sim only sees the pAMM's last-committed-block storage.

Ref: https://docs.titanbuilder.xyz/propamms/takers#pamm-state-stream

## Approach

A generic, fully opt-in \"simulation state-override stream\" feature. The wire format is exactly Ethereum's standard State Override Set, so nothing Titan-branded lives in code — the Titan endpoint appears only in `example.toml` comments and this PR description. When the config section is absent: no task is spawned, and the RPC override parameters are omitted entirely — byte-identical behavior to today.

The stream module (`crates/simulator/src/state_override_stream.rs`) spawns a background tokio task that connects to the websocket, parses per-venue frames, and flattens them into one `StateOverride` (latest frame wins per account, matching the builder's `pamm_quote_stream` accumulator design). It publishes via `tokio::sync::watch`; `SimulationOverrides::current()` gates on staleness (local receive time, not the producer wall-clock frame timestamp) and block lag, returning `None` so callers omit the RPC params entirely on a stale/unconfigured stream. Reconnect uses exponential backoff (250 ms → 15 s cap). Prometheus metrics cover frames, parse failures, reconnects, account count, and `simulations_with_overrides{applied,stale}`.

### Next-block pinning

`current()` also returns `BlockOverrides { number: head+1, time: head_timestamp + chain_block_time }`. The stream frame's top-level `timestamp` is the producer wall clock (nanoseconds), not block time, so the next-block timestamp is derived from the current head block's timestamp plus `Chain::block_time_in_ms()` instead. This pins the simulation to the next block — the block context the streamed venue state is intended for.

### Backends

- **Ethereum**: `estimate_gas` gains `Option<StateOverride>` + `Option<BlockOverrides>` via `overrides_opt` / `with_block_overrides_opt` (`None` omits the RPC params). Requires a node supporting `eth_estimateGas` state/block overrides (geth ≥1.13, reth, nethermind, recent erigon, anvil).
- **Tenderly**: `simulate` gains `Option<StateOverride>`; nonce is stripped inline (Tenderly's `StateObject::try_from` rejects it, pAMM frames always carry it, and contract nonces only matter for CREATE). Full-`state` overrides are left for `try_from` to reject.
- **`access_list()`**: unchanged — the access-list probe is a 1-wei ETH transfer that never touches pAMM state, and `create_access_list` has no override support.

### Trade verifier

`SettlementSimulator` gains an optional `SimulationOverrides` handle. `finish_simulation_builder` appends streamed overrides as `AccountOverrideRequest::Custom` so `build_final_state_overrides`' existing merge + conflict handling arbitrates against the verifier's own overrides (solver code, trader balance/approval slots). Block overrides are forwarded into `EthCallInputs` and applied in `simulate()` (`eth_call`) and `simulation_report()` (`debug_traceCall`). The shared `SettlementSimulator` covers both the trade verifier and the orderbook order-creation simulator.

### Config

```toml
# [simulator.state-override-stream]
# ws-url = "wss://eu.rpc.titanbuilder.xyz/ws/pamm_quote_stream"
# max-age = "3s"        # ignore the snapshot if the last frame is older than this
# max-block-lag = 1     # ignore the snapshot if its block number lags head by more than this
```

The same optional section is added to the price-estimation config for the trade-verifier path.

## Tests

- 9 hermetic unit tests: frame parsing (verbatim Titan sample + real frames captured from `wss://eu.rpc.titanbuilder.xyz/ws/pamm_quote_stream`), per-account flattening across venues, latest-wins conflict handling, all three staleness gates, and an in-process WebSocket server reconnect/accumulation test.
- 2 `#[ignore]`'d anvil integration tests: deploy a contract reverting unless storage slot 0 is nonzero, assert `estimate_gas` reverts without the override and succeeds with it, and that block overrides are accepted.
