### PR TITLE
Fix playground

### DIFF
--- a/.github/workflows/playground-check.yaml
+++ b/.github/workflows/playground-check.yaml
@@ -5,6 +5,9 @@ on:
   schedule:
     # Run this job once per day
     - cron: "0 0 * * *"
+  pull_request:
+    paths:
+      - "playground/**"
 
 jobs:
   playground-check:

--- a/playground/docker-compose.fork.yml
+++ b/playground/docker-compose.fork.yml
@@ -45,6 +45,11 @@ services:
       - postgres:/var/lib/postgresql/data
     ports:
       - 5432:5432
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   adminer:
     image: adminer
@@ -52,7 +57,8 @@ services:
     ports:
       - 8082:8080
     depends_on:
-      - db
+      db:
+        condition: service_healthy
 
   db-migrations:
     build:
@@ -63,7 +69,8 @@ services:
     environment:
       - FLYWAY_URL=jdbc:postgresql://db/?user=${POSTGRES_USER}&password=${POSTGRES_PASSWORD}
     depends_on:
-      - db
+      db:
+        condition: service_healthy
 
   orderbook:
     build:

--- a/playground/docker-compose.fork.yml
+++ b/playground/docker-compose.fork.yml
@@ -80,6 +80,7 @@ services:
     # explicit tag so the localdev and prebuilt compose variants never reuse
     # each other's images (default tags collide on project + service name)
     image: playground-orderbook:localdev
+    pull_policy: build
     restart: always
     command:
       [
@@ -111,6 +112,7 @@ services:
       target: localdev
       dockerfile: ./playground/Dockerfile
     image: playground-autopilot:localdev
+    pull_policy: build
     restart: always
     command:
       [
@@ -144,6 +146,7 @@ services:
       target: localdev
       dockerfile: ./playground/Dockerfile
     image: playground-driver:localdev
+    pull_policy: build
     restart: always
     command:
       [
@@ -177,6 +180,7 @@ services:
       target: localdev
       dockerfile: ./playground/Dockerfile
     image: playground-baseline:localdev
+    pull_policy: build
     restart: always
     command:
       [

--- a/playground/docker-compose.non-interactive.yml
+++ b/playground/docker-compose.non-interactive.yml
@@ -45,6 +45,11 @@ services:
       - postgres:/var/lib/postgresql/data
     ports:
       - 5432:5432
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   adminer:
     image: adminer
@@ -52,7 +57,8 @@ services:
     ports:
       - 8082:8080
     depends_on:
-      - db
+      db:
+        condition: service_healthy
 
   db-migrations:
     build:
@@ -63,7 +69,8 @@ services:
     environment:
       - FLYWAY_URL=jdbc:postgresql://db/?user=${POSTGRES_USER}&password=${POSTGRES_PASSWORD}
     depends_on:
-      - db
+      db:
+        condition: service_healthy
 
   orderbook:
     build:


### PR DESCRIPTION
# Description
When running the playground locally 2 issues happened:
1. docker thought it's supposed to pull the images that it was supposed to build - fixed with `pull_policy: build`
2. some services didn't start properly because they tried to use the DB before it was actually ready - fixed with health check

## How to test
I ran the playground test script locally.
Also I adjusted the playground test action to trigger on PRs that modify any files in the `playground` directory to test this change also in CI. ([successful run](https://github.com/cowprotocol/services/actions/runs/28856995972/job/85585895882?pr=4608))