### PR TITLE
Only log tenderly command on error

### DIFF
--- a/crates/price-estimation/src/trade_verifier.rs
+++ b/crates/price-estimation/src/trade_verifier.rs
@@ -7,7 +7,11 @@ use {
         map_interactions_data,
     },
     ::alloy::sol_types::SolCall,
-    alloy::primitives::{Address, U256, address, aliases::I512},
+    alloy::{
+        primitives::{Address, Bytes, U256, address, aliases::I512},
+        providers::Provider,
+        rpc::types::{TransactionRequest, state::StateOverride},
+    },
     anyhow::{Context, Result},
     bigdecimal::BigDecimal,
     contracts::support::Solver,
@@ -129,9 +133,26 @@ impl TradeVerifier {
             .assemble_settle_call(&verification, query, trade)
             .await?;
 
-        let summary = self
-            .generate_execution_report(settle_call, trade, query, &verification)
-            .await?;
+        let swap_call = self.build_swap_call(settle_call, trade, query, &verification)?;
+
+        let summary = match self
+            .execute_and_analyze(&swap_call, query, &verification)
+            .await
+        {
+            Ok(s) => s,
+            Err(err) => {
+                if let Some(tenderly) = &self.tenderly
+                    && let Err(log_err) = tenderly.log_simulation_command(
+                        swap_call.tx_request,
+                        swap_call.state_overrides,
+                        swap_call.block.into(),
+                    )
+                {
+                    tracing::debug!(?log_err, "could not log tenderly simulation command");
+                }
+                return Err(err);
+            }
+        };
 
         tracing::debug!(
             tokens_lost = ?summary.tokens_lost,
@@ -150,16 +171,16 @@ impl TradeVerifier {
         ensure_quote_accuracy(&self.quote_inaccuracy_limit, query, trade, &summary)
     }
 
-    /// To understand what's happening during the `settle_call` we need to
-    /// execute it through a helper contract. This function sets this up,
-    /// runs the simulation, and returns the resulting report.
-    async fn generate_execution_report(
+    /// Prepares a `SwapCall` by encoding the settlement through the helper
+    /// solver contract. The returned value can be used both to execute the
+    /// simulation and, on failure, to generate a Tenderly debugging command.
+    fn build_swap_call(
         &self,
         settle_call: EthCallInputs,
         trade: &TradeKind,
         query: &PriceQuery,
         verification: &Verification,
-    ) -> Result<SettleOutput, Error> {
+    ) -> Result<SwapCall, Error> {
         // Use `tx_origin` if response indicates that a special address is needed for
         // the simulation to pass. Otherwise just use the solver address.
         let solver_contract =
@@ -180,7 +201,7 @@ impl TradeVerifier {
             OrderKind::Buy => trade.out_amount(query)?,
         };
 
-        let swap_call = solver_contract
+        let call = solver_contract
             .swap(
                 self.simulator.settlement_address(),
                 tokens.clone(),
@@ -192,33 +213,46 @@ impl TradeVerifier {
                 settle_call.calldata.clone(),
             )
             .from(*solver_contract.address())
-            .gas(self.simulator.max_gas_limit())
-            .block(settle_call.block.into())
-            .state(settle_call.state_overrides.clone());
+            .gas(self.simulator.max_gas_limit());
 
-        if let Some(tenderly) = &self.tenderly
-            && let Err(err) = tenderly.log_simulation_command(
-                swap_call.clone().into_transaction_request(),
-                settle_call.state_overrides,
-                settle_call.block.into(),
-            )
-        {
-            tracing::debug!(?err, "could not log tenderly simulation command");
-        }
+        Ok(SwapCall {
+            tx_request: call.into_transaction_request(),
+            state_overrides: settle_call.state_overrides,
+            block: settle_call.block,
+            tokens,
+            calldata: settle_call.calldata,
+        })
+    }
 
-        let output = swap_call
-            .call()
+    /// Runs the `swap_call` simulation via a raw provider call and extracts
+    /// the [`SettleOutput`] from the decoded response.
+    async fn execute_and_analyze(
+        &self,
+        swap: &SwapCall,
+        query: &PriceQuery,
+        verification: &Verification,
+    ) -> Result<SettleOutput, Error> {
+        let output_bytes = self
+            .simulator
+            .provider()
+            .call(swap.tx_request.clone())
+            .overrides(swap.state_overrides.clone())
+            .block(swap.block.into())
             .await
             .context("failed to simulate quote")
             .map_err(Error::SimulationFailed)?;
 
-        let mut summary = SettleOutput::from_swap(output, query.kind, &tokens)?;
+        let output = Solver::Solver::swapCall::abi_decode_returns(&output_bytes)
+            .context("failed to decode swap output")
+            .map_err(Error::SimulationFailed)?;
+
+        let mut summary = SettleOutput::from_swap(output, query.kind, &swap.tokens)?;
 
         // adjust the reported gas cost since it does not take into account the 21K
         // units every tx has to pay and the cost for the calldata. we are
         // overcounting the calldata cost slightly since a regular settlement
         // would not include the 2 interactions measuring the token balances.
-        let call_data_cost = settle_call
+        let call_data_cost = swap
             .calldata
             .iter()
             .map(|byte| if byte == &0x0 { 4 } else { 16 })
@@ -624,6 +658,20 @@ impl TradeVerifying for TradeVerifier {
             }
         }
     }
+}
+
+/// Prepared simulation call: contains a transaction request ready to execute
+/// via `eth_call` plus all the metadata needed to construct a Tenderly
+/// debugging command on failure.
+struct SwapCall {
+    tx_request: TransactionRequest,
+    state_overrides: StateOverride,
+    /// Block number used for both execution and Tenderly logging.
+    block: u64,
+    /// Token list passed to `Solver::swap` for balance-change tracking.
+    tokens: Vec<Address>,
+    /// Encoded settlement calldata, needed for gas cost computation.
+    calldata: Bytes,
 }
 
 /// Analyzed output of `Solver::settle` smart contract call.

--- a/crates/price-estimation/src/trade_verifier.rs
+++ b/crates/price-estimation/src/trade_verifier.rs
@@ -670,7 +670,7 @@ impl TradeVerifying for TradeVerifier {
     }
 }
 
-/// Contains information to execute the simulation request, interpret the data
+/// Contains information to execute the simulation request, interpret the result
 /// and construct a tenderly simulation from it for debugging.
 struct SwapCall {
     tx_request: TransactionRequest,

--- a/crates/price-estimation/src/trade_verifier.rs
+++ b/crates/price-estimation/src/trade_verifier.rs
@@ -139,10 +139,8 @@ impl TradeVerifier {
             .context("solver provided no gas estimate")
     }
 
-    /// Executes the simulation and checks quote accuracy. Takes the `SwapCall`
-    /// by reference so the caller retains ownership for Tenderly logging when
-    /// it decides to surface the error.
-    async fn verify_quote(
+    /// Executes the simulation and checks quote accuracy.
+    async fn get_verified_price_estimate(
         &self,
         swap: &SwapCall,
         query: &PriceQuery,
@@ -171,10 +169,10 @@ impl TradeVerifier {
         ensure_quote_accuracy(&self.quote_inaccuracy_limit, query, trade, &summary)
     }
 
-    /// Takes the prepared `settle_call` and builds the final `Solver::swap()`
-    /// call from it. That calls into the verification machinery that
-    /// collects additional data while the `settle_call` gets executed.
-    fn build_swap_call(
+    /// Passes the prepared `settle_call` to the simulation machinery which
+    /// makes sure all the pre-conditions are met and collects additional
+    /// information throughout the call (e.g. token movements, gas costs).
+    fn build_simulation_call(
         &self,
         settle_call: EthCallInputs,
         trade: &TradeKind,
@@ -224,8 +222,8 @@ impl TradeVerifier {
         })
     }
 
-    /// Runs the `swap_call` simulation via a raw provider call and extracts
-    /// the [`SettleOutput`] from the decoded response.
+    /// Runs the `swap_call` simulation, decodes the returned data, and analyzes
+    /// it.
     async fn execute_and_analyze(
         &self,
         swap: &SwapCall,
@@ -607,7 +605,7 @@ impl TradeVerifying for TradeVerifier {
             .build_settle_call(&verification, query, &trade)
             .await
             .and_then(|settle_call| {
-                self.build_swap_call(settle_call, &trade, query, &verification)
+                self.build_simulation_call(settle_call, &trade, query, &verification)
             });
 
         let swap_call = match swap_call_res {
@@ -623,7 +621,7 @@ impl TradeVerifying for TradeVerifier {
         };
 
         let verification_err = match self
-            .verify_quote(&swap_call, query, &verification, &trade)
+            .get_verified_price_estimate(&swap_call, query, &verification, &trade)
             .await
         {
             Ok(verified) => return Ok(verified),

--- a/crates/price-estimation/src/trade_verifier.rs
+++ b/crates/price-estimation/src/trade_verifier.rs
@@ -628,6 +628,19 @@ impl TradeVerifying for TradeVerifier {
             Err(err) => err,
         };
 
+        // because this log is extremely large we only emit the resimulation
+        // command if the trade had some interactions and it didn't pass verification
+        if trade.has_execution_plan()
+            && let Some(tenderly) = &self.tenderly
+            && let Err(log_err) = tenderly.log_simulation_command(
+                swap_call.tx_request,
+                swap_call.state_overrides,
+                swap_call.block.into(),
+            )
+        {
+            tracing::debug!(?log_err, "could not log tenderly simulation command");
+        }
+
         // For some tokens it's not possible to provide verifiable calldata in the
         // quote (e.g. when they require the use of proprietary APIs which don't give
         // out calldata willy nilly).
@@ -643,23 +656,8 @@ impl TradeVerifying for TradeVerifier {
         // `Error::BuffersPayForOrder` errors if the solver actually tried to provide
         // an execution plan but it's just not correct. In all other cases we just
         // flag the solution as unverified but let it pass.
-        let has_execution_plan = trade.has_execution_plan();
-        if has_execution_plan && matches!(verification_err, Error::BuffersPayForOrder) {
-            tracing::debug!(
-                has_execution_plan,
-                "discarding quote because buffers pay for order"
-            );
-            // because this log is extremely large we only emit the command
-            // to resimulate quotes that had some issue
-            if let Some(tenderly) = &self.tenderly
-                && let Err(log_err) = tenderly.log_simulation_command(
-                    swap_call.tx_request,
-                    swap_call.state_overrides,
-                    swap_call.block.into(),
-                )
-            {
-                tracing::debug!(?log_err, "could not log tenderly simulation command");
-            }
+        if trade.has_execution_plan() && matches!(verification_err, Error::BuffersPayForOrder) {
+            tracing::debug!("discarding quote because buffers pay for order");
             Err(verification_err.into())
         } else {
             tracing::debug!(estimate = ?unverified_result, ?verification_err, "quote verification failed");

--- a/crates/price-estimation/src/trade_verifier.rs
+++ b/crates/price-estimation/src/trade_verifier.rs
@@ -171,6 +171,9 @@ impl TradeVerifier {
         ensure_quote_accuracy(&self.quote_inaccuracy_limit, query, trade, &summary)
     }
 
+    /// Takes the prepared `settle_call` and builds the final `Solver::swap()`
+    /// call from it. That calls into the verification machinery that
+    /// collects additional data while the `settle_call` gets executed.
     fn build_swap_call(
         &self,
         settle_call: EthCallInputs,
@@ -265,7 +268,7 @@ impl TradeVerifier {
     ///   `0`). That way the solver can deliver **less** than promised and we
     ///   can still measure how much they actually delivered since the
     ///   simulation will not revert due to limit price violations.
-    async fn assemble_settle_call(
+    async fn build_settle_call(
         &self,
         verification: &Verification,
         query: &PriceQuery,
@@ -600,14 +603,14 @@ impl TradeVerifying for TradeVerifier {
             );
         }
 
-        let swap_call = self
-            .assemble_settle_call(&verification, query, &trade)
+        let swap_call_res = self
+            .build_settle_call(&verification, query, &trade)
             .await
             .and_then(|settle_call| {
                 self.build_swap_call(settle_call, &trade, query, &verification)
             });
 
-        let swap_call = match swap_call {
+        let swap_call = match swap_call_res {
             Ok(c) => c,
             Err(err) => {
                 tracing::debug!(
@@ -617,6 +620,14 @@ impl TradeVerifying for TradeVerifier {
                 );
                 return unverified_result;
             }
+        };
+
+        let verification_err = match self
+            .verify_quote(&swap_call, query, &verification, &trade)
+            .await
+        {
+            Ok(verified) => return Ok(verified),
+            Err(err) => err,
         };
 
         // For some tokens it's not possible to provide verifiable calldata in the
@@ -634,35 +645,27 @@ impl TradeVerifying for TradeVerifier {
         // `Error::BuffersPayForOrder` errors if the solver actually tried to provide
         // an execution plan but it's just not correct. In all other cases we just
         // flag the solution as unverified but let it pass.
-        match self
-            .verify_quote(&swap_call, query, &verification, &trade)
-            .await
-        {
-            Ok(verified) => Ok(verified),
-            Err(err) => {
-                let has_execution_plan = trade.has_execution_plan();
-                if has_execution_plan && matches!(err, Error::BuffersPayForOrder) {
-                    tracing::debug!(
-                        has_execution_plan,
-                        "discarding quote because buffers pay for order"
-                    );
-                    // because this log is extremely large we only emit the command
-                    // to resimulate quotes that had some issue
-                    if let Some(tenderly) = &self.tenderly
-                        && let Err(log_err) = tenderly.log_simulation_command(
-                            swap_call.tx_request,
-                            swap_call.state_overrides,
-                            swap_call.block.into(),
-                        )
-                    {
-                        tracing::debug!(?log_err, "could not log tenderly simulation command");
-                    }
-                    Err(err.into())
-                } else {
-                    tracing::debug!(estimate = ?unverified_result, ?err, "quote verification failed");
-                    unverified_result
-                }
+        let has_execution_plan = trade.has_execution_plan();
+        if has_execution_plan && matches!(verification_err, Error::BuffersPayForOrder) {
+            tracing::debug!(
+                has_execution_plan,
+                "discarding quote because buffers pay for order"
+            );
+            // because this log is extremely large we only emit the command
+            // to resimulate quotes that had some issue
+            if let Some(tenderly) = &self.tenderly
+                && let Err(log_err) = tenderly.log_simulation_command(
+                    swap_call.tx_request,
+                    swap_call.state_overrides,
+                    swap_call.block.into(),
+                )
+            {
+                tracing::debug!(?log_err, "could not log tenderly simulation command");
             }
+            Err(verification_err.into())
+        } else {
+            tracing::debug!(estimate = ?unverified_result, ?verification_err, "quote verification failed");
+            unverified_result
         }
     }
 }

--- a/crates/price-estimation/src/trade_verifier.rs
+++ b/crates/price-estimation/src/trade_verifier.rs
@@ -11,7 +11,6 @@ use {
         primitives::{Address, Bytes, U256, address, aliases::I512},
         providers::Provider,
         rpc::types::{TransactionRequest, state::StateOverride},
-        uint,
     },
     anyhow::{Context, Result},
     bigdecimal::BigDecimal,

--- a/crates/price-estimation/src/trade_verifier.rs
+++ b/crates/price-estimation/src/trade_verifier.rs
@@ -11,6 +11,7 @@ use {
         primitives::{Address, Bytes, U256, address, aliases::I512},
         providers::Provider,
         rpc::types::{TransactionRequest, state::StateOverride},
+        uint,
     },
     anyhow::{Context, Result},
     bigdecimal::BigDecimal,
@@ -751,16 +752,28 @@ impl SettleOutput {
         })
     }
 
+    /// Adjusts the reported gas cost since the simulation measurement does not
+    /// take into account the 21K units every tx has to pay and the cost for
+    /// the calldata. We are overcounting the calldata cost slightly since a
+    /// regular settlement would not include the 2 interactions measuring
+    /// the token balances.
     fn with_call_overhead(mut self, calldata: &[u8]) -> Self {
-        // adjust the reported gas cost since it does not take into account the 21K
-        // units every tx has to pay and the cost for the calldata. we are
-        // overcounting the calldata cost slightly since a regular settlement
-        // would not include the 2 interactions measuring the token balances.
+        // constants as defined in <https://ethereum.github.io/yellowpaper/paper.pdf>
+        // refferred to as Gtransaction, Gtxdatazero, and Gtxdatanonzero
+        const TX_BASE_COST: u64 = 21_000;
+        const CALLDATA_COST_PER_ZERO_BYTE: u64 = 4;
+        const CALLDATA_COST_PER_NONZERO_BYTE: u64 = 16;
         let call_data_cost = calldata
             .iter()
-            .map(|byte| if byte == &0x0 { 4 } else { 16 })
+            .map(|byte| {
+                if byte == &0x0 {
+                    CALLDATA_COST_PER_ZERO_BYTE
+                } else {
+                    CALLDATA_COST_PER_NONZERO_BYTE
+                }
+            })
             .sum::<u64>();
-        self.gas_used += U256::from(21_000) + U256::from(call_data_cost);
+        self.gas_used += U256::from(TX_BASE_COST.saturating_add(call_data_cost));
         self
     }
 }

--- a/crates/price-estimation/src/trade_verifier.rs
+++ b/crates/price-estimation/src/trade_verifier.rs
@@ -110,49 +110,49 @@ impl TradeVerifier {
         }
     }
 
-    async fn verify_inner(
+    /// Builds an unverified estimate from the trade's own gas estimate and
+    /// promised output amount. Returns an error if the trade provides no gas
+    /// estimate, since an unverified quote is meaningless without one.
+    fn unverified_estimate(&self, query: &PriceQuery, trade: &TradeKind) -> Result<Estimate> {
+        let out_amount = trade
+            .out_amount(query)
+            .context("failed to compute trade out amount")?;
+        trade
+            .gas_estimate()
+            .map(|gas| {
+                let gas = gas.clamp(
+                    self.min_gas_amount_for_unverified_quotes as u64,
+                    self.max_gas_amount_for_unverified_quotes as u64,
+                );
+                Estimate {
+                    out_amount,
+                    gas,
+                    solver: trade.solver(),
+                    verified: false,
+                    execution: QuoteExecution {
+                        interactions: map_interactions_data(trade.interactions()),
+                        pre_interactions: map_interactions_data(trade.pre_interactions()),
+                        jit_orders: trade.jit_orders().cloned().collect(),
+                    },
+                }
+            })
+            .context("solver provided no gas estimate")
+    }
+
+    /// Executes the simulation and checks quote accuracy. Takes the `SwapCall`
+    /// by reference so the caller retains ownership for Tenderly logging when
+    /// it decides to surface the error.
+    async fn verify_quote(
         &self,
+        swap: &SwapCall,
         query: &PriceQuery,
-        mut verification: Verification,
+        verification: &Verification,
         trade: &TradeKind,
     ) -> Result<Estimate, Error> {
         let start = std::time::Instant::now();
         let out_amount = trade.out_amount(query)?;
 
-        // if the user does not have their wallet connected we use a random
-        // address because many tokens revert when transfers involve the 0 address.
-        if verification.from.is_zero() {
-            verification.from = Address::random();
-            tracing::debug!(
-                trader = ?verification.from,
-                "using random trader address with fake balances"
-            );
-        }
-
-        let settle_call = self
-            .assemble_settle_call(&verification, query, trade)
-            .await?;
-
-        let swap_call = self.build_swap_call(settle_call, trade, query, &verification)?;
-
-        let summary = match self
-            .execute_and_analyze(&swap_call, query, &verification)
-            .await
-        {
-            Ok(s) => s,
-            Err(err) => {
-                if let Some(tenderly) = &self.tenderly
-                    && let Err(log_err) = tenderly.log_simulation_command(
-                        swap_call.tx_request,
-                        swap_call.state_overrides,
-                        swap_call.block.into(),
-                    )
-                {
-                    tracing::debug!(?log_err, "could not log tenderly simulation command");
-                }
-                return Err(err);
-            }
-        };
+        let summary = self.execute_and_analyze(swap, query, verification).await?;
 
         tracing::debug!(
             tokens_lost = ?summary.tokens_lost,
@@ -171,9 +171,6 @@ impl TradeVerifier {
         ensure_quote_accuracy(&self.quote_inaccuracy_limit, query, trade, &summary)
     }
 
-    /// Prepares a `SwapCall` by encoding the settlement through the helper
-    /// solver contract. The returned value can be used both to execute the
-    /// simulation and, on failure, to generate a Tenderly debugging command.
     fn build_swap_call(
         &self,
         settle_call: EthCallInputs,
@@ -220,7 +217,7 @@ impl TradeVerifier {
             state_overrides: settle_call.state_overrides,
             block: settle_call.block,
             tokens,
-            calldata: settle_call.calldata,
+            settle_calldata: settle_call.calldata,
         })
     }
 
@@ -246,18 +243,8 @@ impl TradeVerifier {
             .context("failed to decode swap output")
             .map_err(Error::SimulationFailed)?;
 
-        let mut summary = SettleOutput::from_swap(output, query.kind, &swap.tokens)?;
-
-        // adjust the reported gas cost since it does not take into account the 21K
-        // units every tx has to pay and the cost for the calldata. we are
-        // overcounting the calldata cost slightly since a regular settlement
-        // would not include the 2 interactions measuring the token balances.
-        let call_data_cost = swap
-            .calldata
-            .iter()
-            .map(|byte| if byte == &0x0 { 4 } else { 16 })
-            .sum::<u64>();
-        summary.gas_used += U256::from(21_000) + U256::from(call_data_cost);
+        let summary = SettleOutput::from_swap(output, query.kind, &swap.tokens)?
+            .with_call_overhead(&swap.settle_calldata);
 
         Self::post_process_summary(
             self.simulator.settlement_address(),
@@ -592,31 +579,7 @@ impl TradeVerifying for TradeVerifier {
         verification: &Verification,
         trade: TradeKind,
     ) -> Result<Estimate> {
-        let out_amount = trade
-            .out_amount(query)
-            .context("failed to compute trade out amount")?;
-
-        let unverified_result = trade
-            .gas_estimate()
-            .map(|gas| {
-                let gas = gas.clamp(
-                    self.min_gas_amount_for_unverified_quotes as u64,
-                    self.max_gas_amount_for_unverified_quotes as u64,
-                );
-
-                Estimate {
-                    out_amount,
-                    gas,
-                    solver: trade.solver(),
-                    verified: false,
-                    execution: QuoteExecution {
-                        interactions: map_interactions_data(trade.interactions()),
-                        pre_interactions: map_interactions_data(trade.pre_interactions()),
-                        jit_orders: trade.jit_orders().cloned().collect(),
-                    },
-                }
-            })
-            .context("solver provided no gas estimate");
+        let unverified_result = self.unverified_estimate(query, &trade);
 
         let skip_verification = [query.buy_token, query.sell_token]
             .iter()
@@ -626,30 +589,74 @@ impl TradeVerifying for TradeVerifier {
             return unverified_result;
         }
 
-        match self.verify_inner(query, verification.clone(), &trade).await {
+        let mut verification = verification.clone();
+        // if the user does not have their wallet connected we use a random
+        // address because many tokens revert when transfers involve the 0 address.
+        if verification.from.is_zero() {
+            verification.from = Address::random();
+            tracing::debug!(
+                trader = ?verification.from,
+                "using random trader address with fake balances"
+            );
+        }
+
+        let swap_call = self
+            .assemble_settle_call(&verification, query, &trade)
+            .await
+            .and_then(|settle_call| {
+                self.build_swap_call(settle_call, &trade, query, &verification)
+            });
+
+        let swap_call = match swap_call {
+            Ok(c) => c,
+            Err(err) => {
+                tracing::debug!(
+                    estimate = ?unverified_result,
+                    ?err,
+                    "quote verification failed"
+                );
+                return unverified_result;
+            }
+        };
+
+        // For some tokens it's not possible to provide verifiable calldata in the
+        // quote (e.g. when they require the use of proprietary APIs which don't give
+        // out calldata willy nilly).
+        //
+        // Since you can't magically make up calldata that makes your quote verifiable
+        // solvers don't provide any call data in those cases.
+        // This has 2 possible outcomes:
+        // 1. the settlement contract has enough buy_tokens to pay for the order =>
+        //    Error::BuffersPayForOrder
+        // 2. not enough buy tokens in buffer => Error::SimulationFailed
+        //
+        // To make handling of these quotes more predictable we'll only discard
+        // `Error::BuffersPayForOrder` errors if the solver actually tried to provide
+        // an execution plan but it's just not correct. In all other cases we just
+        // flag the solution as unverified but let it pass.
+        match self
+            .verify_quote(&swap_call, query, &verification, &trade)
+            .await
+        {
             Ok(verified) => Ok(verified),
             Err(err) => {
-                // For some tokens it's not possible to provide verifiable calldata in the
-                // quote (e.g. when they require the use of proprietary APIs which don't give
-                // out calldata willy nilly).
-                //
-                // Since you can't magically make up calldata that makes your quote verifiable
-                // solvers don't provide any call data in those cases.
-                // This has 2 possible outcomes:
-                // 1. the settlement contract has enough buy_tokens to pay for the order =>
-                //    Error::BuffersPayForOrder
-                // 2. not enough buy tokens in buffer => error::SimulationFailure
-                //
-                // To make handling of these quotes more predictable we'll only discard
-                // `Error::BufferPayForOrder` errors if the solver actually tried to provide a
-                // an execution plan but it's just not correct. In all other cases we just flag
-                // the solution as unverified but let it pass.
                 let has_execution_plan = trade.has_execution_plan();
                 if has_execution_plan && matches!(err, Error::BuffersPayForOrder) {
                     tracing::debug!(
                         has_execution_plan,
                         "discarding quote because buffers pay for order"
                     );
+                    // because this log is extremely large we only emit the command
+                    // to resimulate quotes that had some issue
+                    if let Some(tenderly) = &self.tenderly
+                        && let Err(log_err) = tenderly.log_simulation_command(
+                            swap_call.tx_request,
+                            swap_call.state_overrides,
+                            swap_call.block.into(),
+                        )
+                    {
+                        tracing::debug!(?log_err, "could not log tenderly simulation command");
+                    }
                     Err(err.into())
                 } else {
                     tracing::debug!(estimate = ?unverified_result, ?err, "quote verification failed");
@@ -670,8 +677,11 @@ struct SwapCall {
     block: u64,
     /// Token list passed to `Solver::swap` for balance-change tracking.
     tokens: Vec<Address>,
-    /// Encoded settlement calldata, needed for gas cost computation.
-    calldata: Bytes,
+    /// Calldata of the `settle()` call we are analysing. Note that this is
+    /// different from the calldata of the `tx_request` as that calls into
+    /// additionaly machinery needed for the analysis.
+    /// This calldata gets used to finalize the gas used of the simulation.
+    settle_calldata: Bytes,
 }
 
 /// Analyzed output of `Solver::settle` smart contract call.
@@ -741,6 +751,19 @@ impl SettleOutput {
             out_amount,
             tokens_lost,
         })
+    }
+
+    fn with_call_overhead(mut self, calldata: &[u8]) -> Self {
+        // adjust the reported gas cost since it does not take into account the 21K
+        // units every tx has to pay and the cost for the calldata. we are
+        // overcounting the calldata cost slightly since a regular settlement
+        // would not include the 2 interactions measuring the token balances.
+        let call_data_cost = calldata
+            .iter()
+            .map(|byte| if byte == &0x0 { 4 } else { 16 })
+            .sum::<u64>();
+        self.gas_used += U256::from(21_000) + U256::from(call_data_cost);
+        self
     }
 }
 

--- a/crates/price-estimation/src/trade_verifier.rs
+++ b/crates/price-estimation/src/trade_verifier.rs
@@ -670,9 +670,8 @@ impl TradeVerifying for TradeVerifier {
     }
 }
 
-/// Prepared simulation call: contains a transaction request ready to execute
-/// via `eth_call` plus all the metadata needed to construct a Tenderly
-/// debugging command on failure.
+/// Contains information to execute the simulation request, interpret the data
+/// and construct a tenderly simulation from it for debugging.
 struct SwapCall {
     tx_request: TransactionRequest,
     state_overrides: StateOverride,


### PR DESCRIPTION
# Description
While the `curl` commands to resimulate a quote are very helpful they are also extremely huge and put considerable load on our logging infra.
Also usually you only look into quotes that could not be verified and since the majority of quotes can be verified this produces a lot of expensive noise.

# Changes
Getting the tenderly data out of the simulation without a ton of duplicated error handling is not straight forward because it's getting generated a few calls deep and the tenderly data is needed in some Ok and also Err cases.
That's why I decided to refactor the code into effectively 2 phases:
1. build the simulation call
2. execute and analyze the simulation call

Since the data returned by `1` is enough to emit the tenderly call from it and `2` encapsulates the entire rest of the logic we can more or less just match once on the result of `2` and emit the tenderly report when it's needed.
The new logic emits a quote when:
* simulation call reverts
* we discard a quote for being too inaccurate (note that this already takes the RWA escape hatch into account).

## How to test
e2e test assertions make sure the behavior of the simulation logic didn't change
inspecting the logs of an e2e test with an unverifiable quote shows we emit logs correctly