### PR TITLE
feat(solana-indexer): 7.2 decode settlement instructions into typed events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9047,6 +9047,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "settlement-interface"
+version = "0.1.0"
+source = "git+https://github.com/cowprotocol/solana-programs?rev=4e0bd7eaed7c237a327705425be2a4a50a8b4a3a#4e0bd7eaed7c237a327705425be2a4a50a8b4a3a"
+dependencies = [
+ "arrayref",
+ "derive_more 1.0.0",
+ "num_enum",
+ "solana-account-view",
+ "solana-address 2.6.1",
+ "solana-hash 3.1.0",
+ "solana-instruction",
+ "solana-program-error",
+ "solana-pubkey 3.0.0",
+ "solana-sdk-ids",
+ "solana-sha256-hasher",
+ "solana-system-interface 3.2.0",
+ "spl-token-interface",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9443,6 +9463,16 @@ dependencies = [
  "solana-address 2.6.1",
  "solana-program-error",
  "solana-program-memory",
+]
+
+[[package]]
+name = "solana-account-view"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc141b940560430425ebaadb7645496c45f6a10fad9911d719bd03eab7f4d422"
+dependencies = [
+ "solana-address 2.6.1",
+ "solana-program-error",
 ]
 
 [[package]]
@@ -9884,6 +9914,7 @@ dependencies = [
  "bytes",
  "derive_more 1.0.0",
  "futures",
+ "settlement-interface",
  "solana-client",
  "solana-sdk",
  "thiserror 1.0.69",

--- a/crates/solana-indexer/Cargo.toml
+++ b/crates/solana-indexer/Cargo.toml
@@ -20,7 +20,11 @@ async-trait = { workspace = true }
 bytes = { workspace = true }
 derive_more = { workspace = true }
 futures = { workspace = true }
-settlement-interface = { git = "https://github.com/cowprotocol/solana-programs", rev = "4e0bd7eaed7c237a327705425be2a4a50a8b4a3a", package = "settlement-interface" }
+settlement-interface = {
+  package = "settlement-interface",
+  git = "https://github.com/cowprotocol/solana-programs",
+  rev = "4e0bd7eaed7c237a327705425be2a4a50a8b4a3a"
+}
 solana-client = { workspace = true }
 solana-sdk = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/solana-indexer/Cargo.toml
+++ b/crates/solana-indexer/Cargo.toml
@@ -20,6 +20,7 @@ async-trait = { workspace = true }
 bytes = { workspace = true }
 derive_more = { workspace = true }
 futures = { workspace = true }
+settlement-interface = { git = "https://github.com/cowprotocol/solana-programs", rev = "4e0bd7eaed7c237a327705425be2a4a50a8b4a3a", package = "settlement-interface" }
 solana-client = { workspace = true }
 solana-sdk = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/solana-indexer/src/indexer/decoder.rs
+++ b/crates/solana-indexer/src/indexer/decoder.rs
@@ -253,8 +253,8 @@ fn decode_order_created(
 ) -> Result<SettlementEvent, DecodeError> {
     let intent_bytes: &[u8; EncodedOrderIntent::SIZE] =
         body.try_into().map_err(|_| DecodeError::SchemaMismatch)?;
-    let (intent, uid) =
-        EncodedOrderIntent::decode_and_hash(intent_bytes).map_err(|_| DecodeError::SchemaMismatch)?;
+    let (intent, uid) = EncodedOrderIntent::decode_and_hash(intent_bytes)
+        .map_err(|_| DecodeError::SchemaMismatch)?;
     let created_by = resolve_account(instruction, account_keys, CREATE_ORDER_CREATED_BY)
         .ok_or(DecodeError::SchemaMismatch)?;
     Ok(SettlementEvent::OrderCreated {

--- a/crates/solana-indexer/src/indexer/decoder.rs
+++ b/crates/solana-indexer/src/indexer/decoder.rs
@@ -12,7 +12,7 @@ use {
         types::{
             Signature,
             channel::StreamUpdate,
-            errors::PersistenceError,
+            errors::{DecodeError, PersistenceError},
             events::{SettlementEvent, TradeDelta},
             order::OrderUid,
             slot::Slot,
@@ -197,26 +197,39 @@ fn decode_settlement(
 
     // Instructions decodable on their own, without tx-level pairing.
     for instruction in instructions {
-        let Ok((discriminator, _)) = recover_discriminator(&instruction.data) else {
+        let Ok((discriminator, body)) = recover_discriminator(&instruction.data) else {
             tracing::debug!(
                 instruction_index = instruction.instruction_index,
                 "settlement instruction with an unknown discriminator, skipping"
             );
             continue;
         };
-        match discriminator {
+        // A landed (non-reverted) transaction carries valid instruction data, so
+        // a decode failure here means a decoder bug or an unannounced program
+        // layout change, not a normal case. Surface it as a warning rather than
+        // dropping it silently. Once the persistence adapter lands these route to
+        // the dead-letter table.
+        let decoded = match discriminator {
             SettlementInstruction::CreateOrder => {
-                if let Some(event) = decode_order_created(instruction, &ctx.account_keys) {
-                    events.push(event);
-                }
+                decode_order_created(instruction, body, &ctx.account_keys).map(|event| vec![event])
             }
             SettlementInstruction::CreateBuffer => {
-                events.extend(decode_buffers_created(instruction, &ctx.account_keys));
+                decode_buffers_created(instruction, &ctx.account_keys)
             }
             // Bootstrap only, no domain event.
-            SettlementInstruction::Initialize => {}
+            SettlementInstruction::Initialize => Ok(Vec::new()),
             // Paired below, once both halves of the settlement are in hand.
-            SettlementInstruction::BeginSettle | SettlementInstruction::FinalizeSettle => {}
+            SettlementInstruction::BeginSettle | SettlementInstruction::FinalizeSettle => {
+                Ok(Vec::new())
+            }
+        };
+        match decoded {
+            Ok(decoded_events) => events.extend(decoded_events),
+            Err(err) => tracing::warn!(
+                instruction_index = instruction.instruction_index,
+                %err,
+                "failed to decode settlement instruction"
+            ),
         }
     }
 
@@ -235,13 +248,16 @@ fn decode_settlement(
 /// resolved from the instruction's account list.
 fn decode_order_created(
     instruction: &ResolvedInstruction,
+    body: &[u8],
     account_keys: &[Pubkey],
-) -> Option<SettlementEvent> {
-    let (_, body) = recover_discriminator(&instruction.data).ok()?;
-    let intent_bytes: &[u8; EncodedOrderIntent::SIZE] = body.try_into().ok()?;
-    let (intent, uid) = EncodedOrderIntent::decode_and_hash(intent_bytes).ok()?;
-    let created_by = resolve_account(instruction, account_keys, CREATE_ORDER_CREATED_BY)?;
-    Some(SettlementEvent::OrderCreated {
+) -> Result<SettlementEvent, DecodeError> {
+    let intent_bytes: &[u8; EncodedOrderIntent::SIZE] =
+        body.try_into().map_err(|_| DecodeError::SchemaMismatch)?;
+    let (intent, uid) =
+        EncodedOrderIntent::decode_and_hash(intent_bytes).map_err(|_| DecodeError::SchemaMismatch)?;
+    let created_by = resolve_account(instruction, account_keys, CREATE_ORDER_CREATED_BY)
+        .ok_or(DecodeError::SchemaMismatch)?;
+    Ok(SettlementEvent::OrderCreated {
         order_uid: OrderUid(uid.to_bytes()),
         owner: to_sdk_pubkey(intent.owner),
         created_by,
@@ -254,25 +270,24 @@ fn decode_order_created(
 fn decode_buffers_created(
     instruction: &ResolvedInstruction,
     account_keys: &[Pubkey],
-) -> Vec<SettlementEvent> {
-    let Some(per_buffer) = instruction.accounts.get(CREATE_BUFFER_SHARED_ACCOUNTS..) else {
-        return Vec::new();
-    };
+) -> Result<Vec<SettlementEvent>, DecodeError> {
+    let per_buffer = instruction
+        .accounts
+        .get(CREATE_BUFFER_SHARED_ACCOUNTS..)
+        .ok_or(DecodeError::SchemaMismatch)?;
     let (pairs, remainder) = per_buffer.as_chunks::<2>();
     if !remainder.is_empty() || pairs.is_empty() {
-        tracing::debug!(
-            instruction_index = instruction.instruction_index,
-            "CreateBuffer accounts did not form whole (buffer, mint) pairs, skipping"
-        );
-        return Vec::new();
+        return Err(DecodeError::SchemaMismatch);
     }
     pairs
         .iter()
-        .filter_map(|pair| {
+        .map(|pair| {
             // Each pair is `[buffer_pda_index, mint_index]`; the event token is
             // the buffer's mint.
-            let token = account_keys.get(usize::from(pair[1]))?;
-            Some(SettlementEvent::BufferCreated { token: *token })
+            let token = account_keys
+                .get(usize::from(pair[1]))
+                .ok_or(DecodeError::SchemaMismatch)?;
+            Ok(SettlementEvent::BufferCreated { token: *token })
         })
         .collect()
 }

--- a/crates/solana-indexer/src/indexer/decoder.rs
+++ b/crates/solana-indexer/src/indexer/decoder.rs
@@ -103,6 +103,9 @@ impl Decoder {
             post_token_balances,
         };
 
+        // `relevant_instructions` yields only settlement and SolFlow instructions.
+        // The settlement set is decoded here and the SolFlow set below, so the two
+        // filters are exhaustive and nothing is silently dropped.
         let settlement: Vec<ResolvedInstruction> = instructions
             .iter()
             .filter(|instruction| instruction.program_id == self.settlement_program)

--- a/crates/solana-indexer/src/indexer/decoder.rs
+++ b/crates/solana-indexer/src/indexer/decoder.rs
@@ -17,6 +17,7 @@ use {
         },
     },
     bytes::Bytes,
+    settlement_interface::{SettlementInstruction, recover_discriminator},
     solana_sdk::pubkey::Pubkey,
     tokio::sync::mpsc::Receiver,
 };
@@ -77,12 +78,53 @@ impl Decoder {
         }
     }
 
-    /// TODO: decode the settlement instruction data into typed events.
+    /// Identify the settlement instruction by its discriminator and route it to
+    /// the matching decode step.
+    ///
+    /// TODO: the per-instruction bodies are stubbed. Real decoding is blocked
+    /// on the program emitting `auction_id` (BeginSettle) and the sell/push
+    /// amounts (BeginSettle/FinalizeSettle), and on a data-only interface
+    /// parser: the interface's `parse` wants on-chain `AccountView`s a
+    /// tx-only indexer does not have. Discriminator dispatch is wired so
+    /// each arm can be filled once those land.
     fn decode_settlement(&self, instruction: &ResolvedInstruction) {
-        tracing::debug!(
-            instruction_index = instruction.instruction_index,
-            "settlement instruction decode not implemented"
-        );
+        let index = instruction.instruction_index;
+        let Ok((discriminator, _body)) = recover_discriminator(&instruction.data) else {
+            tracing::debug!(
+                instruction_index = index,
+                "settlement instruction with an unknown discriminator, skipping"
+            );
+            return;
+        };
+        match discriminator {
+            SettlementInstruction::CreateOrder => {
+                tracing::debug!(
+                    instruction_index = index,
+                    "CreateOrder, OrderCreated decode stubbed"
+                );
+            }
+            SettlementInstruction::BeginSettle => {
+                tracing::debug!(
+                    instruction_index = index,
+                    "BeginSettle, sell amounts + auction_id decode stubbed"
+                );
+            }
+            SettlementInstruction::FinalizeSettle => {
+                tracing::debug!(
+                    instruction_index = index,
+                    "FinalizeSettle, push amounts decode stubbed"
+                );
+            }
+            SettlementInstruction::CreateBuffer => {
+                tracing::debug!(
+                    instruction_index = index,
+                    "CreateBuffer, BufferCreated decode stubbed"
+                );
+            }
+            SettlementInstruction::Initialize => {
+                tracing::debug!(instruction_index = index, "Initialize, no domain event");
+            }
+        }
     }
 
     /// TODO: decode the SolFlow instruction data. The on-chain program does not

--- a/crates/solana-indexer/src/indexer/decoder.rs
+++ b/crates/solana-indexer/src/indexer/decoder.rs
@@ -2,22 +2,32 @@
 //! The decoder pulls `StreamUpdate`s from the ingester, decodes
 //! settlement-program and SolFlow transactions, and persists typed events.
 
-// TODO: `decode_settlement`/`decode_solflow` and the persist path are stubbed.
-// `run` drains the channel and routes each transaction's tracked instructions
-// to those stubs.
+// TODO: `decode_solflow` and the persist path are stubbed. `run` drains the
+// channel, decodes settlement instructions into `SettlementEvent`s, and drops
+// them until the persistence adapter lands.
 
 use {
     crate::{
         persistence::Persistence,
         types::{
+            Signature,
             channel::StreamUpdate,
             errors::PersistenceError,
-            tx::ResolvedInstruction,
+            events::{SettlementEvent, TradeDelta},
+            order::OrderUid,
+            slot::Slot,
+            tx::{ResolvedInstruction, TxContext},
             wire::SubscribeUpdateTransactionInfo,
         },
     },
     bytes::Bytes,
-    settlement_interface::{SettlementInstruction, recover_discriminator},
+    settlement_interface::{
+        Pubkey as InterfacePubkey,
+        SettlementInstruction,
+        data::intent::EncodedOrderIntent,
+        instruction::settle::recover_counterpart,
+        recover_discriminator,
+    },
     solana_sdk::pubkey::Pubkey,
     tokio::sync::mpsc::Receiver,
 };
@@ -53,78 +63,74 @@ impl Decoder {
         }
     }
 
-    /// Main loop. Drains the channel and routes each transaction's tracked
-    /// instructions to their per-program decoders. Returns when the ingester
-    /// drops the sender.
+    /// Main loop. Drains the channel and decodes each transaction's tracked
+    /// instructions. Returns when the ingester drops the sender.
     pub async fn run(&mut self) -> Result<(), PersistenceError> {
         while let Some(update) = self.rx.recv().await {
-            let StreamUpdate::Tx { inner, .. } = update;
-            self.decode(&inner);
+            let StreamUpdate::Tx {
+                slot,
+                signature,
+                inner,
+            } = update;
+            self.decode(&inner, slot, signature);
         }
         Ok(())
     }
 
-    /// Route each tracked instruction in the transaction to its per-program
-    /// decoder.
-    fn decode(&self, tx: &SubscribeUpdateTransactionInfo) {
-        for instruction in
-            relevant_instructions(tx, &self.settlement_program, &self.solflow_program)
-        {
-            if instruction.program_id == self.settlement_program {
-                self.decode_settlement(&instruction);
-            } else {
-                self.decode_solflow(&instruction);
-            }
-        }
-    }
-
-    /// Identify the settlement instruction by its discriminator and route it to
-    /// the matching decode step.
-    ///
-    /// TODO: the per-instruction bodies are stubbed. Real decoding is blocked
-    /// on the program emitting `auction_id` (BeginSettle) and the sell/push
-    /// amounts (BeginSettle/FinalizeSettle), and on a data-only interface
-    /// parser: the interface's `parse` wants on-chain `AccountView`s a
-    /// tx-only indexer does not have. Discriminator dispatch is wired so
-    /// each arm can be filled once those land.
-    fn decode_settlement(&self, instruction: &ResolvedInstruction) {
-        let index = instruction.instruction_index;
-        let Ok((discriminator, _body)) = recover_discriminator(&instruction.data) else {
-            tracing::debug!(
-                instruction_index = index,
-                "settlement instruction with an unknown discriminator, skipping"
-            );
+    /// Decode one transaction's tracked instructions into domain events. The
+    /// settlement half runs through the pure [`decode_settlement`]; the SolFlow
+    /// half is still stubbed.
+    fn decode(&self, tx: &SubscribeUpdateTransactionInfo, slot: Slot, signature: Signature) {
+        let instructions =
+            relevant_instructions(tx, &self.settlement_program, &self.solflow_program);
+        if instructions.is_empty() {
             return;
-        };
-        match discriminator {
-            SettlementInstruction::CreateOrder => {
-                tracing::debug!(
-                    instruction_index = index,
-                    "CreateOrder, OrderCreated decode stubbed"
-                );
-            }
-            SettlementInstruction::BeginSettle => {
-                tracing::debug!(
-                    instruction_index = index,
-                    "BeginSettle, sell amounts + auction_id decode stubbed"
-                );
-            }
-            SettlementInstruction::FinalizeSettle => {
-                tracing::debug!(
-                    instruction_index = index,
-                    "FinalizeSettle, push amounts decode stubbed"
-                );
-            }
-            SettlementInstruction::CreateBuffer => {
-                tracing::debug!(
-                    instruction_index = index,
-                    "CreateBuffer, BufferCreated decode stubbed"
-                );
-            }
-            SettlementInstruction::Initialize => {
-                tracing::debug!(instruction_index = index, "Initialize, no domain event");
-            }
         }
+
+        // `relevant_instructions` reconstructs the account list internally to
+        // resolve program ids; rebuild it once here so the decode can resolve
+        // account indices to pubkeys too.
+        let account_keys = build_account_keys(tx);
+        let post_token_balances = tx
+            .meta
+            .as_ref()
+            .map(|meta| meta.post_token_balances.clone())
+            .unwrap_or_default();
+        let ctx = TxContext {
+            slot,
+            signature,
+            account_keys,
+            post_token_balances,
+        };
+
+        let settlement: Vec<ResolvedInstruction> = instructions
+            .iter()
+            .filter(|instruction| instruction.program_id == self.settlement_program)
+            .cloned()
+            .collect();
+
+        // TODO: resolve order PDAs against persisted order rows once the store
+        // adapter lands. Until then nothing resolves, so `SettlementFinalized`
+        // events carry the tx-level fields with empty trades.
+        // TODO: skip transactions whose `meta.err` is set: a reverted settlement
+        // or order creation must not emit an event. Deferred until the persist
+        // path is wired (nothing is persisted yet).
+        let events = decode_settlement(&settlement, &ctx, |_order_pda| None);
+
+        for instruction in instructions
+            .iter()
+            .filter(|instruction| instruction.program_id == self.solflow_program)
+        {
+            self.decode_solflow(instruction);
+        }
+
+        // TODO: persist `events` once the persistence adapter lands; for now the
+        // decode runs end to end but its output is dropped.
+        tracing::debug!(
+            slot = %ctx.slot,
+            event_count = events.len(),
+            "decoded settlement events"
+        );
     }
 
     /// TODO: decode the SolFlow instruction data. The on-chain program does not
@@ -135,6 +141,297 @@ impl Decoder {
             "sol_flow instruction decode not implemented"
         );
     }
+}
+
+/// Auction id is not carried on the `BeginSettle` wire yet, so every
+/// `SettlementFinalized` uses this fixed placeholder.
+// TODO: not in the BeginSettle wire yet; use the real value once the program
+// emits it.
+const PLACEHOLDER_AUCTION_ID: u64 = 0;
+
+/// The buy-side push amount is not carried on the `FinalizeSettle` wire yet, so
+/// every trade's `amount_received_delta` uses this fixed placeholder.
+// TODO: FinalizeSettle carries no push amount yet; use the real value once it
+// does.
+const PLACEHOLDER_AMOUNT_RECEIVED: u64 = 0;
+
+/// Position of the `created_by` account in a `CreateOrder`'s account list
+/// `[owner (S), created_by (W,S), order_pda (W), system_program (R)]`.
+const CREATE_ORDER_CREATED_BY: usize = 1;
+
+/// Accounts a `BeginSettle` carries before its per-order accounts:
+/// `[instructions_sysvar, state_pda, token_program]`.
+const BEGIN_SETTLE_FIXED_ACCOUNTS: usize = 3;
+
+/// Accounts a `CreateBuffer` carries before its per-buffer `(buffer_pda, mint)`
+/// pairs: `[payer, system_program, token_program]`.
+const CREATE_BUFFER_SHARED_ACCOUNTS: usize = 3;
+
+/// Order fields the `BeginSettle` wire does not carry, looked up per order PDA
+/// through an injected resolver so the decode stays a pure function. A future
+/// PR backs the resolver with the persisted order rows.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ResolvedOrder {
+    /// UID of the order held at the PDA.
+    order_uid: OrderUid,
+    /// Whether the order is fully filled after this settlement.
+    order_fulfilled: bool,
+}
+
+/// Decode the settlement-program instructions of one transaction into domain
+/// events.
+///
+/// Pure: every tx-level input arrives through `ctx`, and any order field the
+/// `BeginSettle` wire does not carry is resolved through `resolve_order` (keyed
+/// on the order PDA), so tests can inject a canned map. `instructions` must be
+/// the transaction's settlement-program instructions, in execution order.
+fn decode_settlement(
+    instructions: &[ResolvedInstruction],
+    ctx: &TxContext,
+    resolve_order: impl Fn(&Pubkey) -> Option<ResolvedOrder>,
+) -> Vec<SettlementEvent> {
+    let mut events = Vec::new();
+
+    // Instructions decodable on their own, without tx-level pairing.
+    for instruction in instructions {
+        let Ok((discriminator, _)) = recover_discriminator(&instruction.data) else {
+            tracing::debug!(
+                instruction_index = instruction.instruction_index,
+                "settlement instruction with an unknown discriminator, skipping"
+            );
+            continue;
+        };
+        match discriminator {
+            SettlementInstruction::CreateOrder => {
+                if let Some(event) = decode_order_created(instruction, &ctx.account_keys) {
+                    events.push(event);
+                }
+            }
+            SettlementInstruction::CreateBuffer => {
+                events.extend(decode_buffers_created(instruction, &ctx.account_keys));
+            }
+            // Bootstrap only, no domain event.
+            SettlementInstruction::Initialize => {}
+            // Paired below, once both halves of the settlement are in hand.
+            SettlementInstruction::BeginSettle | SettlementInstruction::FinalizeSettle => {}
+        }
+    }
+
+    // A `BeginSettle` plus the `FinalizeSettle` it names make one
+    // `SettlementFinalized`; pairing needs the whole transaction.
+    events.extend(decode_settlements_finalized(
+        instructions,
+        ctx,
+        &resolve_order,
+    ));
+    events
+}
+
+/// `CreateOrder` -> `OrderCreated`. The instruction data is the encoded order
+/// intent: its hash is the order UID and it carries the owner. `created_by` is
+/// resolved from the instruction's account list.
+fn decode_order_created(
+    instruction: &ResolvedInstruction,
+    account_keys: &[Pubkey],
+) -> Option<SettlementEvent> {
+    let (_, body) = recover_discriminator(&instruction.data).ok()?;
+    let intent_bytes: &[u8; EncodedOrderIntent::SIZE] = body.try_into().ok()?;
+    let (intent, uid) = EncodedOrderIntent::decode_and_hash(intent_bytes).ok()?;
+    let created_by = resolve_account(instruction, account_keys, CREATE_ORDER_CREATED_BY)?;
+    Some(SettlementEvent::OrderCreated {
+        order_uid: OrderUid(uid.to_bytes()),
+        owner: to_sdk_pubkey(intent.owner),
+        created_by,
+    })
+}
+
+/// `CreateBuffer` -> one `BufferCreated` per created buffer. The wire body is
+/// empty; each buffer is a trailing `(buffer_pda, mint)` account pair after the
+/// shared accounts, and the event's token is the buffer's mint.
+fn decode_buffers_created(
+    instruction: &ResolvedInstruction,
+    account_keys: &[Pubkey],
+) -> Vec<SettlementEvent> {
+    let Some(per_buffer) = instruction.accounts.get(CREATE_BUFFER_SHARED_ACCOUNTS..) else {
+        return Vec::new();
+    };
+    let (pairs, remainder) = per_buffer.as_chunks::<2>();
+    if !remainder.is_empty() || pairs.is_empty() {
+        tracing::debug!(
+            instruction_index = instruction.instruction_index,
+            "CreateBuffer accounts did not form whole (buffer, mint) pairs, skipping"
+        );
+        return Vec::new();
+    }
+    pairs
+        .iter()
+        .filter_map(|pair| {
+            // Each pair is `[buffer_pda_index, mint_index]`; the event token is
+            // the buffer's mint.
+            let token = account_keys.get(usize::from(pair[1]))?;
+            Some(SettlementEvent::BufferCreated { token: *token })
+        })
+        .collect()
+}
+
+/// Pair each `BeginSettle` with the `FinalizeSettle` it names and emit one
+/// `SettlementFinalized` per pair.
+///
+/// Pairing is by index: a `BeginSettle` body carries the top-level instruction
+/// index of its `FinalizeSettle` (recovered via [`recover_counterpart`]), which
+/// must match a `FinalizeSettle` present in the same transaction. It is
+/// independent of the two instructions' relative order.
+fn decode_settlements_finalized(
+    instructions: &[ResolvedInstruction],
+    ctx: &TxContext,
+    resolve_order: &impl Fn(&Pubkey) -> Option<ResolvedOrder>,
+) -> Vec<SettlementEvent> {
+    // The solver is the transaction fee payer: the first account key, which
+    // Solana guarantees is the signer that submitted the transaction.
+    let Some(&solver) = ctx.account_keys.first() else {
+        return Vec::new();
+    };
+
+    let mut events = Vec::new();
+    for begin in instructions {
+        let Ok((SettlementInstruction::BeginSettle, body)) = recover_discriminator(&begin.data)
+        else {
+            continue;
+        };
+        // Body: `[finalize_ix_index: u16 BE][n][bump×n][count×n][amount×T]`.
+        // Peel the counterpart index, leaving the per-order pull layout.
+        let Ok((finalize_ix_index, pull_body)) = recover_counterpart(body) else {
+            continue;
+        };
+        // The named `FinalizeSettle` must actually be present in this tx.
+        let paired = instructions.iter().any(|instruction| {
+            instruction.instruction_index == u32::from(finalize_ix_index)
+                && matches!(
+                    recover_discriminator(&instruction.data),
+                    Ok((SettlementInstruction::FinalizeSettle, _))
+                )
+        });
+        if !paired {
+            tracing::debug!(
+                instruction_index = begin.instruction_index,
+                finalize_ix_index,
+                "BeginSettle without a paired FinalizeSettle in the tx, skipping"
+            );
+            continue;
+        }
+
+        let Some(orders) = parse_begin_settle_orders(pull_body) else {
+            tracing::warn!(
+                instruction_index = begin.instruction_index,
+                "BeginSettle body did not match the expected pull layout, skipping"
+            );
+            continue;
+        };
+
+        let trades = orders
+            .into_iter()
+            .filter_map(|order| {
+                let order_pda =
+                    resolve_account(begin, &ctx.account_keys, order.order_pda_position)?;
+                let resolved = resolve_order(&order_pda)?;
+                Some(TradeDelta {
+                    order_uid: resolved.order_uid,
+                    amount_withdrawn_delta: order.amount_withdrawn_delta,
+                    amount_received_delta: PLACEHOLDER_AMOUNT_RECEIVED,
+                    order_fulfilled: resolved.order_fulfilled,
+                })
+            })
+            .collect();
+
+        events.push(SettlementEvent::SettlementFinalized {
+            auction_id: PLACEHOLDER_AUCTION_ID,
+            solver,
+            tx_signature: ctx.signature,
+            slot: ctx.slot,
+            trades,
+        });
+    }
+    events
+}
+
+/// One settled order recovered from a `BeginSettle` body: where its order PDA
+/// sits in the instruction's account list, and the sell amount pulled for it.
+struct BeginSettleOrder {
+    /// Position of the order's PDA within the instruction's account list.
+    order_pda_position: usize,
+    /// Sum of the order's pull amounts: the sell-side `amount_withdrawn` delta.
+    amount_withdrawn_delta: u64,
+}
+
+/// Hand-parse a `BeginSettle` body (after the counterpart index) into per-order
+/// pull totals and the account position of each order's PDA.
+//
+// TODO: this duplicates the `BeginSettle` wire layout owned by
+// `settlement_interface` (`[n][bump×n][count×n][amount: u64 BE ×T]`); the
+// interface's own parser is account-coupled, so there is no data-only helper to
+// call yet. Replace this once one exists. The layout also shifts when the
+// program adds `auction_id` to the wire, so this must move in lockstep.
+fn parse_begin_settle_orders(body: &[u8]) -> Option<Vec<BeginSettleOrder>> {
+    let (&order_count, rest) = body.split_first()?;
+    let order_count = usize::from(order_count);
+    // Bumps are on-chain PDA-derivation input the indexer does not need.
+    let (_bumps, rest) = rest.split_at_checked(order_count)?;
+    let (counts, amount_bytes) = rest.split_at_checked(order_count)?;
+    let (amounts, remainder) = amount_bytes.as_chunks::<8>();
+    if !remainder.is_empty() {
+        return None;
+    }
+    // The per-order transfer counts must sum to the number of amounts, so every
+    // destination pairs with exactly one amount.
+    let counts_sum = counts
+        .iter()
+        .map(|&count| usize::from(count))
+        .sum::<usize>();
+    if counts_sum != amounts.len() {
+        return None;
+    }
+
+    let mut orders = Vec::with_capacity(order_count);
+    let mut account_position = BEGIN_SETTLE_FIXED_ACCOUNTS;
+    let mut amount_index = 0usize;
+    for &count in counts {
+        let count = usize::from(count);
+        let mut amount_withdrawn_delta = 0u64;
+        for amount in &amounts[amount_index..amount_index + count] {
+            // On-chain amounts are already u64, so a sum from a single sell
+            // account cannot exceed u64. Guard anyway: the stream is untrusted.
+            amount_withdrawn_delta =
+                amount_withdrawn_delta.checked_add(u64::from_be_bytes(*amount))?;
+        }
+        amount_index += count;
+        orders.push(BeginSettleOrder {
+            order_pda_position: account_position,
+            amount_withdrawn_delta,
+        });
+        // Each order occupies its order PDA, its sell token account, and one
+        // destination per transfer.
+        account_position += 2 + count;
+    }
+    Some(orders)
+}
+
+/// Resolve the account at `position` in the instruction's account list to its
+/// pubkey, returning `None` if the position or the resolved index is out of
+/// range.
+fn resolve_account(
+    instruction: &ResolvedInstruction,
+    account_keys: &[Pubkey],
+    position: usize,
+) -> Option<Pubkey> {
+    let index = *instruction.accounts.get(position)?;
+    account_keys.get(usize::from(index)).copied()
+}
+
+/// Bridge a `settlement_interface` pubkey to the indexer's `solana_sdk` pubkey.
+/// The two crates pin different `solana-pubkey` majors, so the types differ and
+/// a byte round-trip is the conversion.
+fn to_sdk_pubkey(pubkey: InterfacePubkey) -> Pubkey {
+    Pubkey::new_from_array(pubkey.to_bytes())
 }
 
 /// The transaction's full account list that instruction indices resolve

--- a/crates/solana-indexer/src/indexer/decoder/tests.rs
+++ b/crates/solana-indexer/src/indexer/decoder/tests.rs
@@ -1,11 +1,22 @@
 use {
-    super::{Decoder, build_account_keys, relevant_instructions},
+    super::{
+        Decoder,
+        PLACEHOLDER_AMOUNT_RECEIVED,
+        PLACEHOLDER_AUCTION_ID,
+        ResolvedOrder,
+        build_account_keys,
+        decode_settlement,
+        relevant_instructions,
+    },
     crate::{
         persistence::Persistence,
         types::{
             Signature,
             channel::StreamUpdate,
+            events::{SettlementEvent, TradeDelta},
+            order::OrderUid,
             slot::Slot,
+            tx::TxContext,
             wire::{
                 CompiledInstruction,
                 InnerInstruction,
@@ -18,6 +29,11 @@ use {
         },
     },
     bytes::Bytes,
+    settlement_interface::{
+        Pubkey as InterfacePubkey,
+        SettlementInstruction,
+        data::intent::{EncodedOrderIntent, OrderIntent, OrderKind},
+    },
     solana_sdk::pubkey::Pubkey,
     tokio::sync::mpsc::Sender,
 };
@@ -273,4 +289,148 @@ async fn run_drains_transactions_until_the_sender_drops() {
     drop(sender);
 
     assert!(decoder.run().await.is_ok());
+}
+
+/// A crafted `CreateOrder` decodes to `OrderCreated` with the real UID (the
+/// hash of the encoded intent), the intent's owner, and the `created_by`
+/// account resolved from the instruction's account list. The account-list owner
+/// differs from the intent owner, so this also pins that the event owner comes
+/// from the intent data, not the accounts.
+#[test]
+fn create_order_decodes_to_order_created() {
+    let (settlement, solflow) = (pubkey(1), pubkey(2));
+    let created_by = pubkey(12);
+    // Account list: [settlement(0), owner(1), created_by(2), order_pda(3),
+    // system(4)].
+    let account_keys = vec![settlement, pubkey(11), created_by, pubkey(13), pubkey(14)];
+
+    // Build the encoded intent through the interface's public API so the test
+    // hashes it independently of the decoder.
+    let intent = OrderIntent {
+        owner: InterfacePubkey::new_from_array([0x11; 32]),
+        buy_token_account: InterfacePubkey::new_from_array([0x22; 32]),
+        sell_token_account: InterfacePubkey::new_from_array([0x33; 32]),
+        sell_amount: 1_000,
+        buy_amount: 2_000,
+        valid_to: 42,
+        kind: OrderKind::Sell,
+        partially_fillable: false,
+        app_data: [0x44; 32],
+    };
+    let encoded = EncodedOrderIntent::from(&intent);
+    let intent_bytes: [u8; EncodedOrderIntent::SIZE] = (&encoded).into();
+    let mut data = vec![SettlementInstruction::CreateOrder.discriminator()];
+    data.extend_from_slice(&intent_bytes);
+
+    // CreateOrder accounts: [owner, created_by, order_pda, system].
+    let tx = tx_info(
+        account_keys,
+        vec![],
+        vec![],
+        vec![compiled(0, vec![1, 2, 3, 4], data)],
+        vec![],
+    );
+
+    let ctx = TxContext {
+        slot: Slot(5),
+        signature: signature(6),
+        account_keys: build_account_keys(&tx),
+        post_token_balances: vec![],
+    };
+    let instructions = relevant_instructions(&tx, &settlement, &solflow);
+    let events = decode_settlement(&instructions, &ctx, |_| None);
+
+    assert_eq!(
+        events,
+        vec![SettlementEvent::OrderCreated {
+            order_uid: OrderUid(intent.uid().to_bytes()),
+            owner: Pubkey::new_from_array([0x11; 32]),
+            created_by,
+        }]
+    );
+}
+
+/// A crafted `BeginSettle` + `FinalizeSettle` pair decodes to one
+/// `SettlementFinalized`: the real summed sell amount and the resolved order
+/// UID (via the injected map), with the auction id and buy-side amount left at
+/// their documented placeholders and the solver read as the fee payer.
+#[test]
+fn begin_and_finalize_settle_decode_to_settlement_finalized() {
+    let (settlement, solflow) = (pubkey(1), pubkey(2));
+    let solver = pubkey(10);
+    let order_pda = pubkey(20);
+    // Account list:
+    // [solver(0), settlement(1), sysvar(2), state(3), token(4), order_pda(5),
+    //  sell(6), dest0(7), dest1(8)].
+    let account_keys = vec![
+        solver,
+        settlement,
+        pubkey(22),
+        pubkey(23),
+        pubkey(24),
+        order_pda,
+        pubkey(26),
+        pubkey(27),
+        pubkey(28),
+    ];
+
+    // BeginSettle body: finalize index 1, one order, bump 0xAA, two transfers of
+    // 300 and 700 (sum 1000 = the sell-side amount withdrawn).
+    let mut begin_data = vec![SettlementInstruction::BeginSettle.discriminator()];
+    begin_data.extend_from_slice(&1u16.to_be_bytes());
+    begin_data.push(1);
+    begin_data.push(0xAA);
+    begin_data.push(2);
+    begin_data.extend_from_slice(&300u64.to_be_bytes());
+    begin_data.extend_from_slice(&700u64.to_be_bytes());
+
+    // FinalizeSettle body: begin index 0.
+    let mut finalize_data = vec![SettlementInstruction::FinalizeSettle.discriminator()];
+    finalize_data.extend_from_slice(&0u16.to_be_bytes());
+
+    let tx = tx_info(
+        account_keys,
+        vec![],
+        vec![],
+        vec![
+            // BeginSettle @ 0: sysvar, state, token, order_pda, sell, dest0, dest1.
+            compiled(1, vec![2, 3, 4, 5, 6, 7, 8], begin_data),
+            // FinalizeSettle @ 1: sysvar only.
+            compiled(1, vec![2], finalize_data),
+        ],
+        vec![],
+    );
+
+    let expected_uid = OrderUid([0x55; 32]);
+    let resolve_order = |pda: &Pubkey| {
+        (*pda == order_pda).then_some(ResolvedOrder {
+            order_uid: expected_uid,
+            order_fulfilled: true,
+        })
+    };
+
+    let ctx = TxContext {
+        slot: Slot(5),
+        signature: signature(6),
+        account_keys: build_account_keys(&tx),
+        post_token_balances: vec![],
+    };
+    let instructions = relevant_instructions(&tx, &settlement, &solflow);
+    let events = decode_settlement(&instructions, &ctx, resolve_order);
+
+    assert_eq!(
+        events,
+        vec![SettlementEvent::SettlementFinalized {
+            auction_id: PLACEHOLDER_AUCTION_ID,
+            solver,
+            tx_signature: signature(6),
+            slot: Slot(5),
+            trades: vec![TradeDelta {
+                order_uid: expected_uid,
+                amount_withdrawn_delta: 1_000,
+                amount_received_delta: PLACEHOLDER_AMOUNT_RECEIVED,
+                order_fulfilled: true,
+            }],
+        }]
+    );
 }

--- a/crates/solana-indexer/src/indexer/decoder/tests.rs
+++ b/crates/solana-indexer/src/indexer/decoder/tests.rs
@@ -277,6 +277,10 @@ fn stream_tx(slot: Slot, signature: Signature, settlement: Pubkey) -> StreamUpda
     }
 }
 
+/// Verifies the run loop drains buffered updates and returns Ok when the sender
+/// drops. It does not assert the decoded event yet: decode output is dropped
+/// until the persistence adapter lands, at which point this test should assert
+/// the emitted event.
 #[tokio::test]
 async fn run_drains_transactions_until_the_sender_drops() {
     let (settlement, solflow) = (pubkey(1), pubkey(2));

--- a/crates/solana-indexer/src/types/channel.rs
+++ b/crates/solana-indexer/src/types/channel.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 //! Message types passed over the internal channel.
 //!
 //! The ingester pushes [`StreamUpdate`] into the channel to the decoder.


### PR DESCRIPTION
# Description
The settlement decoder now turns settlement-program instructions into typed `SettlementEvent` instead of just routing them. `CreateOrder` decodes fully. `BeginSettle` and `FinalizeSettle` are paired into a `SettlementFinalized`, and `CreateBuffer` yields `BufferCreated`. Two fields, the on-chain program does not emit yet, the auction id and the buy-side amount, are fixed placeholder constants. The order fields that come from the database (order uid, fulfilled flag) resolve through an injected lookup, so tests can mock them ahead of the persistence layer.

This PR runs ahead on purpose. It unblocks the end-to-end pipeline and persistence work before the on-chain program and the store are finished, and several pieces are provisional and change once those land (see Notes).

# Changes
- Decode `CreateOrder` into `OrderCreated`: uid from the encoded intent hash, owner from the intent, creator from the accounts.
- Pair `BeginSettle` with its `FinalizeSettle` and emit `SettlementFinalized`, summing each order's sell amounts from the BeginSettle body.
- Decode `CreateBuffer` into one `BufferCreated` per buffer.
- Resolve the database-backed order fields through an injected closure, keeping the decode pure and testable.
- Placeholder the auction id and the buy-side amount until the program carries them.

# How to test
New unit tests.

# Notes
Known gaps, all documented in-code:
- `auction_id` and the buy amount are placeholder constants until the program emits them.
- The order uid / fulfilled lookup returns `None` in production until the persistence layer lands (PR 14).
- `solver` is read as the transaction fee payer, which is wrong if a relayer submits the settlement. Needs confirming against how Solana settlements are sent.
- Failed transactions are not filtered yet, so a reverted settlement would emit an event. To be gated before persistence.
- The `BeginSettle` body is hand-parsed in `parse_begin_settle_orders`, which duplicates the wire layout `settlement_interface` owns. This is provisional. Once the interface exposes a positional, account-generic parser (solana-programs#63), the indexer reuses it and the hand-parse goes away, so the layout and amount endianness live in one place. The parse assumes big-endian amounts today and has to track the program if it flips to little-endian.
