### PR TITLE
Manually deserialize debug traces without recursion limit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ schemars = { version = "1.2", features = ["chrono04"] }
 scopeguard = "1.2.0"
 serde = { version = "1.0.203", features = ["derive"] }
 serde-ext = { path = "crates/serde-ext" }
-serde_json = { version = "1.0.117", features = ["unbounded_depth"] }
+serde_json = { version = "1.0.117", features = ["unbounded_depth", "raw_value"] }
 serde_with = "3.8.1"
 sha2 = "0.10"
 shared = { path = "crates/shared" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ schemars = { version = "1.2", features = ["chrono04"] }
 scopeguard = "1.2.0"
 serde = { version = "1.0.203", features = ["derive"] }
 serde-ext = { path = "crates/serde-ext" }
-serde_json = "1.0.117"
+serde_json = { version = "1.0.117", features = ["unbounded_depth"] }
 serde_with = "3.8.1"
 sha2 = "0.10"
 shared = { path = "crates/shared" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,7 +117,7 @@ schemars = { version = "1.2", features = ["chrono04"] }
 scopeguard = "1.2.0"
 serde = { version = "1.0.203", features = ["derive"] }
 serde-ext = { path = "crates/serde-ext" }
-serde_json = { version = "1.0.117", features = ["unbounded_depth", "raw_value"] }
+serde_json = { version = "1.0.117", features = ["raw_value", "unbounded_depth"] }
 serde_with = "3.8.1"
 sha2 = "0.10"
 shared = { path = "crates/shared" }

--- a/crates/autopilot/src/infra/blockchain/mod.rs
+++ b/crates/autopilot/src/infra/blockchain/mod.rs
@@ -161,8 +161,7 @@ async fn fetch_debug_trace(provider: &impl Provider, hash: eth::TxId) -> Result<
 
     let mut de = serde_json::Deserializer::from_str(raw.get());
     de.disable_recursion_limit();
-    GethTrace::deserialize(&mut de)
-        .map_err(|e| Error::IncompleteTransactionData(anyhow::anyhow!(e)))
+    GethTrace::deserialize(&mut de).map_err(Error::DeserializationFailed)
 }
 
 fn into_domain(
@@ -199,4 +198,6 @@ pub enum Error {
     TransactionNotFound,
     #[error("unsupported chain")]
     UnsupportedChain,
+    #[error("failed to deserialize tx: {0:?}")]
+    DeserializationFailed(#[from] serde_json::Error),
 }

--- a/crates/autopilot/src/infra/blockchain/mod.rs
+++ b/crates/autopilot/src/infra/blockchain/mod.rs
@@ -2,7 +2,7 @@ use {
     self::contracts::Contracts,
     crate::{boundary, domain},
     alloy::{
-        providers::{Provider, ext::DebugApi},
+        providers::Provider,
         rpc::types::{
             TransactionReceipt,
             trace::geth::{GethDebugBuiltInTracerType, GethDebugTracingOptions, GethTrace},
@@ -12,6 +12,8 @@ use {
     chain::Chain,
     eth_domain_types as eth,
     ethrpc::{Web3, block_stream::CurrentBlockWatcher},
+    futures::TryFutureExt as _,
+    serde::Deserialize,
     thiserror::Error,
     url::Url,
 };
@@ -114,13 +116,13 @@ impl Ethereum {
         hash: eth::TxId,
     ) -> Result<domain::blockchain::Transaction, Error> {
         let (receipt, traces): (Option<TransactionReceipt>, GethTrace) = tokio::try_join!(
-            self.web3.provider.get_transaction_receipt(hash.0),
+            self.web3
+                .provider
+                .get_transaction_receipt(hash.0)
+                .map_err(Error::Alloy),
             // Use unbuffered transport for the Debug API since not all providers support
             // batched debug calls.
-            self.unbuffered_web3.provider.debug_trace_transaction(
-                hash.0,
-                GethDebugTracingOptions::new_tracer(GethDebugBuiltInTracerType::CallTracer),
-            )
+            fetch_debug_trace(&self.unbuffered_web3.provider, hash)
         )?;
 
         let receipt = receipt.ok_or(Error::TransactionNotFound)?;
@@ -140,6 +142,27 @@ impl Ethereum {
         into_domain(receipt, traces, block.header.timestamp)
             .map_err(Error::IncompleteTransactionData)
     }
+}
+
+/// Fetches the debug traces for the given transaction while bypassing serde's
+/// default recursion limit. This is needed to support transactions with
+/// exceptionally deep call stacks. (e.g.
+/// <https://dashboard.tenderly.co/tx/0x5200aab12fbe4e0aef019748bf0f79266155fbbea00557bf1071fa2859e7eb9b>)
+async fn fetch_debug_trace(provider: &impl Provider, hash: eth::TxId) -> Result<GethTrace, Error> {
+    let params = serde_json::value::to_raw_value(&(
+        hash.0,
+        GethDebugTracingOptions::new_tracer(GethDebugBuiltInTracerType::CallTracer),
+    ))
+    .expect("serialization of known-good types");
+
+    let raw = provider
+        .raw_request_dyn("debug_traceTransaction".into(), &params)
+        .await?;
+
+    let mut de = serde_json::Deserializer::from_str(raw.get());
+    de.disable_recursion_limit();
+    GethTrace::deserialize(&mut de)
+        .map_err(|e| Error::IncompleteTransactionData(anyhow::anyhow!(e)))
 }
 
 fn into_domain(


### PR DESCRIPTION
# Description
In order to find out which solver ultimately is responsible we need to get the debug traces of the settlement tx and analyze them.
This step fails for a base [tx](https://dashboard.tenderly.co/tx/0x5200aab12fbe4e0aef019748bf0f79266155fbbea00557bf1071fa2859e7eb9b/gas-usage) which apparently ran into endless recursion but was successful anyway due to hitting serde's default recursion limit of 128.

# Changes
"manually" call `debug_traceTransaction` such that we can deserialize the response bytes by ourselves with a deserializer that has its recursion limit lifted.

Note that ethereum's transaction gas limit and the fact that each call only gets 63/64 of the remaining gas already limits the size of the JSON considerably so I don't think we have to worry about any crazy memory usage.
Also so far there was literally only 1 tx that needed the limit lifted in the first place.

## How to test
tested it with a unit test verifying that the tx can now be deserialized. The test is not checked in because it requires an actual node which can be down.

```
#[cfg(test)]
mod tests {
    use {super::*, alloy::primitives::b256};

    #[tokio::test]
    async fn test_base_tx() {
        let provider = ethrpc::Web3::new_from_url("http://localhost:8545");
        let traces = fetch_debug_trace(
            &provider.provider,
            eth::TxId(b256!(
                "0x5200aab12fbe4e0aef019748bf0f79266155fbbea00557bf1071fa2859e7eb9b"
            )),
        )
        .await
        .unwrap();
        dbg!(traces);
    }
}
```