### PR TITLE
Drop auction_orders Table

### DIFF
--- a/database/sql/V113__drop_auction_orders.sql
+++ b/database/sql/V113__drop_auction_orders.sql
@@ -1,0 +1,6 @@
+-- Drop the redundant `auction_orders` junction table. Its data duplicated
+-- `competition_auctions.order_uids`; the order->auction lookup now uses the GIN
+-- index on that array (V112). The write path was removed in #4568, so this drop
+-- ships one release later to ensure no pod running the old code still writes to
+-- the table during the rollover.
+DROP TABLE IF EXISTS auction_orders;


### PR DESCRIPTION
# Description
Follow-up to #4568, which stopped using the `auction_orders` table and switched the order->auction lookup to the GIN index on `competition_auctions.order_uids` (V112). This drops the now-unused table, as a follow-up (hotfix) release after V112.

Drop is a fast, metadata-only Flyway migration (prior `auction_orders` drop in V092 took 55 ms on prod) — no manual step needed despite the table's size.

# Changes

* Add `V113__drop_auction_orders.sql`: `DROP TABLE IF EXISTS auction_orders`.

## How to test
No manual step needed as `DROP TABLE` on an unused table is metadata-only and
instant. CI runs the full migration set; confirm it applies cleanly.

## Related Issues
Partially addresses #3057.