### PR TITLE
Stop alerting on Bitget swap error codes (80020, 80000)

### DIFF
--- a/crates/solvers/src/infra/dex/bitget/mod.rs
+++ b/crates/solvers/src/infra/dex/bitget/mod.rs
@@ -365,7 +365,9 @@ impl Bitget {
         }
 
         Err(match error_code.unwrap_or(80000) {
-            80001 // Insufficient token balance
+            80000 // Bitget internal error; not actionable on our side, retried
+                  // next auction. Treated as "no swap" so it doesn't alert.
+            | 80001 // Insufficient token balance
             | 80004 // Order expired
             | 80005 // Insufficient liquidity
             | 80008 // Reverse quote did not converge
@@ -374,6 +376,7 @@ impl Bitget {
             | 80011 // Failed to generate calldata
             | 80012 // Quote failed
             | 80014 // Order not found
+            | 80020 // Quote deviation too high (output too low): no competitive route
             => Error::NotFound,
             80002 // Amount below minimum
             | 80003 // Amount above maximum


### PR DESCRIPTION
# Description

The `mainnet-bitget-prod-solve` "single order Failure Rate Too High" alert has been firing. Over 24h, the `"failed to get swap"` logs are ~99% Bitget error code `80020` ("quote deviation too high" — output too low vs input), with a long tail of `80000` (Bitget internal error, flagged earlier by Martin).

`handle_api_error` only classified codes 80001–80014, so `80020`/`80000` fell through to the `Error::Api` catch-all → `Error::Other`, the only variant that logs at `warn!` and increments `solve_errors{reason="Other"}`.
But 80020 isn't a failure: it means Bitget has no competitive route, which is exactly `NotFound` for a single-order aggregator.
80000 is a non-actionable Bitget-side error we don't want to alert on either.

# Changes

* Map Bitget `80020` (no competitive quote) and `80000` (internal error) to `Error::NotFound`, so they log at `debug` and stay out of the alerting `Other` bucket instead of being treated as unexpected errors.