### PR TITLE
fix(bad_token): recipient balance check is inversed

### DIFF
--- a/crates/bad-tokens/src/trace_call.rs
+++ b/crates/bad-tokens/src/trace_call.rs
@@ -278,7 +278,7 @@ impl TraceCallDetectorRaw {
         // Allow for a small discrepancy (1 wei) in the balance after the transfer
         // which may come from rounding discrepancies in tokens that track
         // balances with "shares" (e.g. eUSD).
-        if computed_balance_recipient_after < balance_recipient_after.saturating_sub(U256::ONE) {
+        if balance_recipient_after < computed_balance_recipient_after.saturating_sub(U256::ONE) {
             return Ok(TokenQuality::bad(format!(
                 "Transferring {amount} into arbitrary recipient {arbitrary:?} was expected to \
                  result in a balance of {computed_balance_recipient_after} but actually resulted \


### PR DESCRIPTION
# Description

In the bad_token simulations/detector, fix the recipient balance check, which is currently validating inverse of what it should be.

The [previous condition verifying the transfer INTO the settlement contract](https://github.com/cowprotocol/services/blob/f3b91403f6575ae0df5eabcbf14abc5c8141232d/crates/bad-tokens/src/trace_call.rs#L254) is already correct, so its unlikely this bug has previously affected anything (as the bad token would have to behave differently on transfer between receiving tokens to the settlement contract, and receiving them to a user).

## How to test

No tests were added or removed at this time. This is simply something that was included as part of a bug bounty.
