### PR TITLE
Gate playground check on service readiness

### DIFF
--- a/.github/workflows/playground-check.yaml
+++ b/.github/workflows/playground-check.yaml
@@ -60,18 +60,22 @@ jobs:
           docker compose -f ${{ matrix.compose-file }} up -d
 
       - name: Wait for services to be ready
-        # The fork variant compiles the whole workspace inside the containers
-        # after `up -d` returns, so this can take many minutes. Wait for BOTH the
-        # orderbook API and the autopilot: the autopilot's /startup probe only
-        # returns 200 once its run loop is live and the eth-flow event indexer has
-        # a start block, so the smoke test can't place an on-chain order before
-        # the indexer would see it — the cause of the flaky "stuck in indexing"
-        # timeouts. (`docker compose up --wait` is unusable here: it aborts as
-        # soon as the one-shot db-migrations container exits, even with code 0.)
+        # The fork variant compiles the whole workspace in-container after
+        # `up -d`, one service at a time (shared target dir), so services become
+        # ready in a staggered order over many minutes. Wait for everything the
+        # smoke test needs, or it starts against a half-ready stack and fails:
+        #  - native_price 200: the orderbook + driver + baseline solver (pricing
+        #    path) are all up; the baseline solver is usually the last to build,
+        #    and until it is the orderbook returns 404 here.
+        #  - autopilot /startup 200: the run loop is live and the eth-flow event
+        #    indexer has a start block, so the on-chain order can't be placed
+        #    before the indexer would see it (the "stuck in indexing" race).
+        # (`docker compose up --wait` is unusable here: it aborts as soon as the
+        # one-shot db-migrations container exits, even with code 0.)
         working-directory: playground
         run: |
           timeout 3600 bash -c '
-            until curl -sf -m 5 http://localhost:8080/api/v1/version > /dev/null; do sleep 15; done
+            until curl -sf -m 5 http://localhost:8080/api/v1/token/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48/native_price > /dev/null; do sleep 15; done
             until curl -sf -m 5 http://localhost:9589/startup > /dev/null; do sleep 15; done
           '
 

--- a/.github/workflows/playground-check.yaml
+++ b/.github/workflows/playground-check.yaml
@@ -23,7 +23,10 @@ jobs:
           - docker-compose.fork.yml
           - docker-compose.non-interactive.yml
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    # Healthy runs finish well under this (~22 min for the fork variant). The cap
+    # is only a backstop so a stuck stack (e.g. a failed in-container compile)
+    # fails fast instead of hanging; the readiness wait below fails even sooner.
+    timeout-minutes: 60
     env:
       FORK_URL_MAINNET: ${{ secrets.FORK_URL_MAINNET }}
     steps:
@@ -55,34 +58,18 @@ jobs:
           sed -i -e 's/ETH_RPC_URL=.*/ETH_RPC_URL=$FORK_URL_MAINNET/g' playground/.env
           cat playground/.env
 
-      - name: Start docker containers
+      - name: Start docker containers and wait for readiness
         id: containers
         working-directory: playground
         run: |
           # firstly start explorer container to workaround yarn cache problem
           docker compose -f ${{ matrix.compose-file }} up -d explorer
-          docker compose -f ${{ matrix.compose-file }} up -d
-
-      - name: Wait for services to be ready
-        # On the fork variant every service compiles inside its container after
-        # `up -d` returns, one at a time (they share a target dir), so they come
-        # up staggered over several minutes. Start the smoke test too early and
-        # it runs against a half-built stack, so wait for the two things it needs:
-        #   native_price 200  the orderbook + driver + baseline solver can price
-        #                     (the solver builds last; until then this 404s)
-        #   /startup 200      the autopilot run loop is live and its eth-flow
-        #                     indexer has a start block (otherwise the order is
-        #                     placed before indexing starts and gets stuck)
-        # `docker compose up --wait` does not help here: the app services have no
-        # healthchecks, so it only waits for "running" (cargo-watch launched),
-        # not for them to serve. Tried it on the fork variant and the smoke test
-        # still failed against a stack that was still compiling.
-        working-directory: playground
-        run: |
-          timeout 3600 bash -c '
-            until curl -sf -m 5 http://localhost:8080/api/v1/token/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48/native_price > /dev/null; do sleep 15; done
-            until curl -sf -m 5 http://localhost:9589/startup > /dev/null; do sleep 15; done
-          '
+          # --wait blocks until every service is healthy (see the healthchecks in
+          # the compose file), so the smoke test never runs against a half-built
+          # stack. The fork variant compiles in-container first (~20 min), so the
+          # timeout is generous; it matches the healthchecks' start_period so a
+          # slow build is never marked unhealthy before it comes up.
+          docker compose -f ${{ matrix.compose-file }} up -d --wait --wait-timeout 2700
 
       - name: Execute validation script
         id: test_script

--- a/.github/workflows/playground-check.yaml
+++ b/.github/workflows/playground-check.yaml
@@ -1,10 +1,14 @@
 name: Playground operation check
 
 on:
-  # Opt-in only: this is an expensive (~30 min, full workspace compile) smoke
-  # test of the local dev stack, not a production path. It runs on demand and
-  # when the playground itself changes, instead of on a daily schedule.
+  # Expensive (~30 min, full workspace compile) smoke test of the local dev
+  # stack, so it does not run on every PR. Runs daily (the schedule surfaces
+  # breakage even when nobody touches the playground), on demand, and when the
+  # playground itself changes.
   workflow_dispatch:
+  schedule:
+    # Run this job once per day
+    - cron: "0 0 * * *"
   pull_request:
     paths:
       - "playground/**"

--- a/.github/workflows/playground-check.yaml
+++ b/.github/workflows/playground-check.yaml
@@ -2,10 +2,8 @@ name: Playground operation check
 
 on:
   workflow_dispatch:
-  # Expensive (~30 min, full workspace compile) smoke test, so it does not run on
-  # every PR. The daily run catches config or parameter drift that was never
-  # applied to the playground, even when nobody touches the playground directory.
   schedule:
+    # Run this job once per day
     - cron: "0 0 * * *"
   pull_request:
     paths:
@@ -21,9 +19,9 @@ jobs:
           - docker-compose.fork.yml
           - docker-compose.non-interactive.yml
     runs-on: ubuntu-latest
-    # Healthy runs finish well under this (~22 min for the fork variant). The cap
-    # is only a backstop so a stuck stack (e.g. a failed in-container compile)
-    # fails fast instead of hanging; the readiness wait below fails even sooner.
+    # Healthy runs finish well under this (~22 min for the fork variant). If the job
+    # is taking close to this cap, it's likely going to fail, in which case it's
+    # better to fail fast instead of hanging.
     timeout-minutes: 60
     env:
       FORK_URL_MAINNET: ${{ secrets.FORK_URL_MAINNET }}
@@ -62,11 +60,8 @@ jobs:
         run: |
           # firstly start explorer container to workaround yarn cache problem
           docker compose -f ${{ matrix.compose-file }} up -d explorer
-          # --wait blocks until every service is healthy (see the healthchecks in
-          # the compose file), so the smoke test never runs against a half-built
-          # stack. The fork variant compiles in-container first (~20 min), so the
-          # timeout is generous; it matches the healthchecks' start_period so a
-          # slow build is never marked unhealthy before it comes up.
+          # --wait blocks on the healthchecks before the test runs. Fork builds
+          # the services in-container (~20 min), so the timeout matches start_period.
           docker compose -f ${{ matrix.compose-file }} up -d --wait --wait-timeout 2700
 
       - name: Execute validation script

--- a/.github/workflows/playground-check.yaml
+++ b/.github/workflows/playground-check.yaml
@@ -1,13 +1,14 @@
 name: Playground operation check
 
 on:
+  # Opt-in only: this is an expensive (~30 min, full workspace compile) smoke
+  # test of the local dev stack, not a production path. It runs on demand and
+  # when the playground itself changes, instead of on a daily schedule.
   workflow_dispatch:
-  schedule:
-    # Run this job once per day
-    - cron: "0 0 * * *"
   pull_request:
     paths:
       - "playground/**"
+      - ".github/workflows/playground-check.yaml"
 
 jobs:
   playground-check:
@@ -58,14 +59,16 @@ jobs:
           docker compose -f ${{ matrix.compose-file }} up -d explorer
           docker compose -f ${{ matrix.compose-file }} up -d
 
-      - name: Wait for orderbook to be ready
+      - name: Wait for services to be ready
         # The fork variant compiles the workspace inside the containers after
-        # `up -d` returns, which takes far longer than the validation script's
-        # built-in 2 minute retry window.
+        # `up -d` returns (can take several minutes). `--wait` blocks on the
+        # orderbook and autopilot healthchecks, so the validation script never
+        # runs before the autopilot's eth-flow event indexer is live — otherwise
+        # the on-chain order is placed into a block the indexer never scans and
+        # stays stuck in "indexing" forever.
         working-directory: playground
         run: |
-          timeout 3600 bash -c \
-            'until curl -sf -m 5 http://localhost:8080/api/v1/version > /dev/null; do sleep 30; done'
+          docker compose -f ${{ matrix.compose-file }} up -d --wait --wait-timeout 3600 orderbook autopilot
 
       - name: Execute validation script
         id: test_script

--- a/.github/workflows/playground-check.yaml
+++ b/.github/workflows/playground-check.yaml
@@ -1,13 +1,11 @@
 name: Playground operation check
 
 on:
-  # Expensive (~30 min, full workspace compile) smoke test of the local dev
-  # stack, so it does not run on every PR. Runs daily (the schedule surfaces
-  # breakage even when nobody touches the playground), on demand, and when the
-  # playground itself changes.
   workflow_dispatch:
+  # Expensive (~30 min, full workspace compile) smoke test, so it does not run on
+  # every PR. The daily run catches config or parameter drift that was never
+  # applied to the playground, even when nobody touches the playground directory.
   schedule:
-    # Run this job once per day
     - cron: "0 0 * * *"
   pull_request:
     paths:

--- a/.github/workflows/playground-check.yaml
+++ b/.github/workflows/playground-check.yaml
@@ -60,15 +60,20 @@ jobs:
           docker compose -f ${{ matrix.compose-file }} up -d
 
       - name: Wait for services to be ready
-        # The fork variant compiles the workspace inside the containers after
-        # `up -d` returns (can take several minutes). `--wait` blocks on the
-        # orderbook and autopilot healthchecks, so the validation script never
-        # runs before the autopilot's eth-flow event indexer is live — otherwise
-        # the on-chain order is placed into a block the indexer never scans and
-        # stays stuck in "indexing" forever.
+        # The fork variant compiles the whole workspace inside the containers
+        # after `up -d` returns, so this can take many minutes. Wait for BOTH the
+        # orderbook API and the autopilot: the autopilot's /startup probe only
+        # returns 200 once its run loop is live and the eth-flow event indexer has
+        # a start block, so the smoke test can't place an on-chain order before
+        # the indexer would see it — the cause of the flaky "stuck in indexing"
+        # timeouts. (`docker compose up --wait` is unusable here: it aborts as
+        # soon as the one-shot db-migrations container exits, even with code 0.)
         working-directory: playground
         run: |
-          docker compose -f ${{ matrix.compose-file }} up -d --wait --wait-timeout 3600 orderbook autopilot
+          timeout 3600 bash -c '
+            until curl -sf -m 5 http://localhost:8080/api/v1/version > /dev/null; do sleep 15; done
+            until curl -sf -m 5 http://localhost:9589/startup > /dev/null; do sleep 15; done
+          '
 
       - name: Execute validation script
         id: test_script

--- a/.github/workflows/playground-check.yaml
+++ b/.github/workflows/playground-check.yaml
@@ -64,18 +64,19 @@ jobs:
           docker compose -f ${{ matrix.compose-file }} up -d
 
       - name: Wait for services to be ready
-        # The fork variant compiles the whole workspace in-container after
-        # `up -d`, one service at a time (shared target dir), so services become
-        # ready in a staggered order over many minutes. Wait for everything the
-        # smoke test needs, or it starts against a half-ready stack and fails:
-        #  - native_price 200: the orderbook + driver + baseline solver (pricing
-        #    path) are all up; the baseline solver is usually the last to build,
-        #    and until it is the orderbook returns 404 here.
-        #  - autopilot /startup 200: the run loop is live and the eth-flow event
-        #    indexer has a start block, so the on-chain order can't be placed
-        #    before the indexer would see it (the "stuck in indexing" race).
-        # (`docker compose up --wait` is unusable here: it aborts as soon as the
-        # one-shot db-migrations container exits, even with code 0.)
+        # On the fork variant every service compiles inside its container after
+        # `up -d` returns, one at a time (they share a target dir), so they come
+        # up staggered over several minutes. Start the smoke test too early and
+        # it runs against a half-built stack, so wait for the two things it needs:
+        #   native_price 200  the orderbook + driver + baseline solver can price
+        #                     (the solver builds last; until then this 404s)
+        #   /startup 200      the autopilot run loop is live and its eth-flow
+        #                     indexer has a start block (otherwise the order is
+        #                     placed before indexing starts and gets stuck)
+        # `docker compose up --wait` does not help here: the app services have no
+        # healthchecks, so it only waits for "running" (cargo-watch launched),
+        # not for them to serve. Tried it on the fork variant and the smoke test
+        # still failed against a stack that was still compiling.
         working-directory: playground
         run: |
           timeout 3600 bash -c '

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,10 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry --mount=type=cache,targe
 
 # Create an intermediate image to extract the binaries
 FROM docker.io/debian:bookworm-slim AS intermediate
+# curl is used by the playground compose healthchecks (this image is not the
+# production one; prod builds from Dockerfile.deploy-ci).
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked apt-get update && \
-    apt-get install -y ca-certificates tini gettext-base && \
+    apt-get install -y ca-certificates tini gettext-base curl && \
     apt-get clean
 
 FROM intermediate AS autopilot

--- a/playground/docker-compose.fork.yml
+++ b/playground/docker-compose.fork.yml
@@ -106,16 +106,12 @@ services:
       - 8080:80 # API
       - 9586:9586 # metrics
       - 6669:6669 # tokio console
-    # Fork services compile inside their container after startup (they share a
-    # target dir, so builds serialize), so "running" is not the same as ready.
-    # These healthchecks make `docker compose up --wait` block until each one
-    # actually serves. start_period is generous to cover the serialized compile.
     healthcheck:
-      # ready == can price, which also needs the driver and baseline solver up
-      test: ["CMD-SHELL", "curl -sf http://localhost/api/v1/token/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48/native_price || exit 1"]
+      test: ["CMD-SHELL", "curl -sf http://localhost/api/v1/ready || exit 1"]
       interval: 10s
       timeout: 5s
       retries: 5
+      # long start_period: fork services compile in-container after start
       start_period: 2700s
 
   autopilot:

--- a/playground/docker-compose.fork.yml
+++ b/playground/docker-compose.fork.yml
@@ -105,15 +105,6 @@ services:
       - 8080:80 # API
       - 9586:9586 # metrics
       - 6669:6669 # tokio console
-    healthcheck:
-      test: ["CMD-SHELL", "curl -sf http://localhost:80/api/v1/version || exit 1"]
-      interval: 5s
-      timeout: 4s
-      retries: 12
-      # localdev compiles the whole workspace on first startup (all services
-      # share one mounted target dir, so builds serialize) — allow generous time
-      # before the container is considered unhealthy.
-      start_period: 1800s
 
   autopilot:
     build:
@@ -148,18 +139,6 @@ services:
     ports:
       - 9589:9589 # metrics
       - 6670:6669 # tokio console
-    healthcheck:
-      # /startup flips to 200 once the run loop is live and the eth-flow event
-      # indexer has captured its start block. Gating order creation on this
-      # avoids placing an order the indexer would never scan (skip-event-sync).
-      test: ["CMD-SHELL", "curl -sf http://localhost:9589/startup || exit 1"]
-      interval: 5s
-      timeout: 4s
-      retries: 12
-      # localdev compiles the whole workspace on first startup (all services
-      # share one mounted target dir, so builds serialize) — allow generous time
-      # before the container is considered unhealthy.
-      start_period: 1800s
 
   driver:
     build:

--- a/playground/docker-compose.fork.yml
+++ b/playground/docker-compose.fork.yml
@@ -105,6 +105,15 @@ services:
       - 8080:80 # API
       - 9586:9586 # metrics
       - 6669:6669 # tokio console
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:80/api/v1/version || exit 1"]
+      interval: 5s
+      timeout: 4s
+      retries: 12
+      # localdev compiles the whole workspace on first startup (all services
+      # share one mounted target dir, so builds serialize) — allow generous time
+      # before the container is considered unhealthy.
+      start_period: 1800s
 
   autopilot:
     build:
@@ -139,6 +148,18 @@ services:
     ports:
       - 9589:9589 # metrics
       - 6670:6669 # tokio console
+    healthcheck:
+      # /startup flips to 200 once the run loop is live and the eth-flow event
+      # indexer has captured its start block. Gating order creation on this
+      # avoids placing an order the indexer would never scan (skip-event-sync).
+      test: ["CMD-SHELL", "curl -sf http://localhost:9589/startup || exit 1"]
+      interval: 5s
+      timeout: 4s
+      retries: 12
+      # localdev compiles the whole workspace on first startup (all services
+      # share one mounted target dir, so builds serialize) — allow generous time
+      # before the container is considered unhealthy.
+      start_period: 1800s
 
   driver:
     build:

--- a/playground/docker-compose.fork.yml
+++ b/playground/docker-compose.fork.yml
@@ -111,7 +111,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
-      # long start_period: fork services compile in-container after start
+      # start_period is long because fork builds in-container after start
       start_period: 2700s
 
   autopilot:
@@ -148,8 +148,7 @@ services:
       - 9589:9589 # metrics
       - 6670:6669 # tokio console
     healthcheck:
-      # /startup flips to 200 only once the run loop is live and the eth-flow
-      # event indexer has a start block
+      # /startup returns 200 only after the run loop is up and the eth-flow indexer has a start block
       test: ["CMD-SHELL", "curl -sf http://localhost:9589/startup || exit 1"]
       interval: 10s
       timeout: 5s

--- a/playground/docker-compose.fork.yml
+++ b/playground/docker-compose.fork.yml
@@ -100,11 +100,23 @@ services:
     volumes:
       - ../:/src
     depends_on:
-      - db-migrations
+      db-migrations:
+        condition: service_completed_successfully
     ports:
       - 8080:80 # API
       - 9586:9586 # metrics
       - 6669:6669 # tokio console
+    # Fork services compile inside their container after startup (they share a
+    # target dir, so builds serialize), so "running" is not the same as ready.
+    # These healthchecks make `docker compose up --wait` block until each one
+    # actually serves. start_period is generous to cover the serialized compile.
+    healthcheck:
+      # ready == can price, which also needs the driver and baseline solver up
+      test: ["CMD-SHELL", "curl -sf http://localhost/api/v1/token/0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48/native_price || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 2700s
 
   autopilot:
     build:
@@ -139,6 +151,14 @@ services:
     ports:
       - 9589:9589 # metrics
       - 6670:6669 # tokio console
+    healthcheck:
+      # /startup flips to 200 only once the run loop is live and the eth-flow
+      # event indexer has a start block
+      test: ["CMD-SHELL", "curl -sf http://localhost:9589/startup || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 2700s
 
   driver:
     build:
@@ -172,6 +192,12 @@ services:
     depends_on:
       chain:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost/healthz || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 2700s
 
   # baseline (solver engine)
   baseline:
@@ -202,6 +228,12 @@ services:
     ports:
       - 9001:80 # API & metrics
       - 6672:6669 # tokio console
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost/healthz || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 2700s
 
   frontend:
     build:

--- a/playground/docker-compose.non-interactive.yml
+++ b/playground/docker-compose.non-interactive.yml
@@ -99,6 +99,12 @@ services:
       - 8080:80 # API
       - 9586:9586 # metrics
       - 6669:6669 # tokio console
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost/api/v1/ready || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 600s
 
   autopilot:
     build:
@@ -126,6 +132,12 @@ services:
     ports:
       - 9589:9589 # metrics
       - 6670:6669 # tokio console
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost:9589/startup || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 600s
 
   driver:
     build:
@@ -152,6 +164,12 @@ services:
     depends_on:
       chain:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost/healthz || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 600s
 
   # baseline (solver engine)
   baseline:
@@ -175,6 +193,12 @@ services:
     ports:
       - 9001:80 # API & metrics
       - 6672:6669 # tokio console
+    healthcheck:
+      test: ["CMD-SHELL", "curl -sf http://localhost/healthz || exit 1"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 600s
 
   frontend:
     build:

--- a/playground/docker-compose.non-interactive.yml
+++ b/playground/docker-compose.non-interactive.yml
@@ -93,7 +93,8 @@ services:
     volumes:
       - ./configs/orderbook.toml:/orderbook.toml
     depends_on:
-      - db-migrations
+      db-migrations:
+        condition: service_completed_successfully
     ports:
       - 8080:80 # API
       - 9586:9586 # metrics


### PR DESCRIPTION
# Description

The Playground operation check was failing ~50% of runs, mainly due to a startup race in teh fork setup. The fork variant compiles each service inside its container on boot, but CI only waited for the orderbook before running the smoke test. If the autopilot was still compiling, the eth-flow order got created on-chain before its event indexer was live; since that indexer starts from the block current at process boot (`skip-event-sync`), so the order did not get indexed and the test timed out on `indexing`.

# Changes

- Gave each playground service a healthcheck, so a service counts as healthy only once it is actually serving, instead of right away after its container has started.
- CI now uses `docker compose up -d --wait`, which waits for those healthchecks before running the smoke test. This also helps anyone running the playground locally, since compose now reports readiness correctly
- Dropped the job timeout from 90 to 60 minutes so a stuck run fails sooner.

# How to test

Actions → "Playground operation check" → Run workflow on this branch (or `gh workflow run playground-check.yaml --ref aryan/fix-playground-check-flake`).
A healthy run progresses to `Order status: traded`.