### PR TITLE
feat(solana-indexer): PR 14 PostgresStore persist decoded events + slot watermark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9948,6 +9948,7 @@ dependencies = [
  "settlement-interface",
  "solana-client",
  "solana-sdk",
+ "sqlx",
  "thiserror 1.0.69",
  "tokio",
  "tracing",

--- a/crates/solana-indexer/Cargo.toml
+++ b/crates/solana-indexer/Cargo.toml
@@ -27,6 +27,7 @@ settlement-interface = {
 }
 solana-client = { workspace = true }
 solana-sdk = { workspace = true }
+sqlx = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync"] }
 tracing = { workspace = true }

--- a/crates/solana-indexer/src/indexer/decoder/tests.rs
+++ b/crates/solana-indexer/src/indexer/decoder/tests.rs
@@ -256,7 +256,7 @@ fn signature(n: u8) -> Signature {
 
 fn test_decoder(settlement: Pubkey, solflow: Pubkey) -> (Decoder, Sender<StreamUpdate>) {
     let (sender, rx) = tokio::sync::mpsc::channel(16);
-    let decoder = Decoder::new(Persistence {}, rx, settlement, solflow);
+    let decoder = Decoder::new(Persistence::stub(), rx, settlement, solflow);
     (decoder, sender)
 }
 

--- a/crates/solana-indexer/src/persistence.rs
+++ b/crates/solana-indexer/src/persistence.rs
@@ -1,43 +1,82 @@
-#![expect(dead_code, unused_variables)]
+#![allow(dead_code, unused_variables)]
 //! PostgreSQL persistence layer for decoded events and slot state.
 
 use {
     crate::types::{
         commitment::{Commitment, UnfinalizedRow},
         errors::PersistenceError,
-        events::DecodedEvent,
+        events::{DecodedEvent, SettlementEvent},
         recovery::PdaSnapshot,
         slot::Slot,
     },
+    sqlx::{PgConnection, PgPool, types::BigDecimal},
     std::ops::RangeInclusive,
 };
 
+#[cfg(test)]
+mod tests;
+
+/// Single-row id for the slot watermark in `solana.indexer_state`.
+const WATERMARK_ROW_ID: i32 = 0;
+
 /// PostgreSQL persistence. Used by Decoder, Watchdog, and FinalizationWorker.
 ///
-/// Cheap to clone: wraps a shared pool. The method bodies are stubbed until the
-/// Postgres adapter lands.
-// TODO: hold `postgres: Arc<Postgres>` once the adapter is added.
+/// Cheap to clone: `PgPool` is an `Arc` internally.
 #[derive(Clone)]
-pub(crate) struct Persistence {}
+pub(crate) struct Persistence {
+    pool: PgPool,
+}
 
 impl Persistence {
-    /// Save decoded events and advance the slot watermark atomically.
+    pub(crate) fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    /// Test stub: a lazily-connected pool that never touches a DB unless a
+    /// query actually runs. Lets components that hold a `Persistence` be built
+    /// in unit tests that do not exercise the persistence path.
+    #[cfg(test)]
+    pub(crate) fn stub() -> Self {
+        Self {
+            pool: PgPool::connect_lazy("postgresql://localhost").expect("valid lazy url"),
+        }
+    }
+
+    /// Save decoded events and advance the slot watermark in one transaction.
     pub(crate) async fn persist_events(
         &self,
         events: Vec<DecodedEvent>,
         new_watermark: u64,
     ) -> Result<(), PersistenceError> {
-        todo!()
+        let mut tx = self.pool.begin().await.map_err(map_err)?;
+        for event in events {
+            match event {
+                DecodedEvent::Settlement(event) => write_settlement_event(&mut tx, event).await?,
+                // The SolFlow program is not live yet and its decode is stubbed,
+                // so no SolFlow events reach here. Wired once the program lands.
+                DecodedEvent::SolFlow(_) => {}
+            }
+        }
+        advance_watermark(&mut tx, new_watermark).await?;
+        tx.commit().await.map_err(map_err)?;
+        Ok(())
     }
 
-    /// Record a slot checkpoint. Rejects downward writes.
+    /// Record a slot checkpoint. Downward writes are ignored (monotonic).
     pub(crate) async fn write_watermark(&self, slot: u64) -> Result<(), PersistenceError> {
-        todo!()
+        let mut conn = self.pool.acquire().await.map_err(map_err)?;
+        advance_watermark(&mut conn, slot).await
     }
 
-    /// Read persisted watermark for resuming after reconnect.
+    /// Read the persisted watermark for resuming after reconnect.
     pub(crate) async fn read_watermark(&self) -> Result<Option<u64>, PersistenceError> {
-        todo!()
+        let row: Option<(i64,)> =
+            sqlx::query_as("SELECT last_indexed_slot FROM solana.indexer_state WHERE id = $1")
+                .bind(WATERMARK_ROW_ID)
+                .fetch_optional(&self.pool)
+                .await
+                .map_err(map_err)?;
+        Ok(row.map(|(slot,)| slot as u64))
     }
 
     /// Record gaps that fell outside the replay window (write-only in v0.1).
@@ -45,61 +84,177 @@ impl Persistence {
         &self,
         range: RangeInclusive<u64>,
     ) -> Result<(), PersistenceError> {
-        todo!()
+        todo!("recovery flows are out of scope for v0.1 (database spec §13)")
     }
 
-    /// Primary promotion pass: fetch `confirmed` rows whose `slot` is old
-    /// enough to be finalized (typically `slot <= tip - 32`) but new enough to
-    /// still be within the RPC signature-status retention horizon.
-    ///
-    /// `limit` is a DB fetch bound (page size), not the RPC batch size. The
-    /// finalization worker chunks the returned rows into <=256-signature
-    /// `getSignatureStatuses` calls. Returns `Err` on backend failure so the
-    /// caller can back off rather than silently stall on a dead store.
+    /// Primary promotion pass source rows. Implemented with the
+    /// FinalizationWorker.
     pub(crate) async fn get_confirmed_rows(
         &self,
         max_slot: Slot,
         limit: usize,
     ) -> Result<Vec<UnfinalizedRow>, PersistenceError> {
-        todo!()
+        todo!("FinalizationWorker PR")
     }
 
-    /// Safety-net sweep for `confirmed` rows the primary promotion pass missed
-    /// (i.e. rows that aged past the signature-status retention horizon,
-    /// ~150 slots behind the chain tip).  Returns `Err` on backend failure
-    /// (see `get_confirmed_rows`).
+    /// Aged-row safety-net sweep source. Implemented with the
+    /// FinalizationWorker.
     pub(crate) async fn get_aged_rows(
         &self,
         retention_horizon_slot: u64,
     ) -> Result<Vec<UnfinalizedRow>, PersistenceError> {
-        todo!()
+        todo!("FinalizationWorker PR")
     }
 
-    /// Flip the `commitment` label on a specific row.
-    ///
-    /// The row's `table` field tells the implementer which `solana.*` table to
-    /// UPDATE.
+    /// Flip the `commitment` label on a row. Implemented with the
+    /// FinalizationWorker.
     pub(crate) async fn update_commitment(
         &self,
         row: &UnfinalizedRow,
         new_commitment: Commitment,
     ) -> Result<(), PersistenceError> {
-        todo!()
+        todo!("FinalizationWorker PR")
     }
 
-    /// Persist a single event during recovery/backfills, not the live ingestion
-    /// path.
-    ///
-    /// Unlike `persist_events`, this does not advance the watermark.
+    /// Persist a single event during recovery/backfills. Out of scope for v0.1.
     pub(crate) async fn backfill_event(&self, event: DecodedEvent) -> Result<(), PersistenceError> {
-        todo!()
+        todo!("recovery flows are out of scope for v0.1 (database spec §13)")
     }
 
-    /// Upsert on-chain PDA state for reconciliation.
+    /// Upsert on-chain PDA state for reconciliation. Out of scope for v0.1.
     pub(crate) async fn upsert_pda_snapshot(
         &self,
         snapshot: PdaSnapshot,
     ) -> Result<(), PersistenceError> {
-        todo!()
+        todo!("recovery flows are out of scope for v0.1 (database spec §13)")
+    }
+}
+
+/// Advance the monotonic slot watermark. A slot at or below the stored value is
+/// a no-op (the `WHERE` guard on the upsert rejects the downward write).
+async fn advance_watermark(conn: &mut PgConnection, slot: u64) -> Result<(), PersistenceError> {
+    sqlx::query(
+        "INSERT INTO solana.indexer_state (id, last_indexed_slot) VALUES ($1, $2) ON CONFLICT \
+         (id) DO UPDATE SET last_indexed_slot = EXCLUDED.last_indexed_slot WHERE \
+         EXCLUDED.last_indexed_slot > solana.indexer_state.last_indexed_slot",
+    )
+    .bind(WATERMARK_ROW_ID)
+    .bind(slot as i64)
+    .execute(&mut *conn)
+    .await
+    .map_err(map_err)?;
+    Ok(())
+}
+
+/// Persist one settlement-program event.
+///
+/// Placeholders mirror PR 7.2: `instruction_index` and `fee_amount` are not
+/// carried by the current event taxonomy (nor is the buy-side amount emitted by
+/// the program yet), so they are written as constants until the decoder
+/// resolves them from the proposed-solution data.
+async fn write_settlement_event(
+    conn: &mut PgConnection,
+    event: SettlementEvent,
+) -> Result<(), PersistenceError> {
+    match event {
+        // Off-chain path: `solana.orders` is the orderbook's row; the indexer
+        // writes only the on-chain PDA mirror. Pure on-chain creation (which
+        // also writes `solana.orders` from the decoded intent) needs the full
+        // intent the current event does not carry. Deferred.
+        SettlementEvent::OrderCreated {
+            order_uid,
+            created_by,
+            ..
+        } => {
+            sqlx::query(
+                "INSERT INTO solana.order_pda (order_uid, created_by) VALUES ($1, $2) ON CONFLICT \
+                 (order_uid) DO NOTHING",
+            )
+            .bind(order_uid.0.to_vec())
+            .bind(created_by.to_bytes().to_vec())
+            .execute(&mut *conn)
+            .await
+            .map_err(map_err)?;
+        }
+        SettlementEvent::SettlementFinalized {
+            auction_id,
+            solver,
+            tx_signature,
+            slot,
+            trades,
+        } => {
+            let tx_sig = tx_signature.as_ref().to_vec();
+            sqlx::query(
+                "INSERT INTO solana.settlements (slot, tx_signature, solver, auction_id, \
+                 solution_uid, commitment) VALUES ($1, $2, $3, $4, NULL, 'confirmed') ON CONFLICT \
+                 (tx_signature) DO NOTHING",
+            )
+            .bind(slot.0 as i64)
+            .bind(&tx_sig)
+            .bind(solver.to_bytes().to_vec())
+            .bind(auction_id as i64)
+            .execute(&mut *conn)
+            .await
+            .map_err(map_err)?;
+
+            for (index, trade) in trades.iter().enumerate() {
+                let order_uid = trade.order_uid.0.to_vec();
+                let sell = BigDecimal::from(trade.amount_withdrawn_delta);
+                let buy = BigDecimal::from(trade.amount_received_delta);
+                sqlx::query(
+                    "INSERT INTO solana.trades \
+                     (settlement_tx_signature, instruction_index, order_uid, sell_amount, \
+                      buy_amount, fee_amount, commitment) \
+                     VALUES ($1, $2, $3, $4, $5, 0, 'confirmed') \
+                     ON CONFLICT DO NOTHING",
+                )
+                .bind(&tx_sig)
+                .bind(index as i32) // placeholder: real instruction_index not carried yet
+                .bind(&order_uid)
+                .bind(&sell)
+                .bind(&buy)
+                .execute(&mut *conn)
+                .await
+                .map_err(map_err)?;
+
+                sqlx::query(
+                    "UPDATE solana.order_pda SET amount_withdrawn = amount_withdrawn + $1, \
+                     amount_received = amount_received + $2 WHERE order_uid = $3",
+                )
+                .bind(&sell)
+                .bind(&buy)
+                .bind(&order_uid)
+                .execute(&mut *conn)
+                .await
+                .map_err(map_err)?;
+            }
+        }
+        SettlementEvent::OrderClosed { order_uid }
+        | SettlementEvent::OrderCancelled { order_uid } => {
+            sqlx::query(
+                "UPDATE solana.order_pda SET cancellation_timestamp = now() WHERE order_uid = $1 \
+                 AND cancellation_timestamp IS NULL",
+            )
+            .bind(order_uid.0.to_vec())
+            .execute(&mut *conn)
+            .await
+            .map_err(map_err)?;
+        }
+        // No MVP table yet: buffers, manager/solver admin events, generic
+        // interactions. Skipped until their tables and PRs land.
+        SettlementEvent::BufferCreated { .. }
+        | SettlementEvent::BufferUsed { .. }
+        | SettlementEvent::ManagerUpdated { .. }
+        | SettlementEvent::SolverAdded { .. }
+        | SettlementEvent::SolverRemoved { .. }
+        | SettlementEvent::SolverInteraction { .. } => {}
+    }
+    Ok(())
+}
+
+fn map_err(error: sqlx::Error) -> PersistenceError {
+    match &error {
+        sqlx::Error::Database(db) if db.is_unique_violation() => PersistenceError::Conflict,
+        _ => PersistenceError::Unavailable,
     }
 }

--- a/crates/solana-indexer/src/persistence.rs
+++ b/crates/solana-indexer/src/persistence.rs
@@ -139,7 +139,7 @@ async fn advance_watermark(conn: &mut PgConnection, slot: u64) -> Result<(), Per
          EXCLUDED.last_indexed_slot > solana.indexer_state.last_indexed_slot",
     )
     .bind(WATERMARK_ROW_ID)
-    .bind(slot as i64)
+    .bind(slot.cast_signed())
     .execute(&mut *conn)
     .await
     .map_err(map_err)?;
@@ -189,10 +189,10 @@ async fn write_settlement_event(
                  solution_uid, commitment) VALUES ($1, $2, $3, $4, NULL, 'confirmed') ON CONFLICT \
                  (tx_signature) DO NOTHING",
             )
-            .bind(slot.0 as i64)
+            .bind(slot.0.cast_signed())
             .bind(&tx_sig)
             .bind(solver.to_bytes().to_vec())
-            .bind(auction_id as i64)
+            .bind(auction_id.cast_signed())
             .execute(&mut *conn)
             .await
             .map_err(map_err)?;
@@ -209,7 +209,8 @@ async fn write_settlement_event(
                      ON CONFLICT DO NOTHING",
                 )
                 .bind(&tx_sig)
-                .bind(index as i32) // placeholder: real instruction_index not carried yet
+                // placeholder: the real instruction_index is not carried yet
+                .bind(i32::try_from(index).unwrap_or_default())
                 .bind(&order_uid)
                 .bind(&sell)
                 .bind(&buy)

--- a/crates/solana-indexer/src/persistence/schema.sql
+++ b/crates/solana-indexer/src/persistence/schema.sql
@@ -1,0 +1,75 @@
+-- Test-only schema fixture for the solana-indexer PostgresStore tests.
+--
+-- This is NOT a committed flyway migration. It is applied to the docker
+-- Postgres in the `#[ignore]` persistence tests only, so the `solana.*`
+-- schema never lands on staging/prod while the shape is still moving. When it
+-- settles, promote this to database/sql-solana/V001__*.sql plus a
+-- `migrations-solana` compose service (mirroring database/sql-pool-indexer/).
+--
+-- Source of truth: database spec §4 (parallel-table schemas). Kept lean: the
+-- autopilot-facing NOTIFY triggers are omitted (the store test does not need
+-- them). The `orderkind` / `orderclass` enums are reused from the migrated
+-- public schema (docker DB has the EVM migrations applied).
+
+CREATE SCHEMA IF NOT EXISTS solana;
+
+CREATE TABLE solana.orders (
+    uid                bytea PRIMARY KEY CHECK (length(uid) = 32),
+    owner              bytea NOT NULL CHECK (length(owner) = 32),
+    sell_token         bytea NOT NULL CHECK (length(sell_token) = 32),
+    buy_token          bytea NOT NULL CHECK (length(buy_token) = 32),
+    sell_token_account bytea NOT NULL CHECK (length(sell_token_account) = 32),
+    buy_token_account  bytea NOT NULL CHECK (length(buy_token_account) = 32),
+    sell_amount        numeric(78,0) NOT NULL,
+    buy_amount         numeric(78,0) NOT NULL,
+    fee_amount         numeric(78,0) NOT NULL,
+    valid_to           bigint NOT NULL,
+    kind               orderkind NOT NULL,
+    partially_fillable boolean NOT NULL,
+    app_data           bytea NOT NULL CHECK (length(app_data) = 32),
+    intent_signature   bytea CHECK (intent_signature IS NULL OR length(intent_signature) = 64),
+    creation_timestamp timestamptz NOT NULL,
+    class              orderclass NOT NULL,
+    order_pda          bytea NOT NULL CHECK (length(order_pda) = 32)
+);
+
+CREATE TABLE solana.order_pda (
+    order_uid              bytea PRIMARY KEY REFERENCES solana.orders(uid),
+    created_by             bytea NOT NULL CHECK (length(created_by) = 32),
+    receiver_owner         bytea CHECK (receiver_owner IS NULL OR length(receiver_owner) = 32),
+    amount_withdrawn       numeric(78,0) NOT NULL DEFAULT 0,
+    amount_received        numeric(78,0) NOT NULL DEFAULT 0,
+    cancellation_timestamp timestamptz,
+    commitment             text NOT NULL DEFAULT 'confirmed'
+                           CHECK (commitment IN ('confirmed', 'finalized'))
+);
+
+CREATE TABLE solana.settlements (
+    slot         bigint NOT NULL,
+    tx_signature bytea PRIMARY KEY CHECK (length(tx_signature) = 64),
+    solver       bytea NOT NULL CHECK (length(solver) = 32),
+    auction_id   bigint NOT NULL,
+    solution_uid bigint NULL,
+    commitment   text NOT NULL DEFAULT 'confirmed'
+                 CHECK (commitment IN ('confirmed', 'finalized'))
+);
+
+CREATE TABLE solana.trades (
+    settlement_tx_signature bytea NOT NULL REFERENCES solana.settlements(tx_signature),
+    instruction_index       integer NOT NULL,
+    inner_ix_path           integer[] NOT NULL DEFAULT '{}',
+    order_uid               bytea NOT NULL CHECK (length(order_uid) = 32),
+    sell_amount             numeric(78,0) NOT NULL,
+    buy_amount              numeric(78,0) NOT NULL,
+    fee_amount              numeric(78,0) NOT NULL,
+    commitment              text NOT NULL DEFAULT 'confirmed'
+                            CHECK (commitment IN ('confirmed', 'finalized')),
+    PRIMARY KEY (settlement_tx_signature, instruction_index, inner_ix_path, order_uid)
+);
+
+-- Slot watermark. Single row (id = 0). The real DDL lives in the database
+-- schema spec; kept minimal here for the watermark round-trip test.
+CREATE TABLE solana.indexer_state (
+    id                 integer PRIMARY KEY DEFAULT 0 CHECK (id = 0),
+    last_indexed_slot  bigint NOT NULL
+);

--- a/crates/solana-indexer/src/persistence/tests.rs
+++ b/crates/solana-indexer/src/persistence/tests.rs
@@ -1,0 +1,78 @@
+//! PostgresStore tests against a real docker Postgres.
+//!
+//! Requires `docker compose up -d` and runs serially (`--test-threads 1`), the
+//! same harness the EVM database tests use. The `solana.*` schema comes from
+//! the test-only `schema.sql` fixture applied here, not from a committed flyway
+//! migration, so nothing lands on staging/prod while the shape is still moving.
+
+use {
+    super::Persistence,
+    crate::types::{
+        events::{DecodedEvent, SettlementEvent, TradeDelta},
+        order::OrderUid,
+        slot::Slot,
+    },
+    solana_sdk::{pubkey::Pubkey, signature::Signature},
+    sqlx::{PgPool, types::BigDecimal},
+};
+
+const SCHEMA: &str = include_str!("schema.sql");
+
+#[tokio::test]
+#[ignore = "requires postgres: docker compose up -d, run with --test-threads 1"]
+async fn persists_settlement_finalized_and_advances_watermark() {
+    let pool = PgPool::connect("postgresql://").await.unwrap();
+    // Fresh solana schema each run, committed to the throwaway docker DB and
+    // dropped at the end. Never a flyway migration, so staging/prod stay clean.
+    sqlx::raw_sql("DROP SCHEMA IF EXISTS solana CASCADE")
+        .execute(&pool)
+        .await
+        .unwrap();
+    sqlx::raw_sql(SCHEMA).execute(&pool).await.unwrap();
+
+    let store = Persistence::new(pool.clone());
+
+    let tx_signature = Signature::from([7u8; 64]);
+    let order_uid = OrderUid([1u8; 32]);
+    let event = DecodedEvent::Settlement(SettlementEvent::SettlementFinalized {
+        auction_id: 42,
+        solver: Pubkey::from([2u8; 32]),
+        tx_signature,
+        slot: Slot(100),
+        trades: vec![TradeDelta {
+            order_uid,
+            amount_withdrawn_delta: 1_000,
+            amount_received_delta: 900,
+            order_fulfilled: true,
+        }],
+    });
+
+    store.persist_events(vec![event], 100).await.unwrap();
+
+    let (auction_id,): (i64,) =
+        sqlx::query_as("SELECT auction_id FROM solana.settlements WHERE tx_signature = $1")
+            .bind(tx_signature.as_ref().to_vec())
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(auction_id, 42);
+
+    let (sell,): (BigDecimal,) =
+        sqlx::query_as("SELECT sell_amount FROM solana.trades WHERE order_uid = $1")
+            .bind(order_uid.0.to_vec())
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(sell, BigDecimal::from(1_000u64));
+
+    assert_eq!(store.read_watermark().await.unwrap(), Some(100));
+
+    // Monotonic: a lower watermark is ignored.
+    store.write_watermark(50).await.unwrap();
+    assert_eq!(store.read_watermark().await.unwrap(), Some(100));
+
+    sqlx::raw_sql("DROP SCHEMA solana CASCADE")
+        .execute(&pool)
+        .await
+        .unwrap();
+}


### PR DESCRIPTION
# Description
Implements the PostgresStore persistence for the indexer's live path: decoded settlement events and the slot watermark land in the `solana.*` tables in one transaction. This retires the `todo!()` stubs on `Persistence` for the ingest path and gives the decoder a real store to write through in a follow-up.

Runs ahead of the schema being frozen. The `solana.*` DDL lives in a test-only fixture applied to docker Postgres in the `#[ignore]` test, not a committed flyway migration, so staging and prod stay clean until the shape settles. When it does, it promotes to `database/sql-solana/` plus a compose service, mirroring the pool-indexer.

# Changes
- `Persistence` holds a `PgPool` and implements `persist_events` (events plus watermark in one transaction), `write_watermark` (monotonic), and `read_watermark`, all runtime sqlx queries.
- Settlement mapping: `OrderCreated` writes `solana.order_pda` (off-chain path, `solana.orders` is the orderbook's row), `SettlementFinalized` writes `solana.settlements` plus per-order `solana.trades` plus the cumulative `solana.order_pda` counters, `OrderClosed`/`OrderCancelled` set the cancellation timestamp. Buffer and admin events are skipped (no MVP table).
- Test-only `schema.sql` fixture and an `#[ignore]` docker-Postgres test.
- The finalization and recovery `Persistence` methods stay `todo!()` (their own PRs, recovery is out of scope for v0.1).

# How to test
`docker compose up -d`, then `cargo nextest run -p solana-indexer --run-ignored all --test-threads 1`. Non-ignored tests run without a database.

# Notes
- Placeholders mirror PR 7.2: `instruction_index` and `fee_amount` on `solana.trades`, and the buy-side amount, are constants until the decoder resolves them from proposed-solution data.
- The decoder does not call `persist_events` yet. Wiring it needs a `Store` trait so the decoder unit tests inject a fake rather than a live database, deferred to a follow-up.
- `schema.sql` is deliberately not a flyway migration (see Description).
