### PR TITLE
feat(solana-solvers): PR 1 crate skeleton, config, /solve scaffold

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10832,6 +10832,7 @@ dependencies = [
  "anyhow",
  "axum 0.8.8",
  "clap",
+ "observe",
  "serde",
  "serde_json",
  "thiserror 1.0.69",
@@ -10840,7 +10841,6 @@ dependencies = [
  "tower 0.5.3",
  "tower-http",
  "tracing",
- "tracing-subscriber",
  "url",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10829,16 +10829,13 @@ dependencies = [
 name = "solana-solvers"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "axum 0.8.8",
  "clap",
  "observe",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
  "tokio",
  "toml",
- "tower 0.5.3",
  "tower-http",
  "tracing",
  "url",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10826,6 +10826,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-solvers"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "axum 0.8.8",
+ "clap",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "toml",
+ "tower 0.5.3",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+]
+
+[[package]]
 name = "solana-stable-layout"
 version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/solana-solvers/Cargo.toml
+++ b/crates/solana-solvers/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "solana-solvers"
+version = "0.1.0"
+edition = "2024"
+license = "GPL-3.0-or-later"
+description = "Solana solver engines for CoW Protocol (Jupiter dex-wrapper)"
+
+[lib]
+name = "solana_solvers"
+path = "src/lib.rs"
+
+[[bin]]
+name = "solana-solvers"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = { workspace = true }
+axum = { workspace = true }
+clap = { workspace = true, features = ["derive", "env"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["fs", "macros", "rt-multi-thread", "signal"] }
+toml = { workspace = true }
+tower = { workspace = true }
+tower-http = { workspace = true, features = ["limit", "trace"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+url = { workspace = true, features = ["serde"] }
+
+[lints]
+workspace = true

--- a/crates/solana-solvers/Cargo.toml
+++ b/crates/solana-solvers/Cargo.toml
@@ -14,17 +14,14 @@ name = "solana-solvers"
 path = "src/main.rs"
 
 [dependencies]
-anyhow = { workspace = true }
 axum = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"] }
 observe = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-thiserror = { workspace = true }
 tokio = { workspace = true, features = ["fs", "macros", "rt-multi-thread", "signal"] }
 toml = { workspace = true }
-tower = { workspace = true }
-tower-http = { workspace = true, features = ["limit", "trace"] }
+tower-http = { workspace = true, features = ["limit"] }
 tracing = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 

--- a/crates/solana-solvers/Cargo.toml
+++ b/crates/solana-solvers/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/main.rs"
 anyhow = { workspace = true }
 axum = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"] }
+observe = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
@@ -25,7 +26,6 @@ toml = { workspace = true }
 tower = { workspace = true }
 tower-http = { workspace = true, features = ["limit", "trace"] }
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 
 [lints]

--- a/crates/solana-solvers/Cargo.toml
+++ b/crates/solana-solvers/Cargo.toml
@@ -2,8 +2,8 @@
 name = "solana-solvers"
 version = "0.1.0"
 edition = "2024"
-license = "GPL-3.0-or-later"
 description = "Solana solver engines for CoW Protocol (Jupiter dex-wrapper)"
+license = "GPL-3.0-or-later"
 
 [lib]
 name = "solana_solvers"

--- a/crates/solana-solvers/config/example.jupiter.toml
+++ b/crates/solana-solvers/config/example.jupiter.toml
@@ -1,0 +1,13 @@
+# Example Jupiter solver configuration.
+
+[dex.jupiter]
+# Base URL of the swap API. Public Jupiter by default; point at Triton's
+# hosted Metis (and set api-key) to hedge against public rate limits.
+endpoint = "https://api.jup.ag"
+# Slippage tolerance encoded into each quote request, as a percent.
+slippage = "0.5"
+# Buy orders quote via Jupiter ExactOut, which is route-limited. Off by default.
+enable-buy-orders = false
+# Compute-unit estimate used when a quote response carries none.
+cu-default = 200000
+# api-key = "..."   # required only for Triton's hosted Metis

--- a/crates/solana-solvers/config/example.jupiter.toml
+++ b/crates/solana-solvers/config/example.jupiter.toml
@@ -7,7 +7,7 @@
 endpoint = "https://api.jup.ag"
 # API key from the Jupiter developer portal (or Triton). Omit only for lite-api.
 api-key = "your-jupiter-api-key"
-# Slippage tolerance encoded into each quote request, as a percent.
-slippage = "0.5"
+# Slippage tolerance in basis points, sent to Jupiter as slippageBps. 50 = 0.5%.
+slippage-bps = 50
 # Buy orders quote via Jupiter ExactOut, which is route-limited. Off by default.
 enable-buy-orders = false

--- a/crates/solana-solvers/config/example.jupiter.toml
+++ b/crates/solana-solvers/config/example.jupiter.toml
@@ -2,10 +2,10 @@
 # Run with: solana-solvers jupiter --config <this file>
 
 [dex]
-# Jupiter swap API base URL. Use api.jup.ag with an api-key, or a Triton-hosted
-# Metis endpoint. The keyless lite-api.jup.ag also works but is rate-limited.
+# Jupiter swap API base URL. Use api.jup.ag, or a Triton-hosted endpoint.
 endpoint = "https://api.jup.ag"
-# API key from the Jupiter developer portal (or Triton). Omit only for lite-api.
+# API key from the Jupiter developer portal (or Triton). Works without one but
+# heavily rate-limited, set it for production.
 api-key = "your-jupiter-api-key"
 # Slippage tolerance in basis points, sent to Jupiter as slippageBps. 50 = 0.5%.
 slippage-bps = 50

--- a/crates/solana-solvers/config/example.jupiter.toml
+++ b/crates/solana-solvers/config/example.jupiter.toml
@@ -1,13 +1,13 @@
 # Example Jupiter solver configuration.
+# Run with: solana-solvers jupiter --config <this file>
 
-[dex.jupiter]
-# Base URL of the swap API. Public Jupiter by default; point at Triton's
-# hosted Metis (and set api-key) to hedge against public rate limits.
+[dex]
+# Jupiter swap API base URL. Use api.jup.ag with an api-key, or a Triton-hosted
+# Metis endpoint. The keyless lite-api.jup.ag also works but is rate-limited.
 endpoint = "https://api.jup.ag"
+# API key from the Jupiter developer portal (or Triton). Omit only for lite-api.
+api-key = "your-jupiter-api-key"
 # Slippage tolerance encoded into each quote request, as a percent.
 slippage = "0.5"
 # Buy orders quote via Jupiter ExactOut, which is route-limited. Off by default.
 enable-buy-orders = false
-# Compute-unit estimate used when a quote response carries none.
-cu-default = 200000
-# api-key = "..."   # required only for Triton's hosted Metis

--- a/crates/solana-solvers/src/api.rs
+++ b/crates/solana-solvers/src/api.rs
@@ -1,8 +1,7 @@
 //! HTTP API for the solver engine.
 //!
-//! Serves the `/solve` contract the driver calls. At this stage the handler is
-//! a scaffold: it accepts any auction and returns no solutions. Real quoting
-//! and solution assembly land in later PRs.
+//! Serves the `/solve` contract the driver calls. The handler is a scaffold: it
+//! accepts any auction and returns no solutions.
 
 use {
     crate::config::Config,
@@ -49,10 +48,8 @@ async fn healthz() -> &'static str {
     "ok"
 }
 
-/// Scaffold `/solve`: accept any auction, return no solutions. The real solve
-/// loop wraps each order's Jupiter quote into a single-order solution (later
-/// PRs); until then the driver wiring can be exercised end to end against an
-/// empty result.
+/// Scaffold `/solve`: accepts any auction and returns no solutions, so the
+/// driver wiring can be exercised against an empty result.
 async fn solve(State(_config): State<Arc<Config>>, Json(_auction): Json<Value>) -> Json<Value> {
     Json(json!({ "solutions": [] }))
 }

--- a/crates/solana-solvers/src/api.rs
+++ b/crates/solana-solvers/src/api.rs
@@ -1,0 +1,58 @@
+//! HTTP API for the solver engine.
+//!
+//! Serves the `/solve` contract the driver calls. At this stage the handler is
+//! a scaffold: it accepts any auction and returns no solutions. Real quoting
+//! and solution assembly land in later PRs.
+
+use {
+    crate::config::Config,
+    axum::{
+        Json,
+        Router,
+        extract::State,
+        routing::{get, post},
+    },
+    serde_json::{Value, json},
+    std::{future::Future, net::SocketAddr, sync::Arc},
+    tower_http::limit::RequestBodyLimitLayer,
+};
+
+const REQUEST_BODY_LIMIT: usize = 10 * 1024 * 1024;
+
+pub struct Api {
+    pub addr: SocketAddr,
+    pub config: Config,
+}
+
+impl Api {
+    /// Bind and serve until `shutdown` resolves.
+    pub async fn serve(
+        self,
+        shutdown: impl Future<Output = ()> + Send + 'static,
+    ) -> std::io::Result<()> {
+        let app = Router::new()
+            .route("/healthz", get(healthz))
+            .route("/solve", post(solve))
+            .with_state(Arc::new(self.config))
+            .layer(RequestBodyLimitLayer::new(REQUEST_BODY_LIMIT))
+            .layer(axum::extract::DefaultBodyLimit::disable());
+
+        let listener = tokio::net::TcpListener::bind(self.addr).await?;
+        tracing::info!(addr = %self.addr, "solana-solvers listening");
+        axum::serve(listener, app)
+            .with_graceful_shutdown(shutdown)
+            .await
+    }
+}
+
+async fn healthz() -> &'static str {
+    "ok"
+}
+
+/// Scaffold `/solve`: accept any auction, return no solutions. The real solve
+/// loop wraps each order's Jupiter quote into a single-order solution (later
+/// PRs); until then the driver wiring can be exercised end to end against an
+/// empty result.
+async fn solve(State(_config): State<Arc<Config>>, Json(_auction): Json<Value>) -> Json<Value> {
+    Json(json!({ "solutions": [] }))
+}

--- a/crates/solana-solvers/src/cli.rs
+++ b/crates/solana-solvers/src/cli.rs
@@ -34,6 +34,5 @@ pub enum Command {
         #[clap(long, env)]
         config: PathBuf,
     },
-    // Baseline (self-indexed on-chain liquidity) lands when the driver's
-    // liquidity module unfreezes.
+    // TODO: add a baseline engine subcommand.
 }

--- a/crates/solana-solvers/src/cli.rs
+++ b/crates/solana-solvers/src/cli.rs
@@ -1,0 +1,39 @@
+//! CLI arguments for the `solana-solvers` binary.
+
+use {
+    clap::{Parser, Subcommand},
+    std::{net::SocketAddr, path::PathBuf},
+};
+
+/// Run a Solana solver engine.
+#[derive(Parser, Debug)]
+#[command(version)]
+pub struct Args {
+    /// The log filter.
+    #[arg(long, env, default_value = "warn,solana_solvers=debug")]
+    pub log: String,
+
+    /// Whether to use JSON format for the logs.
+    #[clap(long, env, default_value = "false")]
+    pub use_json_logs: bool,
+
+    /// The socket address to bind to.
+    #[arg(long, env, default_value = "127.0.0.1:7900")]
+    pub addr: SocketAddr,
+
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+/// The solver engine to run. `config` is a path to a TOML config file.
+#[derive(Subcommand, Debug)]
+#[clap(rename_all = "lowercase")]
+pub enum Command {
+    /// Wrap Jupiter's quote API into single-order solutions.
+    Jupiter {
+        #[clap(long, env)]
+        config: PathBuf,
+    },
+    // Baseline (self-indexed on-chain liquidity) lands when the driver's
+    // liquidity module unfreezes.
+}

--- a/crates/solana-solvers/src/config.rs
+++ b/crates/solana-solvers/src/config.rs
@@ -18,9 +18,8 @@ pub struct JupiterConfig {
     /// endpoint.
     pub endpoint: Url,
 
-    /// API key for the Jupiter API. Required for `api.jup.ag` (issued by the
-    /// Jupiter developer portal) and for Triton. Omit only for the keyless
-    /// `lite-api.jup.ag` endpoint.
+    /// API key from the Jupiter developer portal (or Triton). Requests work
+    /// without one but are heavily rate-limited, so set it for production.
     #[serde(default)]
     pub api_key: Option<String>,
 

--- a/crates/solana-solvers/src/config.rs
+++ b/crates/solana-solvers/src/config.rs
@@ -24,8 +24,9 @@ pub struct JupiterConfig {
     #[serde(default)]
     pub api_key: Option<String>,
 
-    /// Slippage tolerance encoded into each quote request, as a percent string.
-    pub slippage: String,
+    /// Slippage tolerance in basis points, sent to Jupiter as `slippageBps`.
+    /// 50 = 0.5%.
+    pub slippage_bps: u16,
 
     /// Whether buy orders (Jupiter `ExactOut`) are served. Off by default.
     #[serde(default)]
@@ -53,7 +54,7 @@ mod tests {
         let config: Config =
             toml::from_str(include_str!("../config/example.jupiter.toml")).unwrap();
         assert_eq!(config.dex.endpoint.as_str(), "https://api.jup.ag/");
-        assert_eq!(config.dex.slippage, "0.5");
+        assert_eq!(config.dex.slippage_bps, 50);
         assert!(!config.dex.enable_buy_orders);
         assert!(config.dex.api_key.is_some());
     }
@@ -63,7 +64,7 @@ mod tests {
         let toml = r#"
 [dex]
 endpoint = "https://api.jup.ag"
-slippage = "0.5"
+slippage-bps = 50
 bogus = true
 "#;
         assert!(toml::from_str::<Config>(toml).is_err());

--- a/crates/solana-solvers/src/config.rs
+++ b/crates/solana-solvers/src/config.rs
@@ -1,0 +1,82 @@
+//! Solver-engine configuration.
+//!
+//! Mirrors the `crates/solvers` config shape: a `[dex]` table with a
+//! per-aggregator sub-table. Jupiter is the only backend at MVP.
+
+use {serde::Deserialize, std::path::Path, url::Url};
+
+/// Top-level configuration.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct Config {
+    pub dex: DexConfig,
+}
+
+/// The `[dex]` table. One sub-table per aggregator backend.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct DexConfig {
+    pub jupiter: JupiterConfig,
+}
+
+/// The `[dex.jupiter]` sub-table.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct JupiterConfig {
+    /// Base URL of the Jupiter (or Triton-hosted) swap API.
+    pub endpoint: Url,
+
+    /// API key. `None` for the public API, set for Triton's hosted Metis.
+    #[serde(default)]
+    pub api_key: Option<String>,
+
+    /// Slippage tolerance encoded into the quote request, as a percent string.
+    pub slippage: String,
+
+    /// Whether buy orders (Jupiter `ExactOut`) are served. Off by default.
+    #[serde(default)]
+    pub enable_buy_orders: bool,
+
+    /// Default compute-unit estimate used when a quote response carries none.
+    pub cu_default: u32,
+}
+
+/// Load and parse the TOML config file.
+///
+/// # Panics
+///
+/// Panics on I/O or parse errors: a bad config is a startup failure.
+pub async fn load(path: &Path) -> Config {
+    let text = tokio::fs::read_to_string(path)
+        .await
+        .unwrap_or_else(|err| panic!("read config {}: {err}", path.display()));
+    toml::from_str(&text).unwrap_or_else(|err| panic!("parse config {}: {err}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_example_config() {
+        let config: Config =
+            toml::from_str(include_str!("../config/example.jupiter.toml")).unwrap();
+        assert_eq!(config.dex.jupiter.endpoint.as_str(), "https://api.jup.ag/");
+        assert_eq!(config.dex.jupiter.slippage, "0.5");
+        assert!(!config.dex.jupiter.enable_buy_orders);
+        assert_eq!(config.dex.jupiter.cu_default, 200_000);
+        assert!(config.dex.jupiter.api_key.is_none());
+    }
+
+    #[test]
+    fn rejects_unknown_keys() {
+        let toml = r#"
+[dex.jupiter]
+endpoint = "https://api.jup.ag"
+slippage = "0.5"
+cu-default = 200000
+bogus = true
+"#;
+        assert!(toml::from_str::<Config>(toml).is_err());
+    }
+}

--- a/crates/solana-solvers/src/config.rs
+++ b/crates/solana-solvers/src/config.rs
@@ -1,44 +1,35 @@
 //! Solver-engine configuration.
-//!
-//! Mirrors the `crates/solvers` config shape: a `[dex]` table with a
-//! per-aggregator sub-table. Jupiter is the only backend at MVP.
 
 use {serde::Deserialize, std::path::Path, url::Url};
 
-/// Top-level configuration.
+/// Jupiter solver configuration.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct Config {
-    pub dex: DexConfig,
+    pub dex: JupiterConfig,
 }
 
-/// The `[dex]` table. One sub-table per aggregator backend.
-#[derive(Debug, Clone, Deserialize)]
-#[serde(rename_all = "kebab-case", deny_unknown_fields)]
-pub struct DexConfig {
-    pub jupiter: JupiterConfig,
-}
-
-/// The `[dex.jupiter]` sub-table.
+/// The `[dex]` table for the Jupiter backend. The subcommand selects the
+/// engine, so there is no per-aggregator sub-table.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct JupiterConfig {
-    /// Base URL of the Jupiter (or Triton-hosted) swap API.
+    /// Base URL of the Jupiter swap API (`api.jup.ag`) or a Triton-hosted Metis
+    /// endpoint.
     pub endpoint: Url,
 
-    /// API key. `None` for the public API, set for Triton's hosted Metis.
+    /// API key for the Jupiter API. Required for `api.jup.ag` (issued by the
+    /// Jupiter developer portal) and for Triton. Omit only for the keyless
+    /// `lite-api.jup.ag` endpoint.
     #[serde(default)]
     pub api_key: Option<String>,
 
-    /// Slippage tolerance encoded into the quote request, as a percent string.
+    /// Slippage tolerance encoded into each quote request, as a percent string.
     pub slippage: String,
 
     /// Whether buy orders (Jupiter `ExactOut`) are served. Off by default.
     #[serde(default)]
     pub enable_buy_orders: bool,
-
-    /// Default compute-unit estimate used when a quote response carries none.
-    pub cu_default: u32,
 }
 
 /// Load and parse the TOML config file.
@@ -61,20 +52,18 @@ mod tests {
     fn parses_example_config() {
         let config: Config =
             toml::from_str(include_str!("../config/example.jupiter.toml")).unwrap();
-        assert_eq!(config.dex.jupiter.endpoint.as_str(), "https://api.jup.ag/");
-        assert_eq!(config.dex.jupiter.slippage, "0.5");
-        assert!(!config.dex.jupiter.enable_buy_orders);
-        assert_eq!(config.dex.jupiter.cu_default, 200_000);
-        assert!(config.dex.jupiter.api_key.is_none());
+        assert_eq!(config.dex.endpoint.as_str(), "https://api.jup.ag/");
+        assert_eq!(config.dex.slippage, "0.5");
+        assert!(!config.dex.enable_buy_orders);
+        assert!(config.dex.api_key.is_some());
     }
 
     #[test]
     fn rejects_unknown_keys() {
         let toml = r#"
-[dex.jupiter]
+[dex]
 endpoint = "https://api.jup.ag"
 slippage = "0.5"
-cu-default = 200000
 bogus = true
 "#;
         assert!(toml::from_str::<Config>(toml).is_err());

--- a/crates/solana-solvers/src/lib.rs
+++ b/crates/solana-solvers/src/lib.rs
@@ -1,0 +1,11 @@
+//! Solana solver engines for CoW Protocol.
+//!
+//! An MVP dex-wrapper over Jupiter's quote API, mirroring the `crates/solvers`
+//! shape over Solana-native types. This crate is the HTTP `/solve` host; the
+//! Jupiter adapter, solution assembly, and solve loop land in later PRs.
+
+pub mod api;
+pub mod config;
+mod run;
+
+pub use run::start;

--- a/crates/solana-solvers/src/lib.rs
+++ b/crates/solana-solvers/src/lib.rs
@@ -1,9 +1,7 @@
 //! Solana solver engines for CoW Protocol.
 //!
-//! An MVP dex-wrapper over Jupiter's quote API, mirroring the `crates/solvers`
-//! shape over Solana-native types. This crate is the HTTP `/solve` host; the
-//! Jupiter adapter, solution assembly, and solve loop land in later PRs, and a
-//! Solana baseline engine joins once the driver's liquidity module unfreezes.
+//! An MVP dex-wrapper over Jupiter, mirroring the `crates/solvers` shape over
+//! Solana-native types (`u64`, `Pubkey`, instructions). Hosts the `/solve` API.
 
 pub mod api;
 mod cli;

--- a/crates/solana-solvers/src/lib.rs
+++ b/crates/solana-solvers/src/lib.rs
@@ -2,9 +2,11 @@
 //!
 //! An MVP dex-wrapper over Jupiter's quote API, mirroring the `crates/solvers`
 //! shape over Solana-native types. This crate is the HTTP `/solve` host; the
-//! Jupiter adapter, solution assembly, and solve loop land in later PRs.
+//! Jupiter adapter, solution assembly, and solve loop land in later PRs, and a
+//! Solana baseline engine joins once the driver's liquidity module unfreezes.
 
 pub mod api;
+mod cli;
 pub mod config;
 mod run;
 

--- a/crates/solana-solvers/src/main.rs
+++ b/crates/solana-solvers/src/main.rs
@@ -1,0 +1,4 @@
+#[tokio::main]
+async fn main() {
+    solana_solvers::start(std::env::args()).await;
+}

--- a/crates/solana-solvers/src/run.rs
+++ b/crates/solana-solvers/src/run.rs
@@ -1,40 +1,57 @@
-//! Binary entry: parse args, load config, serve the `/solve` API.
+//! Binary entry: parse args, initialize observability, dispatch to the engine.
 
+#[cfg(unix)]
+use tokio::signal::unix::{self, SignalKind};
 use {
-    crate::{api::Api, config},
+    crate::{
+        api::Api,
+        cli::{Args, Command},
+        config,
+    },
     clap::Parser,
-    std::{net::SocketAddr, path::PathBuf},
 };
 
-/// Command-line arguments.
-#[derive(Parser, Debug)]
-#[clap(name = "solana-solvers")]
-pub struct Args {
-    /// Path to the TOML configuration file.
-    #[clap(long, env = "SOLANA_SOLVERS_CONFIG")]
-    pub config: PathBuf,
-
-    /// Socket address the HTTP API binds to.
-    #[clap(long, env = "SOLANA_SOLVERS_BIND", default_value = "0.0.0.0:7900")]
-    pub bind: SocketAddr,
-}
-
-/// Parse args and run the solver engine until shutdown.
+/// Parse args and run the selected solver engine until shutdown.
 pub async fn start(args: impl IntoIterator<Item = String>) {
+    observe::panic_hook::install();
     let args = Args::parse_from(args);
-    tracing_subscriber::fmt::init();
-    tracing::info!(?args, "starting solana-solvers");
 
-    let config = config::load(&args.config).await;
-    let api = Api {
-        addr: args.bind,
-        config,
-    };
-    if let Err(err) = api.serve(shutdown_signal()).await {
-        tracing::error!(?err, "server error");
+    let obs_config = observe::Config::new(
+        &args.log,
+        Some(tracing::Level::ERROR),
+        args.use_json_logs,
+        None,
+    );
+    observe::tracing::init::initialize_reentrant(&obs_config);
+    tracing::info!(version = %observe::version::git_version(), "running solana-solvers with {args:#?}");
+
+    match args.command {
+        Command::Jupiter { config: path } => {
+            let config = config::load(&path).await;
+            let api = Api {
+                addr: args.addr,
+                config,
+            };
+            if let Err(err) = api.serve(shutdown_signal()).await {
+                tracing::error!(?err, "server error");
+            }
+        }
     }
 }
 
+#[cfg(unix)]
 async fn shutdown_signal() {
-    let _ = tokio::signal::ctrl_c().await;
+    // Kubernetes sends SIGTERM; locally SIGINT (ctrl-c) is most common.
+    let mut interrupt = unix::signal(SignalKind::interrupt()).expect("install SIGINT handler");
+    let mut terminate = unix::signal(SignalKind::terminate()).expect("install SIGTERM handler");
+    tokio::select! {
+        _ = interrupt.recv() => (),
+        _ = terminate.recv() => (),
+    };
+}
+
+#[cfg(windows)]
+async fn shutdown_signal() {
+    // Signal handling is not supported on Windows.
+    std::future::pending().await
 }

--- a/crates/solana-solvers/src/run.rs
+++ b/crates/solana-solvers/src/run.rs
@@ -1,0 +1,40 @@
+//! Binary entry: parse args, load config, serve the `/solve` API.
+
+use {
+    crate::{api::Api, config},
+    clap::Parser,
+    std::{net::SocketAddr, path::PathBuf},
+};
+
+/// Command-line arguments.
+#[derive(Parser, Debug)]
+#[clap(name = "solana-solvers")]
+pub struct Args {
+    /// Path to the TOML configuration file.
+    #[clap(long, env = "SOLANA_SOLVERS_CONFIG")]
+    pub config: PathBuf,
+
+    /// Socket address the HTTP API binds to.
+    #[clap(long, env = "SOLANA_SOLVERS_BIND", default_value = "0.0.0.0:7900")]
+    pub bind: SocketAddr,
+}
+
+/// Parse args and run the solver engine until shutdown.
+pub async fn start(args: impl IntoIterator<Item = String>) {
+    let args = Args::parse_from(args);
+    tracing_subscriber::fmt::init();
+    tracing::info!(?args, "starting solana-solvers");
+
+    let config = config::load(&args.config).await;
+    let api = Api {
+        addr: args.bind,
+        config,
+    };
+    if let Err(err) = api.serve(shutdown_signal()).await {
+        tracing::error!(?err, "server error");
+    }
+}
+
+async fn shutdown_signal() {
+    let _ = tokio::signal::ctrl_c().await;
+}


### PR DESCRIPTION
# Description
First PR of the Jupiter solver: a new `solana-solvers` crate that hosts the `/solve` API. It mirrors the `crates/solvers` shape over Solana-native types without reusing the EVM code, which is typed end to end on EVM primitives (`U256`, 20-byte `Address`, single-call calldata) with no chain abstraction. This PR is the skeleton. The Jupiter adapter, solution assembly, and solve loop land in the following PRs.

# Changes
- New `crates/solana-solvers` binary crate (`main`/`lib`/`run`/`cli`), an axum HTTP server with `/healthz` and `/solve`.
- Subcommand CLI (`solana-solvers jupiter --config ...`), so a Solana baseline engine can slot in later.
- `observe`-based logging (JSON option, panic hook) and graceful shutdown on SIGTERM/SIGINT.
- `/solve` is a scaffold: it accepts any auction and returns `{"solutions": []}`, so the driver wiring can be exercised before real quoting lands.
- Config: a `[dex]` table for the Jupiter backend (endpoint, api-key, slippage) with `deny_unknown_fields`, plus `config/example.jupiter.toml`.
- Lean dependency set (axum, clap, observe, serde, tokio, url). No EVM deps pulled in.

# How to test
New unit tests (config parse plus unknown-key rejection).

# Notes
- Part of the Jupiter solver PR plan (specs repo PR https://github.com/cowprotocol/solana-services-specifications/pull/33). PRs 2-4 add the Jupiter adapter, solution assembly, and the solve loop.
