### PR TITLE
feat(solana-solvers): PR 2.1 Jupiter v1 swap adapter (sells)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10839,6 +10839,7 @@ dependencies = [
  "reqwest 0.13.4",
  "serde",
  "serde_json",
+ "serde_with",
  "solana-sdk",
  "thiserror 1.0.69",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10833,10 +10833,14 @@ name = "solana-solvers"
 version = "0.1.0"
 dependencies = [
  "axum 0.8.8",
+ "base64 0.22.1",
  "clap",
  "observe",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
+ "solana-sdk",
+ "thiserror 1.0.69",
  "tokio",
  "toml",
  "tower-http",

--- a/crates/solana-solvers/Cargo.toml
+++ b/crates/solana-solvers/Cargo.toml
@@ -15,10 +15,14 @@ path = "src/main.rs"
 
 [dependencies]
 axum = { workspace = true }
+base64 = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"] }
 observe = { workspace = true }
+reqwest = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+solana-sdk = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true, features = ["fs", "macros", "rt-multi-thread", "signal"] }
 toml = { workspace = true }
 tower-http = { workspace = true, features = ["limit"] }

--- a/crates/solana-solvers/Cargo.toml
+++ b/crates/solana-solvers/Cargo.toml
@@ -21,6 +21,7 @@ observe = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+serde_with = { workspace = true }
 solana-sdk = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["fs", "macros", "rt-multi-thread", "signal"] }

--- a/crates/solana-solvers/config/example.jupiter.toml
+++ b/crates/solana-solvers/config/example.jupiter.toml
@@ -2,12 +2,10 @@
 # Run with: solana-solvers jupiter --config <this file>
 
 [dex]
-# Jupiter swap API base URL. Use api.jup.ag, or a Triton-hosted endpoint.
+# Jupiter swap API base URL: api.jup.ag, or a Triton-hosted endpoint.
 endpoint = "https://api.jup.ag"
 # API key from the Jupiter developer portal (or Triton). Works without one but
 # heavily rate-limited, set it for production.
 api-key = "your-jupiter-api-key"
 # Slippage tolerance in basis points, sent to Jupiter as slippageBps. 50 = 0.5%.
 slippage-bps = 50
-# Buy orders quote via Jupiter ExactOut, which is route-limited. Off by default.
-enable-buy-orders = false

--- a/crates/solana-solvers/src/config.rs
+++ b/crates/solana-solvers/src/config.rs
@@ -9,12 +9,11 @@ pub struct Config {
     pub dex: JupiterConfig,
 }
 
-/// The `[dex]` table for the Jupiter backend. The subcommand selects the
-/// engine, so there is no per-aggregator sub-table.
+/// The `[dex]` table for the Jupiter backend.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct JupiterConfig {
-    /// Base URL of the Jupiter swap API (`api.jup.ag`) or a Triton-hosted Metis
+    /// Base URL of the Jupiter swap API: `api.jup.ag`, or a Triton-hosted
     /// endpoint.
     pub endpoint: Url,
 
@@ -26,10 +25,6 @@ pub struct JupiterConfig {
     /// Slippage tolerance in basis points, sent to Jupiter as `slippageBps`.
     /// 50 = 0.5%.
     pub slippage_bps: u16,
-
-    /// Whether buy orders (Jupiter `ExactOut`) are served. Off by default.
-    #[serde(default)]
-    pub enable_buy_orders: bool,
 }
 
 /// Load and parse the TOML config file.
@@ -54,7 +49,6 @@ mod tests {
             toml::from_str(include_str!("../config/example.jupiter.toml")).unwrap();
         assert_eq!(config.dex.endpoint.as_str(), "https://api.jup.ag/");
         assert_eq!(config.dex.slippage_bps, 50);
-        assert!(!config.dex.enable_buy_orders);
         assert!(config.dex.api_key.is_some());
     }
 

--- a/crates/solana-solvers/src/dex/jupiter/dto.rs
+++ b/crates/solana-solvers/src/dex/jupiter/dto.rs
@@ -13,8 +13,7 @@ use {
     std::str::FromStr,
 };
 
-/// Body of the `/swap-instructions` request. `Pubkey` serializes to its base58
-/// string in JSON, so no manual conversion.
+/// Body of the `/swap-instructions` request.
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SwapInstructionsRequest<'a> {

--- a/crates/solana-solvers/src/dex/jupiter/dto.rs
+++ b/crates/solana-solvers/src/dex/jupiter/dto.rs
@@ -6,6 +6,7 @@ use {
     crate::dex::Swap,
     base64::prelude::*,
     serde::{Deserialize, Serialize},
+    serde_with::serde_as,
     solana_sdk::{
         instruction::{AccountMeta, Instruction},
         pubkey::Pubkey,
@@ -13,14 +14,16 @@ use {
     std::str::FromStr,
 };
 
-/// Body of the `/swap-instructions` request.
+/// Body of the `/swap-instructions` request. `Pubkey`'s default serialization
+/// is a byte array, so the pubkeys serialize via their base58 `Display`.
+#[serde_as]
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SwapInstructionsRequest<'a> {
     quote_response: &'a serde_json::Value,
-    #[serde(serialize_with = "as_base58")]
+    #[serde_as(as = "serde_with::DisplayFromStr")]
     user_public_key: Pubkey,
-    #[serde(serialize_with = "as_base58")]
+    #[serde_as(as = "serde_with::DisplayFromStr")]
     destination_token_account: Pubkey,
     wrap_and_unwrap_sol: bool,
     skip_user_accounts_rpc_calls: bool,
@@ -42,12 +45,6 @@ impl<'a> SwapInstructionsRequest<'a> {
             skip_user_accounts_rpc_calls: true,
         }
     }
-}
-
-/// Serialize a `Pubkey` as its base58 string. Jupiter expects strings, and
-/// `Pubkey`'s default serialization is a byte array.
-fn as_base58<S: serde::Serializer>(pubkey: &Pubkey, serializer: S) -> Result<S::Ok, S::Error> {
-    serializer.serialize_str(&pubkey.to_string())
 }
 
 /// The parts of the `/swap-instructions` response we need to build a [`Swap`].

--- a/crates/solana-solvers/src/dex/jupiter/dto.rs
+++ b/crates/solana-solvers/src/dex/jupiter/dto.rs
@@ -1,17 +1,55 @@
-//! DTO for Jupiter's `/swap-instructions` response, converted to Solana
-//! instructions. Field names follow Jupiter's camelCase JSON.
+//! DTOs for Jupiter's `/swap-instructions` request and response, converting to
+//! and from Solana instructions. Field names follow Jupiter's camelCase JSON.
 
 use {
     super::Error,
     crate::dex::Swap,
     base64::prelude::*,
-    serde::Deserialize,
+    serde::{Deserialize, Serialize},
     solana_sdk::{
         instruction::{AccountMeta, Instruction},
         pubkey::Pubkey,
     },
     std::str::FromStr,
 };
+
+/// Body of the `/swap-instructions` request. `Pubkey` serializes to its base58
+/// string in JSON, so no manual conversion.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SwapInstructionsRequest<'a> {
+    quote_response: &'a serde_json::Value,
+    #[serde(serialize_with = "as_base58")]
+    user_public_key: Pubkey,
+    #[serde(serialize_with = "as_base58")]
+    destination_token_account: Pubkey,
+    wrap_and_unwrap_sol: bool,
+    skip_user_accounts_rpc_calls: bool,
+}
+
+impl<'a> SwapInstructionsRequest<'a> {
+    /// The swap rides inside the settlement tx, so SOL wrapping is left off and
+    /// Jupiter skips its account RPC probes.
+    pub fn new(
+        quote_response: &'a serde_json::Value,
+        taker: &Pubkey,
+        destination: &Pubkey,
+    ) -> Self {
+        Self {
+            quote_response,
+            user_public_key: *taker,
+            destination_token_account: *destination,
+            wrap_and_unwrap_sol: false,
+            skip_user_accounts_rpc_calls: true,
+        }
+    }
+}
+
+/// Serialize a `Pubkey` as its base58 string. Jupiter expects strings, and
+/// `Pubkey`'s default serialization is a byte array.
+fn as_base58<S: serde::Serializer>(pubkey: &Pubkey, serializer: S) -> Result<S::Ok, S::Error> {
+    serializer.serialize_str(&pubkey.to_string())
+}
 
 /// The parts of the `/swap-instructions` response we need to build a [`Swap`].
 /// Amounts come from the `/quote` response.
@@ -42,7 +80,10 @@ impl SwapInstructionsResponse {
         let address_lookup_tables = self
             .address_lookup_table_addresses
             .iter()
-            .map(|address| Pubkey::from_str(address).map_err(|_| Error::BadResponse))
+            .map(|address| {
+                Pubkey::from_str(address)
+                    .map_err(|err| Error::BadResponse(format!("lookup table address: {err}")))
+            })
             .collect::<Result<_, _>>()?;
         Ok(Swap {
             in_amount,
@@ -63,7 +104,8 @@ struct JupInstruction {
 
 impl JupInstruction {
     fn into_instruction(self) -> Result<Instruction, Error> {
-        let program_id = Pubkey::from_str(&self.program_id).map_err(|_| Error::BadResponse)?;
+        let program_id = Pubkey::from_str(&self.program_id)
+            .map_err(|err| Error::BadResponse(format!("program id: {err}")))?;
         let accounts = self
             .accounts
             .into_iter()
@@ -71,7 +113,7 @@ impl JupInstruction {
             .collect::<Result<_, _>>()?;
         let data = BASE64_STANDARD
             .decode(&self.data)
-            .map_err(|_| Error::BadResponse)?;
+            .map_err(|err| Error::BadResponse(format!("instruction data: {err}")))?;
         Ok(Instruction {
             program_id,
             accounts,
@@ -91,7 +133,8 @@ struct JupAccount {
 impl JupAccount {
     fn into_meta(self) -> Result<AccountMeta, Error> {
         Ok(AccountMeta {
-            pubkey: Pubkey::from_str(&self.pubkey).map_err(|_| Error::BadResponse)?,
+            pubkey: Pubkey::from_str(&self.pubkey)
+                .map_err(|err| Error::BadResponse(format!("account pubkey: {err}")))?,
             is_signer: self.is_signer,
             is_writable: self.is_writable,
         })

--- a/crates/solana-solvers/src/dex/jupiter/dto.rs
+++ b/crates/solana-solvers/src/dex/jupiter/dto.rs
@@ -1,0 +1,99 @@
+//! DTO for Jupiter's `/swap-instructions` response, converted to Solana
+//! instructions. Field names follow Jupiter's camelCase JSON.
+
+use {
+    super::Error,
+    crate::dex::Swap,
+    base64::prelude::*,
+    serde::Deserialize,
+    solana_sdk::{
+        instruction::{AccountMeta, Instruction},
+        pubkey::Pubkey,
+    },
+    std::str::FromStr,
+};
+
+/// The parts of the `/swap-instructions` response we need to build a [`Swap`].
+/// Amounts come from the `/quote` response.
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SwapInstructionsResponse {
+    #[serde(default)]
+    setup_instructions: Vec<JupInstruction>,
+    swap_instruction: JupInstruction,
+    #[serde(default)]
+    cleanup_instruction: Option<JupInstruction>,
+    #[serde(default)]
+    address_lookup_table_addresses: Vec<String>,
+}
+
+impl SwapInstructionsResponse {
+    /// Flatten into execution order (setup, swap, cleanup) and resolve the
+    /// lookup-table addresses.
+    pub fn into_swap(self, in_amount: u64, out_amount: u64) -> Result<Swap, Error> {
+        let mut instructions = Vec::with_capacity(self.setup_instructions.len() + 2);
+        for instruction in self.setup_instructions {
+            instructions.push(instruction.into_instruction()?);
+        }
+        instructions.push(self.swap_instruction.into_instruction()?);
+        if let Some(instruction) = self.cleanup_instruction {
+            instructions.push(instruction.into_instruction()?);
+        }
+        let address_lookup_tables = self
+            .address_lookup_table_addresses
+            .iter()
+            .map(|address| Pubkey::from_str(address).map_err(|_| Error::BadResponse))
+            .collect::<Result<_, _>>()?;
+        Ok(Swap {
+            in_amount,
+            out_amount,
+            instructions,
+            address_lookup_tables,
+        })
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct JupInstruction {
+    program_id: String,
+    accounts: Vec<JupAccount>,
+    data: String,
+}
+
+impl JupInstruction {
+    fn into_instruction(self) -> Result<Instruction, Error> {
+        let program_id = Pubkey::from_str(&self.program_id).map_err(|_| Error::BadResponse)?;
+        let accounts = self
+            .accounts
+            .into_iter()
+            .map(JupAccount::into_meta)
+            .collect::<Result<_, _>>()?;
+        let data = BASE64_STANDARD
+            .decode(&self.data)
+            .map_err(|_| Error::BadResponse)?;
+        Ok(Instruction {
+            program_id,
+            accounts,
+            data,
+        })
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct JupAccount {
+    pubkey: String,
+    is_signer: bool,
+    is_writable: bool,
+}
+
+impl JupAccount {
+    fn into_meta(self) -> Result<AccountMeta, Error> {
+        Ok(AccountMeta {
+            pubkey: Pubkey::from_str(&self.pubkey).map_err(|_| Error::BadResponse)?,
+            is_signer: self.is_signer,
+            is_writable: self.is_writable,
+        })
+    }
+}

--- a/crates/solana-solvers/src/dex/jupiter/dto.rs
+++ b/crates/solana-solvers/src/dex/jupiter/dto.rs
@@ -14,8 +14,7 @@ use {
     std::str::FromStr,
 };
 
-/// Body of the `/swap-instructions` request. `Pubkey`'s default serialization
-/// is a byte array, so the pubkeys serialize via their base58 `Display`.
+/// Body of the `/swap-instructions` request.
 #[serde_as]
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/crates/solana-solvers/src/dex/jupiter/mod.rs
+++ b/crates/solana-solvers/src/dex/jupiter/mod.rs
@@ -192,26 +192,6 @@ mod tests {
         assert_eq!(value["skipUserAccountsRpcCalls"], true);
     }
 
-    #[test]
-    fn parses_swap_instructions() {
-        let json = serde_json::json!({
-            "setupInstructions": [],
-            "swapInstruction": {
-                "programId": WSOL,
-                "accounts": [{ "pubkey": USDC, "isSigner": false, "isWritable": true }],
-                "data": "AAEC"
-            },
-            "cleanupInstruction": null,
-            "addressLookupTableAddresses": [USDC, WSOL]
-        });
-        let response: dto::SwapInstructionsResponse = serde_json::from_value(json).unwrap();
-        let swap = response.into_swap(100, 250).unwrap();
-        assert_eq!(swap.instructions.len(), 1);
-        assert_eq!(swap.instructions[0].accounts.len(), 1);
-        assert_eq!(swap.address_lookup_tables.len(), 2);
-        assert_eq!((swap.in_amount, swap.out_amount), (100, 250));
-    }
-
     /// Live Jupiter API. Needs network. Keyless works, set `JUPITER_API_KEY`
     /// for headroom.
     #[tokio::test]

--- a/crates/solana-solvers/src/dex/jupiter/mod.rs
+++ b/crates/solana-solvers/src/dex/jupiter/mod.rs
@@ -1,0 +1,219 @@
+//! Jupiter swap-API adapter.
+//!
+//! v1 `/quote` + `/swap-instructions` (ExactIn). Triton is a base-URL and key
+//! swap behind the same adapter.
+
+mod dto;
+
+use {
+    super::{Order, Side, Swap},
+    crate::config::JupiterConfig,
+    solana_sdk::pubkey::Pubkey,
+};
+
+const QUOTE_PATH: &str = "swap/v1/quote";
+const SWAP_INSTRUCTIONS_PATH: &str = "swap/v1/swap-instructions";
+
+/// Adapter over the Jupiter swap API.
+pub struct Jupiter {
+    client: reqwest::Client,
+    endpoint: reqwest::Url,
+    api_key: Option<String>,
+    slippage_bps: u16,
+}
+
+impl Jupiter {
+    pub fn new(config: &JupiterConfig) -> Result<Self, Error> {
+        Ok(Self {
+            client: reqwest::Client::builder().build()?,
+            endpoint: config.endpoint.clone(),
+            api_key: config.api_key.clone(),
+            slippage_bps: config.slippage_bps,
+        })
+    }
+
+    /// Quote `order` for the settlement signer `taker` and return the swap to
+    /// run inside the settlement transaction.
+    pub async fn swap(&self, order: &Order, taker: &Pubkey) -> Result<Swap, Error> {
+        // Buy orders (ExactOut) aren't served here.
+        if order.side == Side::Buy {
+            return Err(Error::OrderNotSupported);
+        }
+        let quote = self.quote(order, "ExactIn").await?;
+        let in_amount = amount_field(&quote, "inAmount")?;
+        let out_amount = amount_field(&quote, "outAmount")?;
+        self.swap_instructions(&quote, taker, &order.buy_destination)
+            .await?
+            .into_swap(in_amount, out_amount)
+    }
+
+    /// `GET /swap/v1/quote`. Kept opaque and passed back verbatim to
+    /// `/swap-instructions`, we only read the amounts.
+    async fn quote(&self, order: &Order, swap_mode: &str) -> Result<serde_json::Value, Error> {
+        let mut url = self
+            .endpoint
+            .join(QUOTE_PATH)
+            .map_err(|_| Error::RequestBuildFailed)?;
+        url.query_pairs_mut()
+            .append_pair("inputMint", &order.sell_mint.to_string())
+            .append_pair("outputMint", &order.buy_mint.to_string())
+            .append_pair("amount", &order.amount.to_string())
+            .append_pair("swapMode", swap_mode)
+            .append_pair("slippageBps", &self.slippage_bps.to_string());
+        self.send(self.with_key(self.client.get(url))).await
+    }
+
+    /// `POST /swap/v1/swap-instructions` for the given quote.
+    async fn swap_instructions(
+        &self,
+        quote: &serde_json::Value,
+        taker: &Pubkey,
+        destination: &Pubkey,
+    ) -> Result<dto::SwapInstructionsResponse, Error> {
+        let url = self
+            .endpoint
+            .join(SWAP_INSTRUCTIONS_PATH)
+            .map_err(|_| Error::RequestBuildFailed)?;
+        let body = serde_json::json!({
+            "quoteResponse": quote,
+            "userPublicKey": taker.to_string(),
+            // Send the swap output to the order's destination account.
+            "destinationTokenAccount": destination.to_string(),
+            // SOL wrapping is handled outside the swap.
+            "wrapAndUnwrapSol": false,
+            "skipUserAccountsRpcCalls": true,
+        });
+        let body = serde_json::to_string(&body).map_err(|_| Error::RequestBuildFailed)?;
+        let request = self.with_key(
+            self.client
+                .post(url)
+                .header("content-type", "application/json")
+                .body(body),
+        );
+        self.send(request).await
+    }
+
+    fn with_key(&self, request: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        match &self.api_key {
+            Some(key) => request.header("x-api-key", key),
+            None => request,
+        }
+    }
+
+    async fn send<T: serde::de::DeserializeOwned>(
+        &self,
+        request: reqwest::RequestBuilder,
+    ) -> Result<T, Error> {
+        let response = request.send().await?;
+        let status = response.status();
+        let body = response.text().await?;
+        if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            return Err(Error::RateLimited);
+        }
+        // Jupiter answers an unroutable pair with a 4xx error body, not an empty
+        // 200, so any non-success is "no swap for this order".
+        if !status.is_success() {
+            return Err(Error::NotFound);
+        }
+        serde_json::from_str(&body).map_err(|_| Error::BadResponse)
+    }
+}
+
+fn amount_field(quote: &serde_json::Value, field: &str) -> Result<u64, Error> {
+    quote
+        .get(field)
+        .and_then(serde_json::Value::as_str)
+        .and_then(|amount| amount.parse().ok())
+        .ok_or(Error::BadResponse)
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("failed to build the request")]
+    RequestBuildFailed,
+    #[error("no route for this order")]
+    NotFound,
+    #[error("order type is not supported")]
+    OrderNotSupported,
+    #[error("rate limited")]
+    RateLimited,
+    #[error("malformed response from the swap API")]
+    BadResponse,
+    #[error(transparent)]
+    Http(#[from] reqwest::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::*, std::str::FromStr};
+
+    // USDC and wrapped SOL mints.
+    const USDC: &str = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+    const WSOL: &str = "So11111111111111111111111111111111111111112";
+
+    fn config() -> JupiterConfig {
+        JupiterConfig {
+            endpoint: "https://api.jup.ag".parse().unwrap(),
+            api_key: std::env::var("JUPITER_API_KEY").ok(),
+            slippage_bps: 50,
+        }
+    }
+
+    fn sell_order() -> Order {
+        Order {
+            sell_mint: Pubkey::from_str(USDC).unwrap(),
+            buy_mint: Pubkey::from_str(WSOL).unwrap(),
+            buy_destination: Pubkey::from_str(WSOL).unwrap(),
+            amount: 1_000_000,
+            side: Side::Sell,
+        }
+    }
+
+    #[tokio::test]
+    async fn buy_unsupported() {
+        let jupiter = Jupiter::new(&config()).unwrap();
+        let order = Order {
+            side: Side::Buy,
+            ..sell_order()
+        };
+        let result = jupiter.swap(&order, &Pubkey::new_unique()).await;
+        assert!(matches!(result, Err(Error::OrderNotSupported)));
+    }
+
+    #[test]
+    fn parses_swap_instructions() {
+        let json = serde_json::json!({
+            "setupInstructions": [],
+            "swapInstruction": {
+                "programId": WSOL,
+                "accounts": [{ "pubkey": USDC, "isSigner": false, "isWritable": true }],
+                "data": "AAEC"
+            },
+            "cleanupInstruction": null,
+            "addressLookupTableAddresses": [USDC, WSOL]
+        });
+        let response: dto::SwapInstructionsResponse = serde_json::from_value(json).unwrap();
+        let swap = response.into_swap(100, 250).unwrap();
+        assert_eq!(swap.instructions.len(), 1);
+        assert_eq!(swap.instructions[0].accounts.len(), 1);
+        assert_eq!(swap.address_lookup_tables.len(), 2);
+        assert_eq!((swap.in_amount, swap.out_amount), (100, 250));
+    }
+
+    /// Live Jupiter API. Needs network. Keyless works, set `JUPITER_API_KEY`
+    /// for headroom.
+    #[tokio::test]
+    #[ignore]
+    async fn jupiter_live_sell() {
+        let jupiter = Jupiter::new(&config()).unwrap();
+        // Any valid pubkey works for building instructions, the swap only runs
+        // for real once the driver supplies its settlement signer.
+        let swap = jupiter
+            .swap(&sell_order(), &Pubkey::from_str(WSOL).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(swap.in_amount, 1_000_000);
+        assert!(swap.out_amount > 0);
+        assert!(!swap.instructions.is_empty());
+    }
+}

--- a/crates/solana-solvers/src/dex/jupiter/mod.rs
+++ b/crates/solana-solvers/src/dex/jupiter/mod.rs
@@ -179,19 +179,6 @@ mod tests {
         assert!(matches!(result, Err(Error::OrderNotSupported)));
     }
 
-    #[test]
-    fn request_serializes_pubkeys_as_base58() {
-        let quote = serde_json::json!({});
-        let taker = Pubkey::from_str(WSOL).unwrap();
-        let destination = Pubkey::from_str(USDC).unwrap();
-        let payload = dto::SwapInstructionsRequest::new(&quote, &taker, &destination);
-        let value = serde_json::to_value(payload).unwrap();
-        assert_eq!(value["userPublicKey"], WSOL);
-        assert_eq!(value["destinationTokenAccount"], USDC);
-        assert_eq!(value["wrapAndUnwrapSol"], false);
-        assert_eq!(value["skipUserAccountsRpcCalls"], true);
-    }
-
     /// Live Jupiter API. Needs network. Keyless works, set `JUPITER_API_KEY`
     /// for headroom.
     #[tokio::test]

--- a/crates/solana-solvers/src/dex/jupiter/mod.rs
+++ b/crates/solana-solvers/src/dex/jupiter/mod.rs
@@ -74,16 +74,8 @@ impl Jupiter {
             .endpoint
             .join(SWAP_INSTRUCTIONS_PATH)
             .map_err(|_| Error::RequestBuildFailed)?;
-        let body = serde_json::json!({
-            "quoteResponse": quote,
-            "userPublicKey": taker.to_string(),
-            // Send the swap output to the order's destination account.
-            "destinationTokenAccount": destination.to_string(),
-            // SOL wrapping is handled outside the swap.
-            "wrapAndUnwrapSol": false,
-            "skipUserAccountsRpcCalls": true,
-        });
-        let body = serde_json::to_string(&body).map_err(|_| Error::RequestBuildFailed)?;
+        let payload = dto::SwapInstructionsRequest::new(quote, taker, destination);
+        let body = serde_json::to_string(&payload).map_err(|_| Error::RequestBuildFailed)?;
         let request = self.with_key(
             self.client
                 .post(url)
@@ -107,15 +99,20 @@ impl Jupiter {
         let response = request.send().await?;
         let status = response.status();
         let body = response.text().await?;
-        if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
-            return Err(Error::RateLimited);
+        if status.is_success() {
+            return serde_json::from_str(&body)
+                .map_err(|err| Error::BadResponse(format!("response body: {err}")));
         }
-        // Jupiter answers an unroutable pair with a 4xx error body, not an empty
-        // 200, so any non-success is "no swap for this order".
-        if !status.is_success() {
-            return Err(Error::NotFound);
+        match status {
+            reqwest::StatusCode::TOO_MANY_REQUESTS => Err(Error::RateLimited),
+            // Jupiter returns 400 with an error body when it can't route the order.
+            reqwest::StatusCode::BAD_REQUEST => Err(Error::NotFound),
+            // Auth or server errors: carry the status and body so the cause shows.
+            _ => Err(Error::Api {
+                status: status.as_u16(),
+                body,
+            }),
         }
-        serde_json::from_str(&body).map_err(|_| Error::BadResponse)
     }
 }
 
@@ -124,7 +121,7 @@ fn amount_field(quote: &serde_json::Value, field: &str) -> Result<u64, Error> {
         .get(field)
         .and_then(serde_json::Value::as_str)
         .and_then(|amount| amount.parse().ok())
-        .ok_or(Error::BadResponse)
+        .ok_or_else(|| Error::BadResponse(format!("missing or non-numeric {field}")))
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -137,8 +134,10 @@ pub enum Error {
     OrderNotSupported,
     #[error("rate limited")]
     RateLimited,
-    #[error("malformed response from the swap API")]
-    BadResponse,
+    #[error("jupiter api error {status}: {body}")]
+    Api { status: u16, body: String },
+    #[error("malformed swap response: {0}")]
+    BadResponse(String),
     #[error(transparent)]
     Http(#[from] reqwest::Error),
 }
@@ -178,6 +177,19 @@ mod tests {
         };
         let result = jupiter.swap(&order, &Pubkey::new_unique()).await;
         assert!(matches!(result, Err(Error::OrderNotSupported)));
+    }
+
+    #[test]
+    fn request_serializes_pubkeys_as_base58() {
+        let quote = serde_json::json!({});
+        let taker = Pubkey::from_str(WSOL).unwrap();
+        let destination = Pubkey::from_str(USDC).unwrap();
+        let payload = dto::SwapInstructionsRequest::new(&quote, &taker, &destination);
+        let value = serde_json::to_value(payload).unwrap();
+        assert_eq!(value["userPublicKey"], WSOL);
+        assert_eq!(value["destinationTokenAccount"], USDC);
+        assert_eq!(value["wrapAndUnwrapSol"], false);
+        assert_eq!(value["skipUserAccountsRpcCalls"], true);
     }
 
     #[test]

--- a/crates/solana-solvers/src/dex/mod.rs
+++ b/crates/solana-solvers/src/dex/mod.rs
@@ -1,0 +1,53 @@
+//! DEX-adapter boundary: quote one order into an executable swap.
+//!
+//! `Dex` dispatches to the configured engine.
+
+pub mod jupiter;
+
+use solana_sdk::{instruction::Instruction, pubkey::Pubkey};
+
+/// A single order to quote, distilled from the auction.
+#[derive(Debug, Clone)]
+pub struct Order {
+    pub sell_mint: Pubkey,
+    pub buy_mint: Pubkey,
+    /// Where the swap sends its output: the settlement's buy-mint buffer,
+    /// resolved upstream (driver or autopilot). Passed to Jupiter as
+    /// `destinationTokenAccount`. `FinalizeSettle` then pushes to the user.
+    pub buy_destination: Pubkey,
+    /// Sell amount for a `Sell`, buy amount for a `Buy`.
+    pub amount: u64,
+    pub side: Side,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Side {
+    Buy,
+    Sell,
+}
+
+/// A quoted swap: the executed amounts plus the instructions that perform it,
+/// in execution order (setup, swap, cleanup). The address lookup tables travel
+/// alongside so the driver can build the v0 transaction the instructions
+/// assume.
+#[derive(Debug, Clone)]
+pub struct Swap {
+    pub in_amount: u64,
+    pub out_amount: u64,
+    pub instructions: Vec<Instruction>,
+    pub address_lookup_tables: Vec<Pubkey>,
+}
+
+/// The configured DEX backend.
+pub enum Dex {
+    Jupiter(jupiter::Jupiter),
+}
+
+impl Dex {
+    /// Quote `order` for settlement signer `user`.
+    pub async fn swap(&self, order: &Order, user: &Pubkey) -> Result<Swap, jupiter::Error> {
+        match self {
+            Dex::Jupiter(jupiter) => jupiter.swap(order, user).await,
+        }
+    }
+}

--- a/crates/solana-solvers/src/lib.rs
+++ b/crates/solana-solvers/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod api;
 mod cli;
 pub mod config;
+pub mod dex;
 mod run;
 
 pub use run::start;


### PR DESCRIPTION
# Description
Second PR of the Jupiter solver. Adds the adapter that turns one order into an executable Solana swap by calling Jupiter's v1 swap API, so later PRs can assemble solutions and run the solve loop. The solver holds no liquidity: for each order it asks Jupiter for a swap and returns the instructions. Builds on PR1. `/solve` stays a scaffold until PR3/4 wire the adapter in.

# Changes
- New `dex` module with Solana-native `Order`, `Side`, and `Swap` types (u64 amounts, `Pubkey` mints, instructions).
- Jupiter adapter chaining `GET /swap/v1/quote?swapMode=ExactIn` then `POST /swap/v1/swap-instructions`, returning amounts, instructions (setup, swap, cleanup), and the lookup-table addresses the driver needs for the v0 transaction.
- Sells only. Buy orders return `OrderNotSupported`, buys land in PR2.2.
- Swap output goes to the settlement's buy-mint buffer (`destinationTokenAccount`), resolved upstream and passed in. `FinalizeSettle` pushes it to the user.
- Provider boundary: `api.jup.ag`, or a Triton-hosted endpoint (same v1 API), a config base-URL and key swap.
- Adds `reqwest`, `solana-sdk`, `base64`, `thiserror`.

# How to test
New unit tests (buy rejection, response parsing). Also an `#[ignore]` live sell test: `cargo test -p solana-solvers -- --ignored jupiter_live` (keyless works, `JUPITER_API_KEY` optional).

# Notes
- Stacked on PR1 (`solana-solvers/PR1-skeleton`), review that first.
- `taker` is the driver's settlement signer, supplied at solve time in PR4.
- We use v1, not the newer `/swap/v2/build`, so a Triton-hosted endpoint stays a drop-in failover. Triton runs v1/Metis only.
- Part of the Jupiter solver plan (specs PR cowprotocol/solana-services-specifications#33).
