### PR TITLE
Disable automated-trades dispatch on deploy

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -151,15 +151,17 @@ jobs:
           token: ${{ secrets.AUTODEPLOY_TOKEN }}
           timeout: 600000 # 10 minutes
 
+      # Temporarily disabled while the automated-trades deploy setup is reworked
+      # (cowprotocol/automated-trade#36). Re-enable once the new job is in place.
       # After the new version is rolled out to the k8s cluster, ask the
       # infrastructure repo to run an automated test trade on every network
       # to verify the deployment end-to-end.
-      - name: "📣 Dispatch automated trades to infrastructure repo"
-        if: ${{ github.ref == 'refs/heads/main' }}
-        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
-        with:
-          token: ${{ secrets.WORKFLOW_DISPATCH_TOKEN }}
-          repository: cowprotocol/infrastructure
-          event-type: run-automated-trades
-          client-payload: |-
-            {"ref":"${{ github.ref }}","sha":"${{ github.sha }}","source":"services-deploy"}
+      # - name: "📣 Dispatch automated trades to infrastructure repo"
+      #   if: ${{ github.ref == 'refs/heads/main' }}
+      #   uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
+      #   with:
+      #     token: ${{ secrets.WORKFLOW_DISPATCH_TOKEN }}
+      #     repository: cowprotocol/infrastructure
+      #     event-type: run-automated-trades
+      #     client-payload: |-
+      #       {"ref":"${{ github.ref }}","sha":"${{ github.sha }}","source":"services-deploy"}


### PR DESCRIPTION
# Description
Comment out the `run-automated-trades` `repository-dispatch` step in the `deploy` workflow, which fires on every push to `main` and asks infra repo to run automated test trades on all chains.

Unblocks merging `cowprotocol/automated-trade#36`

# Changes
* Comment out the "Dispatch automated trades to infrastructure repo" step in `.github/workflows/deploy.yaml`