### PR TITLE
Fix 4626 classification

### DIFF
--- a/crates/e2e/tests/e2e/eip4626.rs
+++ b/crates/e2e/tests/e2e/eip4626.rs
@@ -46,6 +46,10 @@ const USDC: Address = address!("A0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
 /// `6-decimal vault wrapping 18-decimal asset` direction.
 const DAI: Address = address!("6B175474E89094C44Da98b954EedeAC495271d0F");
 
+/// wmtUSDC on mainnet — a partial EIP-4626 implementation that exposes
+/// `asset()` but reverts on `convertToAssets()`. Must classify as non-vault.
+const WMT_USDC: Address = address!("C9499006a149C553d18171747ED19Aa7C6Dd19E2");
+
 #[tokio::test]
 #[ignore]
 async fn forked_node_mainnet_eip4626_native_price() {
@@ -401,6 +405,29 @@ async fn eip4626_empty_revert_terminal_token_test(web3: Web3) {
             .expect("empty-revert on terminal token must not abort the unwrap");
         assert_eq!(price, expected_price);
     }
+}
+
+#[tokio::test]
+#[ignore]
+async fn forked_node_mainnet_eip4626_partial_vault_terminal_token() {
+    run_forked_test(
+        eip4626_partial_vault_terminal_token_test,
+        std::env::var("FORK_URL_MAINNET")
+            .expect("FORK_URL_MAINNET must be set to run forked tests"),
+    )
+    .await;
+}
+
+async fn eip4626_partial_vault_terminal_token_test(web3: Web3) {
+    let expected_price = 0.0001;
+    let inner = FixedPrice(expected_price);
+    let estimator = Eip4626::new(Box::new(inner), web3.provider);
+
+    let price = estimator
+        .estimate_native_price(WMT_USDC, HEALTHY_PRICE_ESTIMATION_TIME)
+        .await
+        .expect("token missing convertToAssets() must classify as non-vault, not abort");
+    assert_eq!(price, expected_price);
 }
 
 struct FixedPrice(f64);

--- a/crates/price-estimation/src/native/eip4626.rs
+++ b/crates/price-estimation/src/native/eip4626.rs
@@ -53,13 +53,15 @@ use {
 /// - per-atom factor: `1_100_000 / 10^18 == 1.1e-12`
 /// - if USDC's native price is `x`, then ynUSDx's is `x * 1.1e-12`
 ///
-/// Tokens whose `asset()` call reverts are remembered in a negative cache so
+/// Tokens that don't classify as usable vaults — `asset()` reverts, or it
+/// succeeds but a method the pricing relies on (`decimals()`,
+/// `convertToAssets()`) reverts — are remembered in a negative cache so
 /// subsequent requests skip the RPC and go straight to the inner estimator.
 pub struct Eip4626 {
     inner: Box<dyn NativePriceEstimating>,
     provider: AlloyProvider,
-    /// Addresses that are known *not* to be EIP-4626 vaults (i.e. `asset()`
-    /// reverted). Checked before making any RPC calls.
+    /// Addresses that are known *not* to be (usable) EIP-4626 vaults. Checked
+    /// before making any RPC calls.
     non_vault_tokens: DashSet<Address>,
 }
 
@@ -126,17 +128,31 @@ impl Eip4626 {
         }
 
         let Some((asset, vault_decimals)) = self.fetch_vault_info(token).await? else {
-            self.non_vault_tokens.insert(token);
-            metrics::non_vault_cache_size(self.non_vault_tokens.len());
+            self.mark_non_vault(token);
             tracing::debug!(%token, "eip4626: classified as non-vault");
             return Ok(None);
         };
-        let assets = self.fetch_conversion_data(token, vault_decimals).await?;
+
+        //  Some tokens expose `asset()` yet revert here (e.g. a partial EIP-4626
+        // implementation). Treat those as plain ERC-20s.
+        let Some(assets) = self.fetch_conversion_data(token, vault_decimals).await? else {
+            self.mark_non_vault(token);
+            tracing::debug!(%token, "eip4626: convertToAssets() reverts, classified as non-vault");
+            return Ok(None);
+        };
+
         let rate = conversion_rate(assets, vault_decimals)
             .context("conversion rate is not representable as f64")
             .map_err(PriceEstimationError::EstimatorInternal)?;
         tracing::debug!(%token, %asset, rate, "eip4626: unwrapped vault layer");
         Ok(Some((asset, rate)))
+    }
+
+    /// Records `token` in the negative cache so subsequent requests skip the
+    /// RPC probing and delegate straight to the inner estimator.
+    fn mark_non_vault(&self, token: Address) {
+        self.non_vault_tokens.insert(token);
+        metrics::non_vault_cache_size(self.non_vault_tokens.len());
     }
 
     /// Fetches the vault's underlying asset address and vault token decimals.
@@ -178,11 +194,18 @@ impl Eip4626 {
 
     /// Fetches `convertToAssets(10^vault_decimals)` — how many atomic units of
     /// the underlying asset correspond to one full vault token.
+    ///
+    /// Returns:
+    /// - `Ok(Some(assets))` on success.
+    /// - `Ok(None)` when `convertToAssets()` reverts. The caller must not treat
+    ///   it as a vault.
+    /// - `Err` on transient transport failures, so they retry instead of
+    ///   pinning the token as non-vault.
     async fn fetch_conversion_data(
         &self,
         token: Address,
         vault_decimals: u8,
-    ) -> Result<U256, PriceEstimationError> {
+    ) -> Result<Option<U256>, PriceEstimationError> {
         let one_token = U256::from(10u64)
             .checked_pow(U256::from(vault_decimals))
             .ok_or_else(|| {
@@ -192,15 +215,13 @@ impl Eip4626 {
             })?;
 
         let vault = IERC4626::IERC4626::new(token, &self.provider);
-        vault
-            .convertToAssets(one_token)
-            .call()
-            .await
-            .map_err(|err| {
-                PriceEstimationError::EstimatorInternal(anyhow::anyhow!(
-                    "failed to call convertToAssets() on {token}: {err}"
-                ))
-            })
+        match vault.convertToAssets(one_token).call().await {
+            Ok(assets) => Ok(Some(assets)),
+            Err(err) if err.is_contract_revert() => Ok(None),
+            Err(err) => Err(PriceEstimationError::EstimatorInternal(anyhow::anyhow!(
+                "failed to call convertToAssets() on {token}: {err}"
+            ))),
+        }
     }
 }
 
@@ -256,7 +277,7 @@ mod tests {
     use {
         super::*,
         crate::{HEALTHY_PRICE_ESTIMATION_TIME, native::MockNativePriceEstimating},
-        alloy::providers::mock::Asserter,
+        alloy::{providers::mock::Asserter, sol_types::SolCall},
         std::borrow::Cow,
     };
 
@@ -373,5 +394,35 @@ mod tests {
             .estimate(token, HEALTHY_PRICE_ESTIMATION_TIME)
             .await;
         assert_eq!(result.unwrap(), expected_price);
+    }
+
+    #[tokio::test]
+    async fn reverting_convert_to_assets_is_treated_as_non_vault() {
+        let token = Address::repeat_byte(0x11);
+        let underlying = Address::repeat_byte(0x22);
+        let expected_price = 1.5;
+
+        let mut inner = MockNativePriceEstimating::new();
+        inner
+            .expect_estimate_native_price()
+            .withf(move |t, _| *t == token)
+            .returning(move |_, _| Box::pin(async move { Ok(expected_price) }));
+
+        let asserter = Asserter::new();
+        asserter.push_success(&IERC4626::IERC4626::assetCall::abi_encode_returns(
+            &underlying,
+        ));
+        asserter.push_success(&ERC20::ERC20::decimalsCall::abi_encode_returns(&6u8));
+        asserter.push_failure_msg("execution reverted");
+        let web3 = ethrpc::Web3::with_asserter(asserter);
+
+        let estimator = Eip4626::new(Box::new(inner), web3.provider);
+
+        let result = estimator
+            .estimate(token, HEALTHY_PRICE_ESTIMATION_TIME)
+            .await;
+        assert_eq!(result.unwrap(), expected_price);
+        // The failed classification is cached so we don't re-probe on-chain.
+        assert!(estimator.non_vault_tokens.contains(&token));
     }
 }

--- a/crates/price-estimation/src/native/eip4626.rs
+++ b/crates/price-estimation/src/native/eip4626.rs
@@ -53,10 +53,9 @@ use {
 /// - per-atom factor: `1_100_000 / 10^18 == 1.1e-12`
 /// - if USDC's native price is `x`, then ynUSDx's is `x * 1.1e-12`
 ///
-/// Tokens that don't classify as usable vaults — `asset()` reverts, or it
-/// succeeds but a method the pricing relies on (`decimals()`,
-/// `convertToAssets()`) reverts — are remembered in a negative cache so
-/// subsequent requests skip the RPC and go straight to the inner estimator.
+/// Tokens that don't classify as usable vaults are remembered in a negative
+/// cache so subsequent requests skip the RPC and go straight to the inner
+/// estimator.
 pub struct Eip4626 {
     inner: Box<dyn NativePriceEstimating>,
     provider: AlloyProvider,
@@ -133,7 +132,7 @@ impl Eip4626 {
             return Ok(None);
         };
 
-        //  Some tokens expose `asset()` yet revert here (e.g. a partial EIP-4626
+        // Some tokens expose `asset()` yet revert here (e.g. a partial EIP-4626
         // implementation). Treat those as plain ERC-20s.
         let Some(assets) = self.fetch_conversion_data(token, vault_decimals).await? else {
             self.mark_non_vault(token);


### PR DESCRIPTION
# Description
Wintermute is looking to enable quotes for their Wildcat issued wmtUSDx tokens (e.g. [wmtUSDC](https://etherscan.io/token/0xc9499006a149c553d18171747ed19aa7c6dd19e2)). Currently those tokens fail quoting because we cannot find a native price. The reason for this is that the token looks like an [ERC-4626](https://eips.ethereum.org/EIPS/eip-4626) vault token (ie. it implements `assets()`) but doesn't follow the standard (ie it doesn't implement `convertToAssets()`).

In our current logic failure to convert gets bubbled up directly as an estimation error (without attempting the standard ERC20 estimator path)

# Changes
* Treat tokens for which conversion fails like non 4626 assets (fallback to ERC20 estimators)
* Also cache failure to convert so we don't probe the same token over and over again

## How to test
Added unit test