### PR TITLE
Replace solver ID with address in the order status endpoint

### DIFF
--- a/crates/e2e/tests/e2e/partial_fill.rs
+++ b/crates/e2e/tests/e2e/partial_fill.rs
@@ -123,6 +123,6 @@ async fn test(web3: Web3) {
         panic!("last status of order was not traded");
     };
     assert_eq!(solutions.len(), 1);
-    assert_eq!(solutions[0].solver, "test_solver");
+    assert_eq!(solutions[0].solver, solver.address());
     assert!(solutions[0].executed_amounts.is_some());
 }

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -1663,7 +1663,7 @@ components:
             properties:
               solver:
                 type: string
-                description: Name of the solver.
+                description: The on-chain address of the solver.
               executedAmounts:
                 $ref: "#/components/schemas/ExecutedAmounts"
             required:

--- a/crates/orderbook/src/dto/order.rs
+++ b/crates/orderbook/src/dto/order.rs
@@ -90,7 +90,7 @@ pub struct ExecutedAmounts {
 #[serde(rename_all = "camelCase")]
 pub struct SolutionInclusion {
     /// The name or identifier of the solver.
-    pub solver: String,
+    pub solver: Address,
     /// The executed amounts for the order as proposed by the solver, included
     /// if the solution was for the desired order, or omitted otherwise.
     pub executed_amounts: Option<ExecutedAmounts>,

--- a/crates/orderbook/src/orderbook.rs
+++ b/crates/orderbook/src/orderbook.rs
@@ -553,7 +553,7 @@ impl Orderbook {
                         }),
                     });
                     dto::order::SolutionInclusion {
-                        solver: solution.solver,
+                        solver: solution.solver_address,
                         executed_amounts,
                     }
                 })


### PR DESCRIPTION
# Description
Replaces the solver ID with the respective solver address.

This enables removing the `solver_competitions` table and its respective `INSERT`s and friends.

This is a *slightly* breaking change as one can argue that the solver's address is also a solver ID.
We don't expect this to break external consumers as this API was for CowSwap's frontend usage specifically.

There's no way to meaningfully get "who's using it" because this is called directly from the frontend, so as long as it can handle the new address, we're good.

# Changes

* Replaces the solver-id in the status endpoint with the solver's address

## How to test
Tested using the FE, which uses this endpoint to resolve the solver — see https://github.com/cowprotocol/cowswap/pull/7871