### PR TITLE
Quote stream/only emit better results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7536,6 +7536,7 @@ dependencies = [
  "anyhow",
  "app-data",
  "arc-swap",
+ "async-stream",
  "async-trait",
  "bad-tokens",
  "balance-overrides",

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -536,22 +536,21 @@ paths:
         Accepts the same request body as `POST /api/v1/quote`. Instead of
         waiting for all solvers and returning the single best quote, this
         endpoint opens a Server-Sent Events stream and emits quotes as solvers
-        respond. A quote is emitted only when it improves on the best one
-        already sent, so the series improves monotonically and never regresses;
-        the first quote goes out as soon as the fastest solver answers. Solvers
-        without a usable quote, and quotes that do not beat the best already
-        sent, emit no event, so you may receive fewer events than there are
-        solvers. The stream closes when the quote timeout elapses or all solvers
-        have responded. Each emitted quote carries an `id` that can be
-        referenced when placing an order. Clients can use this to show
-        progressive quote updates in real time.
+        respond. A quote is emitted only when it ranks better than the best one
+        already sent; the first goes out as soon as the fastest solver answers.
+        Solvers without a usable quote, and quotes that do not beat the best
+        already sent, emit no event, so you may receive fewer events than there
+        are solvers. The stream closes when the quote timeout elapses or all
+        solvers have responded. Each emitted quote carries an `id` that can be
+        referenced when placing an order.
 
         The `priceQuality` field of the request body is ignored: this endpoint
         always queries all solvers and attempts verification, and each emitted
-        quote carries its own `verified` flag. Individual solver errors are not
-        streamed; if no solver returns a usable quote, a terminal event named
-        `error` is sent with a `PriceEstimationError` body before the stream
-        closes.
+        quote carries its own `verified` flag. A verified quote ranks above an
+        unverified one regardless of amount, so a later quote may report a lower
+        `out_amount`. Individual solver errors are not streamed; if no solver
+        returns a usable quote, a terminal event named `error` is sent with a
+        `PriceEstimationError` body before the stream closes.
       requestBody:
         description: The order parameters to compute quotes for.
         required: true
@@ -563,8 +562,8 @@ paths:
         "200":
           description: >
             A Server-Sent Events stream. Each event's `data` field is a JSON
-            object matching `OrderQuoteResponse`. Events arrive as the best
-            quote improves.
+            object matching `OrderQuoteResponse`. Events arrive as the
+            best-ranked quote improves.
           content:
             text/event-stream:
               schema:

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -531,22 +531,27 @@ paths:
   /api/v1/quote/stream:
     post:
       operationId: quoteStream
-      summary: Stream quotes from individual solvers as they arrive.
+      summary: Stream progressively improving quotes as solvers respond.
       description: >
         Accepts the same request body as `POST /api/v1/quote`. Instead of
         waiting for all solvers and returning the single best quote, this
-        endpoint opens a Server-Sent Events stream and emits one event per quote
-        as solvers respond. Solvers without a usable quote emit no event, so you
-        may receive fewer events than there are solvers. The stream closes when
-        the quote timeout elapses or all solvers have responded. Each emitted
-        quote carries an `id` that can be referenced when placing an order.
-        Clients can use this to show progressive quote updates in real time.
+        endpoint opens a Server-Sent Events stream and emits quotes as solvers
+        respond. A quote is emitted only when it improves on the best one
+        already sent, so the series improves monotonically and never regresses;
+        the first quote goes out as soon as the fastest solver answers. Solvers
+        without a usable quote, and quotes that do not beat the best already
+        sent, emit no event, so you may receive fewer events than there are
+        solvers. The stream closes when the quote timeout elapses or all solvers
+        have responded. Each emitted quote carries an `id` that can be
+        referenced when placing an order. Clients can use this to show
+        progressive quote updates in real time.
 
         The `priceQuality` field of the request body is ignored: this endpoint
-        always queries all solvers and attempts verification, emitting each
-        result with its own `verified` flag. If no solver returns a usable
-        quote, a terminal event named `error` is sent with a
-        `PriceEstimationError` body before the stream closes.
+        always queries all solvers and attempts verification, and each emitted
+        quote carries its own `verified` flag. Individual solver errors are not
+        streamed; if no solver returns a usable quote, a terminal event named
+        `error` is sent with a `PriceEstimationError` body before the stream
+        closes.
       requestBody:
         description: The order parameters to compute quotes for.
         required: true
@@ -558,8 +563,8 @@ paths:
         "200":
           description: >
             A Server-Sent Events stream. Each event's `data` field is a JSON
-            object matching `OrderQuoteResponse`. Events arrive one per quote
-            as solvers respond.
+            object matching `OrderQuoteResponse`. Events arrive as the best
+            quote improves.
           content:
             text/event-stream:
               schema:

--- a/crates/orderbook/src/quoter.rs
+++ b/crates/orderbook/src/quoter.rs
@@ -192,10 +192,10 @@ impl QuoteHandler {
             while let Some(item) = inner.next().await {
                 let quote = match item {
                     Ok(quote) => quote,
-                    // Per-solver failure: skip it, a later solver may still succeed.
+                    // The inner stream now yields terminal errors.
                     Err(err) => {
-                        tracing::debug!(%err, "dropping failed streamed quote");
-                        continue;
+                        yield Err(OrderQuoteError::CalculateQuote(err));
+                        return;
                     }
                 };
                 let response = get_vol_fee_adjusted_quote_data(

--- a/crates/orderbook/src/quoter.rs
+++ b/crates/orderbook/src/quoter.rs
@@ -192,7 +192,7 @@ impl QuoteHandler {
             while let Some(item) = inner.next().await {
                 let quote = match item {
                     Ok(quote) => quote,
-                    // The inner stream now yields terminal errors.
+                    // The inner stream only yields terminal errors.
                     Err(err) => {
                         yield Err(OrderQuoteError::CalculateQuote(err));
                         return;

--- a/crates/price-estimation/Cargo.toml
+++ b/crates/price-estimation/Cargo.toml
@@ -10,6 +10,7 @@ alloy = { workspace = true, features = ["providers", "rpc", "rpc-types", "sol-ty
 anyhow = { workspace = true }
 app-data = { workspace = true }
 arc-swap = { workspace = true }
+async-stream = { workspace = true }
 async-trait = { workspace = true }
 bad-tokens = { workspace = true }
 balance-overrides = { workspace = true }

--- a/crates/price-estimation/src/competition/mod.rs
+++ b/crates/price-estimation/src/competition/mod.rs
@@ -751,19 +751,23 @@ mod tests {
         assert!(matches!(results[0], Err(PriceEstimationError::RateLimited)));
     }
 
-    /// Best-so-far: a result is forwarded only when it beats every quote
-    /// already sent, so the client sees a monotonically improving series. A
-    /// later, worse quote is dropped rather than emitted.
+    /// Best-so-far under `QuoteVerificationMode::Prefer`: a quote is forwarded
+    /// only when it ranks better than the best already sent. Errors are dropped
+    /// mid-stream, and because a verified quote outranks an unverified one
+    /// regardless of `out_amount` (same as the one-shot competition), a later
+    /// verified quote supersedes an earlier, higher unverified one.
     #[tokio::test]
     async fn estimate_stream_only_forwards_improving_quotes() {
-        fn estimator(delay: Duration, out_amount: u64) -> Arc<dyn PriceEstimating> {
+        // Staggered delays make the arrival order deterministic.
+        fn quote(delay_ms: u64, out_amount: u64, verified: bool) -> Arc<dyn PriceEstimating> {
             let mut m = MockPriceEstimating::new();
             m.expect_estimate().times(1).returning(move |_| {
                 async move {
-                    sleep(delay).await;
+                    sleep(Duration::from_millis(delay_ms)).await;
                     Ok(Estimate {
                         out_amount: U256::from(out_amount),
                         gas: 1,
+                        verified,
                         ..Default::default()
                     })
                 }
@@ -772,38 +776,48 @@ mod tests {
             Arc::new(m)
         }
 
-        // Staggered delays make the arrival order deterministic.
-        let estimator: CompetitionEstimator<Arc<dyn PriceEstimating>> = CompetitionEstimator::new(
+        fn failing(delay_ms: u64) -> Arc<dyn PriceEstimating> {
+            let mut m = MockPriceEstimating::new();
+            m.expect_estimate().times(1).returning(move |_| {
+                async move {
+                    sleep(Duration::from_millis(delay_ms)).await;
+                    Err(PriceEstimationError::NoLiquidity)
+                }
+                .boxed()
+            });
+            Arc::new(m)
+        }
+
+        // Arrival order: fast unverified 100, better unverified 200, an error,
+        // then a worse (lower) verified 150.
+        let estimator = CompetitionEstimator::new(
             vec![vec![
-                ("first".to_owned(), estimator(Duration::from_millis(0), 100)),
-                (
-                    "second".to_owned(),
-                    estimator(Duration::from_millis(10), 200),
-                ),
-                (
-                    "third".to_owned(),
-                    estimator(Duration::from_millis(20), 150),
-                ),
-                (
-                    "fourth".to_owned(),
-                    estimator(Duration::from_millis(30), 250),
-                ),
+                ("unverified-fast".to_owned(), quote(0, 100, false)),
+                ("unverified-better".to_owned(), quote(10, 200, false)),
+                ("err".to_owned(), failing(20)),
+                ("verified-worse".to_owned(), quote(30, 150, true)),
             ]],
             PriceRanking::MaxOutAmount,
-        );
+        )
+        .with_verification(QuoteVerificationMode::Prefer);
 
         let results: Vec<_> = estimator.estimate_stream(make_query()).collect().await;
 
+        assert!(
+            results.iter().all(|r| r.is_ok()),
+            "no error should be yielded"
+        );
         let amounts: Vec<_> = results
             .iter()
             .map(|r| r.as_ref().unwrap().out_amount)
             .collect();
-        // 100 (first, becomes best) -> 200 (improves) -> 150 (worse, dropped)
-        // -> 250 (improves).
+        // 100 (best) -> 200 (improves) -> error (dropped) -> 150 (verified,
+        // supersedes).
         assert_eq!(
             amounts,
-            vec![U256::from(100u64), U256::from(200u64), U256::from(250u64)]
+            vec![U256::from(100u64), U256::from(200u64), U256::from(150u64)]
         );
+        assert!(results.last().unwrap().as_ref().unwrap().verified);
     }
 
     #[test]

--- a/crates/price-estimation/src/competition/mod.rs
+++ b/crates/price-estimation/src/competition/mod.rs
@@ -1,15 +1,9 @@
 use {
     super::{QuoteVerificationMode, native::NativePriceEstimating},
-    crate::{
-        PriceEstimateResult,
-        PriceEstimating,
-        PriceEstimationError,
-        Query,
-        StreamingPriceEstimating,
-    },
+    crate::PriceEstimationError,
     futures::{
         future::{BoxFuture, FutureExt},
-        stream::{BoxStream, FuturesUnordered, StreamExt},
+        stream::{FuturesUnordered, StreamExt},
     },
     gas_price_estimation::GasPriceEstimating,
     model::order::OrderKind,
@@ -171,20 +165,6 @@ impl<T: Send + Sync + 'static> CompetitionEstimator<T> {
                 .inc();
         }
         result
-    }
-}
-
-impl StreamingPriceEstimating for CompetitionEstimator<Arc<dyn PriceEstimating>> {
-    /// Runs every estimator concurrently across all stages and yields each
-    /// result as it arrives. No ranking, no early return. The caller stops
-    /// by dropping the stream.
-    fn estimate_stream(&self, query: Arc<Query>) -> BoxStream<'_, PriceEstimateResult> {
-        self.stages
-            .iter()
-            .flatten()
-            .map(|(_name, estimator)| estimator.estimate(query.clone()))
-            .collect::<FuturesUnordered<_>>()
-            .boxed()
     }
 }
 
@@ -695,14 +675,16 @@ mod tests {
         assert_eq!(amounts, vec![U256::from(1u64), U256::from(2u64)]);
     }
 
+    /// A transient error is held back, not forwarded: once a later solver
+    /// returns a usable quote, the client sees only the quote, never the error.
     #[tokio::test]
-    async fn estimate_stream_passes_through_errors() {
+    async fn estimate_stream_suppresses_errors_when_a_quote_arrives() {
         let ok = {
             let mut m = MockPriceEstimating::new();
             m.expect_estimate().times(1).returning(|_| {
                 async {
-                    // Resolve after the error so the error is yielded first. This
-                    // proves an error does not abort the remaining results.
+                    // Resolve after the error to prove the earlier error is
+                    // dropped rather than forwarded ahead of the quote.
                     sleep(Duration::from_millis(10)).await;
                     Ok(Estimate {
                         out_amount: U256::from(1u64),
@@ -732,9 +714,96 @@ mod tests {
 
         let results: Vec<_> = estimator.estimate_stream(make_query()).collect().await;
 
-        assert_eq!(results.len(), 2);
-        assert!(results[0].is_err());
-        assert!(results[1].is_ok());
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].as_ref().unwrap().out_amount, U256::from(1u64));
+    }
+
+    /// When every estimator fails, nothing is forwarded until the stream ends,
+    /// then it emits the single highest-priority error — exactly what the
+    /// one-shot `estimate` returns for the same query.
+    #[tokio::test]
+    async fn estimate_stream_ends_with_highest_priority_error_when_all_fail() {
+        fn failing(err: PriceEstimationError) -> Arc<dyn PriceEstimating> {
+            let mut m = MockPriceEstimating::new();
+            m.expect_estimate()
+                .times(1)
+                .return_once(move |_| async move { Err(err) }.boxed());
+            Arc::new(m)
+        }
+
+        let estimator: CompetitionEstimator<Arc<dyn PriceEstimating>> = CompetitionEstimator::new(
+            vec![vec![
+                (
+                    "low".to_owned(),
+                    failing(PriceEstimationError::ProtocolInternal(anyhow!("boom"))),
+                ),
+                (
+                    "high".to_owned(),
+                    failing(PriceEstimationError::RateLimited),
+                ),
+            ]],
+            PriceRanking::MaxOutAmount,
+        );
+
+        let results: Vec<_> = estimator.estimate_stream(make_query()).collect().await;
+
+        assert_eq!(results.len(), 1);
+        assert!(matches!(results[0], Err(PriceEstimationError::RateLimited)));
+    }
+
+    /// Best-so-far: a result is forwarded only when it beats every quote
+    /// already sent, so the client sees a monotonically improving series. A
+    /// later, worse quote is dropped rather than emitted.
+    #[tokio::test]
+    async fn estimate_stream_only_forwards_improving_quotes() {
+        fn estimator(delay: Duration, out_amount: u64) -> Arc<dyn PriceEstimating> {
+            let mut m = MockPriceEstimating::new();
+            m.expect_estimate().times(1).returning(move |_| {
+                async move {
+                    sleep(delay).await;
+                    Ok(Estimate {
+                        out_amount: U256::from(out_amount),
+                        gas: 1,
+                        ..Default::default()
+                    })
+                }
+                .boxed()
+            });
+            Arc::new(m)
+        }
+
+        // Staggered delays make the arrival order deterministic.
+        let estimator: CompetitionEstimator<Arc<dyn PriceEstimating>> = CompetitionEstimator::new(
+            vec![vec![
+                ("first".to_owned(), estimator(Duration::from_millis(0), 100)),
+                (
+                    "second".to_owned(),
+                    estimator(Duration::from_millis(10), 200),
+                ),
+                (
+                    "third".to_owned(),
+                    estimator(Duration::from_millis(20), 150),
+                ),
+                (
+                    "fourth".to_owned(),
+                    estimator(Duration::from_millis(30), 250),
+                ),
+            ]],
+            PriceRanking::MaxOutAmount,
+        );
+
+        let results: Vec<_> = estimator.estimate_stream(make_query()).collect().await;
+
+        let amounts: Vec<_> = results
+            .iter()
+            .map(|r| r.as_ref().unwrap().out_amount)
+            .collect();
+        // 100 (first, becomes best) -> 200 (improves) -> 150 (worse, dropped)
+        // -> 250 (improves).
+        assert_eq!(
+            amounts,
+            vec![U256::from(100u64), U256::from(200u64), U256::from(250u64)]
+        );
     }
 
     #[test]

--- a/crates/price-estimation/src/competition/quote.rs
+++ b/crates/price-estimation/src/competition/quote.rs
@@ -16,7 +16,7 @@ use {
         winning_price_estimate::WinningPriceEstimateEvent,
     },
     futures::{
-        future::{BoxFuture, FutureExt, TryFutureExt},
+        future::{BoxFuture, Either, FutureExt, TryFutureExt},
         stream::{BoxStream, FuturesUnordered, StreamExt},
     },
     model::order::OrderKind,
@@ -91,10 +91,15 @@ impl PriceEstimating for CompetitionEstimator<Arc<dyn PriceEstimating>> {
 
 impl StreamingPriceEstimating for CompetitionEstimator<Arc<dyn PriceEstimating>> {
     /// Runs every estimator concurrently across all stages and forwards a quote
-    /// only when it beats the best one already sent, so the caller sees a
-    /// monotonically improving series and never a regression. The first
-    /// successful quote goes out as soon as the fastest solver answers. The
-    /// caller stops by dropping the stream.
+    /// only when it ranks strictly better than the best one already sent, so
+    /// the client sees a series that improves in *ranking order* and never
+    /// regresses. The first successful quote goes out as soon as the
+    /// fastest solver answers. The caller stops by dropping the stream.
+    ///
+    /// "Better" is the same ranking the one-shot [`Self::estimate`] uses.
+    /// A verified quote outranks an unverified one regardless of `out_amount`,
+    /// so a later verified quote can supersede an earlier unverified one that
+    /// had a higher nominal amount.
     ///
     /// Errors are not forwarded as they arrive. If no quote is ever produced,
     /// the stream ends with the single error the one-shot [`Self::estimate`]
@@ -107,17 +112,10 @@ impl StreamingPriceEstimating for CompetitionEstimator<Arc<dyn PriceEstimating>>
             OrderKind::Sell => query.buy_token,
         };
         async_stream::stream! {
-            // Fetch the ranking context once, up front, mirroring `estimate`.
-            // Without it we cannot rank, so fail the whole stream like the
-            // one-shot path does on a context error.
-            let context = match self.ranking.provide_context(out_token, query.timeout).await {
-                Ok(context) => context,
-                Err(err) => {
-                    yield Err(err);
-                    return;
-                }
-            };
-
+            // Kick off the estimator calls and the ranking-context fetch
+            // concurrently. Building the `FuturesUnordered` does not poll it, so we
+            // drive it alongside the context future via `select` and buffer any
+            // results that arrive until they can be ranked.
             let mut estimates = self
                 .stages
                 .iter()
@@ -128,20 +126,51 @@ impl StreamingPriceEstimating for CompetitionEstimator<Arc<dyn PriceEstimating>>
             // Every result is kept so that, if no quote is ever forwarded, the
             // terminal error can be picked exactly the way `estimate` does.
             let mut results = Vec::new();
+            let mut context_fut = self.ranking.provide_context(out_token, query.timeout).boxed();
+            let context = loop {
+                match futures::future::select(context_fut, estimates.next()).await {
+                    Either::Left((context, _)) => break context,
+                    Either::Right((Some(result), pending_context)) => {
+                        results.push(result);
+                        context_fut = pending_context;
+                    }
+                    // Estimators drained before the context resolved; just wait.
+                    Either::Right((None, pending_context)) => break pending_context.await,
+                }
+            };
+            let context = match context {
+                Ok(context) => context,
+                // Without a ranking context we cannot rank anything, so fail the
+                // whole stream like the one-shot path does on a context error.
+                Err(err) => {
+                    yield Err(err);
+                    return;
+                }
+            };
+
             let mut best: Option<Estimate> = None;
-            while let Some(result) = estimates.next().await {
+            // Replay the results buffered while the context was loading (in
+            // arrival order), then continue draining the live stream.
+            let mut buffered = std::mem::take(&mut results).into_iter();
+            loop {
+                let result = match buffered.next() {
+                    Some(result) => result,
+                    None => match estimates.next().await {
+                        Some(result) => result,
+                        None => break,
+                    },
+                };
                 if is_reasonable(&result) {
-                    let beats_best = match &best {
-                        None => true,
-                        Some(best) => compare_quote_result(
+                    let beats_best = best.as_ref().is_none_or(|best| {
+                        compare_quote_result(
                             &query,
                             &result,
                             &Ok(best.clone()),
                             &context,
                             self.verification_mode,
                         )
-                        .is_gt(),
-                    };
+                        .is_gt()
+                    });
                     if beats_best {
                         let estimate =
                             result.as_ref().expect("is_reasonable implies Ok").clone();

--- a/crates/price-estimation/src/competition/quote.rs
+++ b/crates/price-estimation/src/competition/quote.rs
@@ -7,6 +7,7 @@ use {
         PriceEstimationError,
         Query,
         QuoteVerificationMode,
+        StreamingPriceEstimating,
     },
     alloy::primitives::{Address, U256},
     anyhow::Context as _,
@@ -15,7 +16,10 @@ use {
         query::{OrderKind as DtoOrderKind, QueryFields},
         winning_price_estimate::WinningPriceEstimateEvent,
     },
-    futures::future::{BoxFuture, FutureExt, TryFutureExt},
+    futures::{
+        future::{BoxFuture, FutureExt, TryFutureExt},
+        stream::{BoxStream, FuturesUnordered, StreamExt},
+    },
     model::order::OrderKind,
     std::{
         cmp::Ordering,
@@ -95,6 +99,91 @@ impl PriceEstimating for CompetitionEstimator<Arc<dyn PriceEstimating>> {
             // but due to the return, the simplest way to handle this is keep it here
             // TODO: clean this up
             self.report_winner(&query, query.kind, winner)
+        }
+        .boxed()
+    }
+}
+
+impl StreamingPriceEstimating for CompetitionEstimator<Arc<dyn PriceEstimating>> {
+    /// Runs every estimator concurrently across all stages and forwards a quote
+    /// only when it beats the best one already sent, so the caller sees a
+    /// monotonically improving series and never a regression. The first
+    /// successful quote goes out as soon as the fastest solver answers. The
+    /// caller stops by dropping the stream.
+    ///
+    /// Errors are not forwarded as they arrive. If no quote is ever produced,
+    /// the stream ends with the single error the one-shot [`Self::estimate`]
+    /// would return for the same query: the highest-priority estimator error,
+    /// or the "unreasonable estimates" error when every quote had 0 gas or 0
+    /// out_amount.
+    fn estimate_stream(&self, query: Arc<Query>) -> BoxStream<'_, PriceEstimateResult> {
+        let out_token = match query.kind {
+            OrderKind::Buy => query.sell_token,
+            OrderKind::Sell => query.buy_token,
+        };
+        let prefer_verified = !matches!(self.verification_mode, QuoteVerificationMode::Unverified);
+
+        async_stream::stream! {
+            // Fetch the ranking context once, up front, mirroring `estimate`.
+            // Without it we cannot rank, so fail the whole stream like the
+            // one-shot path does on a context error.
+            let context = match self.ranking.provide_context(out_token, query.timeout).await {
+                Ok(context) => context,
+                Err(err) => {
+                    yield Err(err);
+                    return;
+                }
+            };
+
+            let is_reasonable = |r: &PriceEstimateResult| {
+                r.as_ref().is_ok_and(|e| e.gas > 0 && !e.out_amount.is_zero())
+            };
+
+            let mut estimates = self
+                .stages
+                .iter()
+                .flatten()
+                .map(|(_name, estimator)| estimator.estimate(query.clone()))
+                .collect::<FuturesUnordered<_>>();
+
+            // Every result is kept so that, if no quote is ever forwarded, the
+            // terminal error can be picked exactly the way `estimate` does.
+            let mut results = Vec::new();
+            let mut best: Option<Estimate> = None;
+            while let Some(result) = estimates.next().await {
+                if is_reasonable(&result) {
+                    let beats_best = match &best {
+                        None => true,
+                        Some(best) => compare_quote_result(
+                            &query,
+                            &result,
+                            &Ok(best.clone()),
+                            &context,
+                            prefer_verified,
+                        )
+                        .is_gt(),
+                    };
+                    if beats_best {
+                        let estimate =
+                            result.as_ref().expect("is_reasonable implies Ok").clone();
+                        best = Some(estimate.clone());
+                        yield Ok(estimate);
+                    }
+                }
+                results.push(result);
+            }
+
+            if best.is_none() {
+                yield results
+                    .into_iter()
+                    .filter(|r| r.is_err() || is_reasonable(r))
+                    .max_by(|a, b| compare_quote_result(&query, a, b, &context, prefer_verified))
+                    .unwrap_or_else(|| {
+                        Err(PriceEstimationError::EstimatorInternal(anyhow::anyhow!(
+                            "all price estimates were unreasonable (0 gas or 0 out_amount)"
+                        )))
+                    });
+            }
         }
         .boxed()
     }

--- a/crates/price-estimation/src/competition/quote.rs
+++ b/crates/price-estimation/src/competition/quote.rs
@@ -10,7 +10,6 @@ use {
         StreamingPriceEstimating,
     },
     alloy::primitives::{Address, U256},
-    anyhow::Context as _,
     event_bus_dto::{
         price_estimate::{EstimateResult, PriceEstimateEvent},
         query::{OrderKind as DtoOrderKind, QueryFields},
@@ -41,13 +40,6 @@ impl PriceEstimating for CompetitionEstimator<Arc<dyn PriceEstimating>> {
             };
             let get_context = self.ranking.provide_context(out_token, query.timeout);
 
-            // Filter out obviously wrong estimates:
-            // - 0 gas cost would lead to us paying huge subsidies
-            // - 0 out_amount means the quote is useless
-            let is_reasonable = |r: &PriceEstimateResult| {
-                r.as_ref()
-                    .is_ok_and(|r| r.gas > 0 && !r.out_amount.is_zero())
-            };
             let get_results = self
                 .produce_results(query.clone(), is_reasonable, |context| {
                     // Call estimate() eagerly so its side-effects still happen
@@ -79,16 +71,9 @@ impl PriceEstimating for CompetitionEstimator<Arc<dyn PriceEstimating>> {
                 .into_iter()
                 .filter(|(_index, r)| r.is_err() || is_reasonable(r))
                 .max_by(|a, b| {
-                    compare_quote_result(
-                        &query,
-                        &a.1,
-                        &b.1,
-                        &context,
-                        !matches!(self.verification_mode, QuoteVerificationMode::Unverified),
-                    )
+                    compare_quote_result(&query, &a.1, &b.1, &context, self.verification_mode)
                 })
-                .with_context(|| "all price estimates were unreasonable (0 gas or 0 out_amount)")
-                .map_err(PriceEstimationError::EstimatorInternal)?;
+                .ok_or_else(unreasonable_estimates_error)?;
 
             if winner.1.is_ok() {
                 let EstimatorIndex(stage_index, estimator_index) = winner.0;
@@ -121,8 +106,6 @@ impl StreamingPriceEstimating for CompetitionEstimator<Arc<dyn PriceEstimating>>
             OrderKind::Buy => query.sell_token,
             OrderKind::Sell => query.buy_token,
         };
-        let prefer_verified = !matches!(self.verification_mode, QuoteVerificationMode::Unverified);
-
         async_stream::stream! {
             // Fetch the ranking context once, up front, mirroring `estimate`.
             // Without it we cannot rank, so fail the whole stream like the
@@ -133,10 +116,6 @@ impl StreamingPriceEstimating for CompetitionEstimator<Arc<dyn PriceEstimating>>
                     yield Err(err);
                     return;
                 }
-            };
-
-            let is_reasonable = |r: &PriceEstimateResult| {
-                r.as_ref().is_ok_and(|e| e.gas > 0 && !e.out_amount.is_zero())
             };
 
             let mut estimates = self
@@ -159,7 +138,7 @@ impl StreamingPriceEstimating for CompetitionEstimator<Arc<dyn PriceEstimating>>
                             &result,
                             &Ok(best.clone()),
                             &context,
-                            prefer_verified,
+                            self.verification_mode,
                         )
                         .is_gt(),
                     };
@@ -177,16 +156,24 @@ impl StreamingPriceEstimating for CompetitionEstimator<Arc<dyn PriceEstimating>>
                 yield results
                     .into_iter()
                     .filter(|r| r.is_err() || is_reasonable(r))
-                    .max_by(|a, b| compare_quote_result(&query, a, b, &context, prefer_verified))
-                    .unwrap_or_else(|| {
-                        Err(PriceEstimationError::EstimatorInternal(anyhow::anyhow!(
-                            "all price estimates were unreasonable (0 gas or 0 out_amount)"
-                        )))
-                    });
+                    .max_by(|a, b| compare_quote_result(&query, a, b, &context, self.verification_mode))
+                    .unwrap_or_else(|| Err(unreasonable_estimates_error()));
             }
         }
         .boxed()
     }
+}
+
+fn is_reasonable(result: &PriceEstimateResult) -> bool {
+    result
+        .as_ref()
+        .is_ok_and(|estimate| estimate.gas > 0 && !estimate.out_amount.is_zero())
+}
+
+fn unreasonable_estimates_error() -> PriceEstimationError {
+    PriceEstimationError::EstimatorInternal(anyhow::anyhow!(
+        "all price estimates were unreasonable (0 gas or 0 out_amount)"
+    ))
 }
 
 fn compare_quote_result(
@@ -194,11 +181,12 @@ fn compare_quote_result(
     a: &PriceEstimateResult,
     b: &PriceEstimateResult,
     context: &RankingContext,
-    prefer_verified_estimates: bool,
+    verification_mode: QuoteVerificationMode,
 ) -> Ordering {
+    let prefer_verified = !matches!(verification_mode, QuoteVerificationMode::Unverified);
     match (a, b) {
         (Ok(a), Ok(b)) => {
-            match (prefer_verified_estimates, a.verified, b.verified) {
+            match (prefer_verified, a.verified, b.verified) {
                 // prefer verified over unverified quotes
                 (true, true, false) => Ordering::Greater,
                 (true, false, true) => Ordering::Less,

--- a/crates/price-estimation/src/competition/quote.rs
+++ b/crates/price-estimation/src/competition/quote.rs
@@ -121,10 +121,10 @@ impl StreamingPriceEstimating for CompetitionEstimator<Arc<dyn PriceEstimating>>
                 .iter()
                 .flatten()
                 .map(|(_name, estimator)| estimator.estimate(query.clone()))
-                .collect::<FuturesUnordered<_>>();
+                .collect::<FuturesUnordered<_>>()
+                // Only errors and reasonable estimates can be ranked
+                .filter(|r| std::future::ready(r.is_err() || is_reasonable(r)));
 
-            // Every result is kept so that, if no quote is ever forwarded, the
-            // terminal error can be picked exactly the way `estimate` does.
             let mut results = Vec::new();
             let mut context_fut = self.ranking.provide_context(out_token, query.timeout).boxed();
             let context = loop {
@@ -148,19 +148,13 @@ impl StreamingPriceEstimating for CompetitionEstimator<Arc<dyn PriceEstimating>>
                 }
             };
 
+            // Replay the buffered results (arrival order), then continue draining
+            // the live stream. Every result is kept so that, if no quote is ever
+            // forwarded, the terminal error can be picked as `estimate` does.
             let mut best: Option<Estimate> = None;
-            // Replay the results buffered while the context was loading (in
-            // arrival order), then continue draining the live stream.
-            let mut buffered = std::mem::take(&mut results).into_iter();
-            loop {
-                let result = match buffered.next() {
-                    Some(result) => result,
-                    None => match estimates.next().await {
-                        Some(result) => result,
-                        None => break,
-                    },
-                };
-                if is_reasonable(&result) {
+            let mut stream = futures::stream::iter(std::mem::take(&mut results)).chain(estimates);
+            while let Some(result) = stream.next().await {
+                if let Ok(estimate) = &result {
                     let beats_best = best.as_ref().is_none_or(|best| {
                         compare_quote_result(
                             &query,
@@ -172,10 +166,8 @@ impl StreamingPriceEstimating for CompetitionEstimator<Arc<dyn PriceEstimating>>
                         .is_gt()
                     });
                     if beats_best {
-                        let estimate =
-                            result.as_ref().expect("is_reasonable implies Ok").clone();
                         best = Some(estimate.clone());
-                        yield Ok(estimate);
+                        yield Ok(estimate.clone());
                     }
                 }
                 results.push(result);
@@ -184,7 +176,6 @@ impl StreamingPriceEstimating for CompetitionEstimator<Arc<dyn PriceEstimating>>
             if best.is_none() {
                 yield results
                     .into_iter()
-                    .filter(|r| r.is_err() || is_reasonable(r))
                     .max_by(|a, b| compare_quote_result(&query, a, b, &context, self.verification_mode))
                     .unwrap_or_else(|| Err(unreasonable_estimates_error()));
             }

--- a/crates/price-estimation/src/competition/quote.rs
+++ b/crates/price-estimation/src/competition/quote.rs
@@ -16,7 +16,7 @@ use {
         winning_price_estimate::WinningPriceEstimateEvent,
     },
     futures::{
-        future::{BoxFuture, Either, FutureExt, TryFutureExt},
+        future::{BoxFuture, FutureExt, TryFutureExt},
         stream::{BoxStream, FuturesUnordered, StreamExt},
     },
     model::order::OrderKind,
@@ -112,10 +112,6 @@ impl StreamingPriceEstimating for CompetitionEstimator<Arc<dyn PriceEstimating>>
             OrderKind::Sell => query.buy_token,
         };
         async_stream::stream! {
-            // Kick off the estimator calls and the ranking-context fetch
-            // concurrently. Building the `FuturesUnordered` does not poll it, so we
-            // drive it alongside the context future via `select` and buffer any
-            // results that arrive until they can be ranked.
             let mut estimates = self
                 .stages
                 .iter()
@@ -125,20 +121,16 @@ impl StreamingPriceEstimating for CompetitionEstimator<Arc<dyn PriceEstimating>>
                 // Only errors and reasonable estimates can be ranked
                 .filter(|r| std::future::ready(r.is_err() || is_reasonable(r)));
 
-            let mut results = Vec::new();
-            let mut context_fut = self.ranking.provide_context(out_token, query.timeout).boxed();
-            let context = loop {
-                match futures::future::select(context_fut, estimates.next()).await {
-                    Either::Left((context, _)) => break context,
-                    Either::Right((Some(result), pending_context)) => {
-                        results.push(result);
-                        context_fut = pending_context;
-                    }
-                    // Estimators drained before the context resolved; just wait.
-                    Either::Right((None, pending_context)) => break pending_context.await,
-                }
-            };
-            let context = match context {
+            let context_fut = self.ranking.provide_context(out_token, query.timeout).shared();
+
+            // Collect estimates concurrently while fetching the ranking context;
+            // they can't be ranked before it resolves.
+            let mut results: Vec<_> = (&mut estimates)
+                .take_until(context_fut.clone())
+                .collect()
+                .await;
+
+            let context = match context_fut.await {
                 Ok(context) => context,
                 // Without a ranking context we cannot rank anything, so fail the
                 // whole stream like the one-shot path does on a context error.
@@ -257,6 +249,7 @@ impl PriceRanking {
     }
 }
 
+#[derive(Clone)]
 struct RankingContext {
     native_price: f64,
     gas_price: f64,

--- a/crates/shared/src/order_quoting.rs
+++ b/crates/shared/src/order_quoting.rs
@@ -671,11 +671,16 @@ impl StreamingQuoting for OrderQuoter {
         let stream = async_stream::stream! {
             let inner = estimator.estimate_stream(trade_query);
             futures::pin_mut!(inner);
+
+            // Errors are only surfaced at the end if no quote ever succeeds.
+            let mut deferred_err: Option<CalculateQuoteError> = None;
+            let mut any_ok = false;
             while let Some(result) = inner.next().await {
                 let estimate = match result {
                     Ok(e) => e,
+                    // An inner errors us terminal but less specific than SellAmountDoesNotCoverFee, so it should not mask the latter.
                     Err(err) => {
-                        yield Err(CalculateQuoteError::from((EstimatorKind::Regular, err)));
+                        deferred_err = deferred_err.or(Some(CalculateQuoteError::from((EstimatorKind::Regular, err))));
                         continue;
                     }
                 };
@@ -698,7 +703,8 @@ impl StreamingQuoting for OrderQuoter {
                 {
                     let sell_amount = value.get().saturating_sub(quote.fee_amount);
                     if sell_amount.is_zero() {
-                        yield Err(CalculateQuoteError::SellAmountDoesNotCoverFee {
+                        // SellAmountDoesNotCoverFee is a more actionable error than a generic inner one
+                        deferred_err = Some(CalculateQuoteError::SellAmountDoesNotCoverFee {
                             fee_amount: quote.fee_amount,
                         });
                         continue;
@@ -713,7 +719,12 @@ impl StreamingQuoting for OrderQuoter {
                     Ok(id) => quote.id = Some(id),
                     Err(err) => tracing::error!(?err, "failed to persist streamed quote"),
                 }
+                any_ok = true;
                 yield Ok(quote);
+            }
+            // No quote succeeded: surface the deferred fee error, if any.
+            if !any_ok && let Some(err) = deferred_err {
+                yield Err(err);
             }
         };
 
@@ -2299,66 +2310,104 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn streaming_before_fee_errors_when_fee_exceeds_sell_amount() {
-        // sell_before_fee = 100, gas = 2000, gas_price = 1, sell_token_price = 1.0
-        // fee = ceil((2000 * 1) / 1.0) = 2000
-        // 100 - 2000 saturates to 0 -> SellAmountDoesNotCoverFee
-        let params = QuoteParameters {
-            sell_token: Address::repeat_byte(1),
-            buy_token: Address::repeat_byte(2),
-            side: OrderQuoteSide::Sell {
-                sell_amount: SellAmount::BeforeFee {
-                    value: number::nonzero::NonZeroU256::try_from(100).unwrap(),
+    async fn streaming_defers_fee_error_until_no_quote_succeeds() {
+        // sell_before_fee = 100, gas_price = 1, sell_token_price = 1.0, so
+        // fee = ceil(gas * 1 / 1.0) = gas. A gas of 2000 saturates 100 - 2000 to
+        // 0 -> SellAmountDoesNotCoverFee; a gas of 10 leaves 90 -> a good quote.
+        fn params() -> QuoteParameters {
+            QuoteParameters {
+                sell_token: Address::repeat_byte(1),
+                buy_token: Address::repeat_byte(2),
+                side: OrderQuoteSide::Sell {
+                    sell_amount: SellAmount::BeforeFee {
+                        value: number::nonzero::NonZeroU256::try_from(100).unwrap(),
+                    },
                 },
-            },
-            signing_scheme: QuoteSigningScheme::Eip712,
-            verification: Default::default(),
-            additional_gas: 0,
-            fast_path: false,
-            timeout: None,
-        };
+                signing_scheme: QuoteSigningScheme::Eip712,
+                verification: Default::default(),
+                additional_gas: 0,
+                fast_path: false,
+                timeout: None,
+            }
+        }
+        fn estimate(gas: u64) -> price_estimation::Estimate {
+            price_estimation::Estimate {
+                out_amount: AlloyU256::from(500),
+                gas,
+                solver: Address::repeat_byte(1),
+                verified: false,
+                supports_fast_path: false,
+                execution: Default::default(),
+            }
+        }
         let gas_price = alloy::eips::eip1559::Eip1559Estimation {
             max_fee_per_gas: 1,
             max_priority_fee_per_gas: 0,
         };
         let now = Utc::now();
 
-        let mut native_price_estimator = MockNativePriceEstimating::new();
-        setup_native_price_mock(
-            &mut native_price_estimator,
-            params.sell_token,
-            params.buy_token,
-        );
+        let make = |results: Vec<price_estimation::PriceEstimateResult>| {
+            let params = params();
+            let mut native_price_estimator = MockNativePriceEstimating::new();
+            setup_native_price_mock(
+                &mut native_price_estimator,
+                params.sell_token,
+                params.buy_token,
+            );
+            let mut streaming_estimator = price_estimation::MockStreamingPriceEstimating::new();
+            streaming_estimator
+                .expect_estimate_stream()
+                .return_once(move |_| stream::iter(results).boxed());
+            let quoter =
+                make_streaming_quoter(streaming_estimator, native_price_estimator, gas_price, now);
+            (quoter, params)
+        };
 
-        let mut streaming_estimator = price_estimation::MockStreamingPriceEstimating::new();
-        streaming_estimator.expect_estimate_stream().returning(|_| {
-            stream::iter([Ok(price_estimation::Estimate {
-                out_amount: AlloyU256::from(500),
-                gas: 2000,
-                solver: Address::repeat_byte(1),
-                verified: false,
-                supports_fast_path: false,
-                execution: Default::default(),
-            })])
-            .boxed()
-        });
+        let assert_sell_amount_error = |err: CalculateQuoteError| {
+            assert!(
+                matches!(
+                    err,
+                    CalculateQuoteError::SellAmountDoesNotCoverFee { fee_amount }
+                        if fee_amount == U256::from(2000)
+                ),
+                "expected SellAmountDoesNotCoverFee, got {err:?}",
+            );
+        };
 
-        let quoter =
-            make_streaming_quoter(streaming_estimator, native_price_estimator, gas_price, now);
+        // Only a fee-exceeding estimate: the deferred error surfaces at the end.
+        let (quoter, params) = make(vec![Ok(estimate(2000))]);
         let mut s = quoter
             .calculate_quote_stream(params)
             .await
             .expect("stream setup must succeed");
+        assert_sell_amount_error(s.next().await.expect("error item").unwrap_err());
+        assert!(s.next().await.is_none());
 
-        let err = s.next().await.expect("error item").unwrap_err();
+        // A later quote covers its fee: the deferred error is suppressed and only
+        // the good quote is yielded.
+        let (quoter, params) = make(vec![Ok(estimate(2000)), Ok(estimate(10))]);
+        let mut s = quoter
+            .calculate_quote_stream(params)
+            .await
+            .expect("stream setup must succeed");
+        let q = s.next().await.expect("quote").expect("ok");
+        assert_eq!(q.sell_amount, AlloyU256::from(90));
         assert!(
-            matches!(
-                err,
-                CalculateQuoteError::SellAmountDoesNotCoverFee { fee_amount }
-                    if fee_amount == U256::from(2000)
-            ),
-            "expected SellAmountDoesNotCoverFee, got {err:?}",
+            s.next().await.is_none(),
+            "the deferred fee error must not be yielded once a quote succeeds",
         );
+
+        // A fee-exceeding quote plus a terminal estimator error: the more
+        // specific SellAmountDoesNotCoverFee must win over the estimator error.
+        let (quoter, params) = make(vec![
+            Ok(estimate(2000)),
+            Err(price_estimation::PriceEstimationError::NoLiquidity),
+        ]);
+        let mut s = quoter
+            .calculate_quote_stream(params)
+            .await
+            .expect("stream setup must succeed");
+        assert_sell_amount_error(s.next().await.expect("error item").unwrap_err());
         assert!(s.next().await.is_none());
     }
 }

--- a/crates/shared/src/order_quoting.rs
+++ b/crates/shared/src/order_quoting.rs
@@ -678,7 +678,7 @@ impl StreamingQuoting for OrderQuoter {
             while let Some(result) = inner.next().await {
                 let estimate = match result {
                     Ok(e) => e,
-                    // An inner errors us terminal but less specific than SellAmountDoesNotCoverFee, so it should not mask the latter.
+                    // An inner error is terminal but less specific than SellAmountDoesNotCoverFee, so it should not mask the latter.
                     Err(err) => {
                         deferred_err = deferred_err.or(Some(CalculateQuoteError::from((EstimatorKind::Regular, err))));
                         continue;


### PR DESCRIPTION
# Description
Currently we emit every quote as part of the streaming quote api. This has been flagged as unergonomic from partners that want to integrate. They are not interested in receiving errors and potentially lower quality quote updates, they only want to see an increasingly better quotes.

This PR implements this by deferring errors to the end and only emitting new results if they are better as the best one so far

> [!IMPORTANT]
> Inline with the non streamed endpoint, verified quotes are considered "better" than an unverified one regardless of out amount. This is because unverified quotes often suffer from overquoting (and promising a price that is "too good to be true).

# Changes
<!-- List of detailed changes (how the change is accomplished) -->

* Move streamed quoting logic into the price estimation module so it can share the ranking logic
* Make it re-use the same ranking and error classification logic as the classic quote endpoint
* Defer emission of errors until it's clear no Ok result can be returned

## How to test
Added unit tests