### PR TITLE
  fix(ci): surface swallowed claude review api errors in claude-review.yml 🚨

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -53,7 +53,8 @@ jobs:
           # branch instead of just the latest commit.
           fetch-depth: 0
 
-      - uses: anthropics/claude-code-action@558b1d6cab4085c7753fe402c10bef0fbb92ac7a # v1.0.165
+      - id: claude
+        uses: anthropics/claude-code-action@558b1d6cab4085c7753fe402c10bef0fbb92ac7a # v1.0.165
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           trigger_phrase: "@claude"
@@ -65,3 +66,26 @@ jobs:
           prompt: |
             Review this PR. Post each issue as an INLINE comment on the exact file and
             line using the create_inline_comment tool. Follow the pr-review skill if available.
+
+      # The action exits 0 even when the model/API errors ("is_error": true in
+      # the execution file), so CI goes green and no review is posted. Re-surface
+      # that as a failed step + PR comment. (Upstream has no fail_on_error input.)
+      - name: Fail if Claude errored
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EXEC_FILE: ${{ steps.claude.outputs.execution_file }}
+          CLAUDE_OUTCOME: ${{ steps.claude.outcome }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          is_error=$(jq -r 'map(select(.type == "result")) | last | .is_error // false' "$EXEC_FILE" 2>/dev/null || echo false)
+          if [ "$CLAUDE_OUTCOME" != "failure" ] && [ "$is_error" != "true" ]; then
+            echo "Claude review completed without error."
+            exit 0
+          fi
+          msg="⚠️ **Claude PR review failed to run** (\`is_error=true\`, no review posted — usually an Anthropic API/auth/credit error). See the [workflow run]($RUN_URL) for details, or check [Claude status](https://status.claude.com/)."
+          echo "::error::Claude PR review failed to run — see $RUN_URL"
+          # ponytail: one comment per failed run; make it a sticky find-or-update comment if the noise matters.
+          gh pr comment "$PR_NUMBER" --body "$msg" || echo "Could not post PR comment"
+          exit 1


### PR DESCRIPTION
  - add id to claude-code-action step so its outputs/outcome are addressable
  - add gate step: fail job + ::error:: annotation when claude errors or is_error=true
  - post pr comment (with run + claude status links) when the review fails to run

  Closes: DEV-114
