### PR TITLE
Downgrade http request + set span logs to trace

### DIFF
--- a/crates/observe/src/tracing/distributed/axum.rs
+++ b/crates/observe/src/tracing/distributed/axum.rs
@@ -3,7 +3,7 @@ use {
     axum::http::Request,
     opentelemetry::{global, trace::TraceContextExt},
     opentelemetry_http::HeaderExtractor,
-    tracing::{Span, field, info, info_span},
+    tracing::{Span, field, info_span, trace},
     tracing_opentelemetry::OpenTelemetrySpanExt,
 };
 
@@ -31,7 +31,7 @@ pub fn make_span<B>(request: &Request<B>) -> Span {
     }
     {
         let _span = span.enter();
-        info!(uri = %request.uri(), method = %request.method(), "HTTP request");
+        trace!(uri = %request.uri(), method = %request.method(), "HTTP request");
     }
 
     span

--- a/crates/observe/src/tracing/distributed/axum.rs
+++ b/crates/observe/src/tracing/distributed/axum.rs
@@ -27,7 +27,7 @@ pub fn make_span<B>(request: &Request<B>) -> Span {
 
     let span = info_span!(SPAN_NAME, request_id = request_id, trace_id = field::Empty);
     if let Err(err) = span.set_parent(parent_context) {
-        tracing::debug!(?err, "failed to set request parent span");
+        tracing::trace!(?err, "failed to set request parent span");
     }
     {
         let _span = span.enter();

--- a/crates/orderbook/src/api.rs
+++ b/crates/orderbook/src/api.rs
@@ -100,7 +100,7 @@ async fn summarize_request(req: Request<axum::body::Body>, next: Next) -> Respon
     let response = next.run(req).await;
     let status = response.status().as_u16();
 
-    tracing::info!(
+    tracing::trace!(
         method,
         uri,
         user_agent,


### PR DESCRIPTION
# Description
Following the discussion in https://nomevlabs.slack.com/archives/C0375NV72SC/p1784657973603719?thread_ts=1784657938.936339&cid=C0375NV72SC


# Changes

This PR downgrades the following to trace:
* `request_summary`
* `http request`
* "failed to set span parent"
