### PR TITLE
Re-use order UIDs allocation when doing batch inserts

### DIFF
--- a/crates/autopilot/src/database/order_events.rs
+++ b/crates/autopilot/src/database/order_events.rs
@@ -15,27 +15,41 @@ impl super::Postgres {
     }
 }
 
+/// Max number of order UIDs sent to the DB per insert statement. Chunking keeps
+/// individual queries bounded regardless of how many events are stored at once.
+const INSERT_CHUNK_SIZE: usize = 1000;
+
 pub async fn store_order_events(
     ex: &mut PgConnection,
-    order_uids: Vec<domain::OrderUid>,
+    order_uids: impl IntoIterator<Item = domain::OrderUid>,
     label: OrderEventLabel,
     reason: Option<OrderFilterReason>,
     timestamp: DateTime<Utc>,
 ) {
     let start = Instant::now();
-    let order_uids: Vec<_> = order_uids.into_iter().map(|o| ByteArray(o.0)).collect();
-    let count = order_uids.len();
 
     let insert = async move {
         let mut ex = ex.begin().await?;
-        for chunk in order_uids.chunks(1000) {
-            order_events::insert_order_events(&mut ex, chunk, timestamp, label, reason).await?;
+        let mut order_uids = order_uids.into_iter().map(|o| ByteArray(o.0));
+        let mut chunk = Vec::with_capacity(INSERT_CHUNK_SIZE);
+        let mut count = 0;
+        loop {
+            chunk.clear();
+            chunk.extend(order_uids.by_ref().take(INSERT_CHUNK_SIZE));
+            if chunk.is_empty() {
+                break;
+            }
+            count += chunk.len();
+            order_events::insert_order_events(&mut ex, &chunk, timestamp, label, reason).await?;
         }
-        ex.commit().await
+        ex.commit().await?;
+        Ok::<_, Error>(count)
     };
 
     match insert.await {
-        Ok(_) => tracing::debug!(?label, count, elapsed = ?start.elapsed(), "stored order events"),
-        Err(err) => tracing::warn!(?label, count, ?err, "failed to insert order events"),
+        Ok(count) => {
+            tracing::debug!(?label, count, elapsed = ?start.elapsed(), "stored order events")
+        }
+        Err(err) => tracing::warn!(?label, ?err, "failed to insert order events"),
     }
 }

--- a/crates/autopilot/src/database/order_events.rs
+++ b/crates/autopilot/src/database/order_events.rs
@@ -31,7 +31,11 @@ pub async fn store_order_events(
     let insert = async move {
         let mut ex = ex.begin().await?;
         let mut order_uids = order_uids.into_iter().map(|o| ByteArray(o.0));
-        let mut chunk = Vec::with_capacity(INSERT_CHUNK_SIZE);
+        let capacity = match order_uids.size_hint().1 {
+            Some(hint) => std::cmp::min(hint, INSERT_CHUNK_SIZE),
+            None => INSERT_CHUNK_SIZE,
+        };
+        let mut chunk = Vec::with_capacity(capacity);
         let mut count = 0;
         loop {
             chunk.clear();

--- a/crates/autopilot/src/infra/persistence/mod.rs
+++ b/crates/autopilot/src/infra/persistence/mod.rs
@@ -286,13 +286,14 @@ impl Persistence {
         reason: Option<OrderFilterReason>,
     ) where
         I: IntoIterator + Send + 'static,
+        I::IntoIter: Send,
         I::Item: Send,
         F: (Fn(I::Item) -> domain::OrderUid) + Send + 'static,
     {
         let db = self.postgres.clone();
         tokio::spawn(
             async move {
-                let order_uids = items.into_iter().map(convert).collect();
+                let order_uids = items.into_iter().map(convert);
                 match db.pool.acquire().await {
                     Ok(mut tx) => {
                         store_order_events(&mut tx, order_uids, label, reason, Utc::now()).await;
@@ -801,7 +802,7 @@ impl Persistence {
 
             store_order_events(
                 &mut ex,
-                fee_breakdown.keys().cloned().collect(),
+                fee_breakdown.keys().cloned(),
                 OrderEventLabel::Traded,
                 None,
                 Utc::now(),


### PR DESCRIPTION
# Description

Stumbled upon a longer poll when evaluating dial9:
<img width="606" height="410" alt="Screenshot 2026-07-23 at 13 01 18" src="https://github.com/user-attachments/assets/7f91eee0-e71d-42cc-84ad-40ecadc5d303" />

Turns out this isn't that helpful in terms of latency, but it does reduce memory jitter in the autopilot; the following graph is mainnet prod:
<img width="937" height="526" alt="image" src="https://github.com/user-attachments/assets/462fdb2a-69d0-46ce-8d30-d2e3f8ab7073" />


# Changes

* Stop collecting the whole vec of order UIDs to then chunk them
* Instead, collect the chunks beforehand and re-use the chunk allocation