### PR TITLE
Use clap and anyhow in event-bus-dto binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4828,7 +4828,9 @@ dependencies = [
 name = "event-bus-dto"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "chrono",
+ "clap",
  "schemars 1.2.0",
  "serde",
  "serde_json",

--- a/crates/event-bus-dto/Cargo.toml
+++ b/crates/event-bus-dto/Cargo.toml
@@ -10,7 +10,9 @@ name = "event-bus-schemas"
 path = "src/bin/print_schemas.rs"
 
 [dependencies]
+anyhow = { workspace = true }
 chrono = { workspace = true, features = ["clock", "serde"] }
+clap = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/event-bus-dto/src/bin/print_schemas.rs
+++ b/crates/event-bus-dto/src/bin/print_schemas.rs
@@ -6,26 +6,31 @@
 
 use std::{collections::BTreeMap, path::PathBuf};
 
-fn main() {
-    let out_path = std::env::args()
-        .nth(1)
-        .map(PathBuf::from)
-        .unwrap_or_else(|| {
-            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-                .join("schemas")
-                .join("events.json")
-        });
+use clap::Parser;
+
+#[derive(Parser)]
+struct CliArguments {
+    /// The path to the output schema file.
+    ///
+    /// Defaults to `schemas/events.json` inside the crate.
+    #[arg(default_value_os_t = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("schemas").join("events.json"))]
+    out_path: PathBuf,
+}
+
+fn main() -> anyhow::Result<()> {
+    let CliArguments { out_path } = CliArguments::parse();
 
     // Sort by subject so the generated document is stable across runs
     let schemas: BTreeMap<String, serde_json::Value> = event_bus_dto::schemas()
         .into_iter()
-        .map(|(subject, schema)| (subject.to_owned(), serde_json::to_value(schema).unwrap()))
-        .collect();
-    let body = serde_json::to_string_pretty(&schemas).unwrap();
+        .map(|(subject, schema)| Ok((subject.to_owned(), serde_json::to_value(schema)?)))
+        .collect::<Result<_, serde_json::Error>>()?;
+    let body = serde_json::to_string_pretty(&schemas)?;
 
     if let Some(parent) = out_path.parent() {
-        std::fs::create_dir_all(parent).expect("failed to create output directory");
+        std::fs::create_dir_all(parent)?;
     }
-    std::fs::write(&out_path, format!("{body}\n")).expect("failed to write schema file");
+    std::fs::write(&out_path, format!("{body}\n"))?;
     eprintln!("wrote {} ({} events)", out_path.display(), schemas.len());
+    Ok(())
 }

--- a/crates/event-bus-dto/src/bin/print_schemas.rs
+++ b/crates/event-bus-dto/src/bin/print_schemas.rs
@@ -4,9 +4,10 @@
 //! By default writes to `schemas/events.json` inside the crate. Pass an
 //! alternative path as the first argument to override.
 
-use std::{collections::BTreeMap, path::PathBuf};
-
-use clap::Parser;
+use {
+    clap::Parser,
+    std::{collections::BTreeMap, path::PathBuf},
+};
 
 #[derive(Parser)]
 struct CliArguments {


### PR DESCRIPTION
# Description
<!--- Describe your changes to provide context for reviewers, including why it is needed -->

Small PR that refactors `src/bin/print_schemas.rs` to use clap for argument parsing and anyhow for error reporting instead of unwrapping.

# Changes
<!-- List of detailed changes (how the change is accomplished) -->

* New struct `CliArguments` in `crates/event-bus-dto/src/bin/print_schemas.rs` that houses a single field `out_path` to specify the output path for the schema file, defaulting to `$CARGO_MANIFEST_DIR/schemas/event.json` if the argument isn't supplied
* `fn main()` in `print_schemas.rs` now returns `anyhow::Result<()>` in order to make use of the question mark operator to early-return from fallible function calls.

## How to test
1. `cargo run` creates the same `schemas/events.json` file as before when no CLI arguments are specified.
2. `cargo run -- foo/bar.json` creates a `bar.json` file under the `foo` directory, creating it if it doesn't exist.