### PR TITLE
Optimize hex serialization

### DIFF
--- a/crates/app-data/src/app_data.rs
+++ b/crates/app-data/src/app_data.rs
@@ -443,7 +443,8 @@ impl Serialize for OrderUid {
     where
         S: Serializer,
     {
-        serializer.serialize_str(self.to_string().as_str())
+        let mut buffer = const_hex::Buffer::<56, true>::new();
+        serializer.serialize_str(buffer.format(&self.0))
     }
 }
 

--- a/crates/app-data/src/app_data_hash.rs
+++ b/crates/app-data/src/app_data_hash.rs
@@ -72,13 +72,8 @@ impl Serialize for AppDataHash {
     where
         S: Serializer,
     {
-        let mut bytes = [0u8; 2 + 32 * 2];
-        bytes[..2].copy_from_slice(b"0x");
-        // Can only fail if the buffer size does not match but we know it is correct.
-        const_hex::encode_to_slice(self.0, &mut bytes[2..]).unwrap();
-        // Hex encoding is always valid utf8.
-        let s = std::str::from_utf8(&bytes).unwrap();
-        serializer.serialize_str(s)
+        let mut buffer = const_hex::Buffer::<32, true>::new();
+        serializer.serialize_str(buffer.format(&self.0))
     }
 }
 

--- a/crates/bytes-hex/src/lib.rs
+++ b/crates/bytes-hex/src/lib.rs
@@ -11,13 +11,8 @@ where
     S: Serializer,
     T: AsRef<[u8]>,
 {
-    let mut v = vec![0u8; 2 + bytes.as_ref().len() * 2];
-    v[0] = b'0';
-    v[1] = b'x';
-    // Unwrap because only possible error is vector wrong size which cannot happen.
-    const_hex::encode_to_slice(bytes, &mut v[2..]).unwrap();
-    // Unwrap because encoded data is always valid utf8.
-    serializer.serialize_str(&String::from_utf8(v).unwrap())
+    let bytes = const_hex::encode_prefixed(bytes);
+    serializer.serialize_str(&bytes)
 }
 
 pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>

--- a/crates/model/src/order.rs
+++ b/crates/model/src/order.rs
@@ -808,7 +808,8 @@ impl Serialize for OrderUid {
     where
         S: Serializer,
     {
-        serializer.serialize_str(self.to_string().as_str())
+        let mut buffer = const_hex::Buffer::<56, true>::new();
+        serializer.serialize_str(buffer.format(&self.0))
     }
 }
 

--- a/crates/model/src/signature.rs
+++ b/crates/model/src/signature.rs
@@ -373,13 +373,8 @@ impl Serialize for EcdsaSignature {
     where
         S: serde::Serializer,
     {
-        let mut bytes = [0u8; 2 + 65 * 2];
-        bytes[..2].copy_from_slice(b"0x");
-        // Can only fail if the buffer size does not match but we know it is correct.
-        const_hex::encode_to_slice(self.to_bytes(), &mut bytes[2..]).unwrap();
-        // Hex encoding is always valid utf8.
-        let str = std::str::from_utf8(&bytes).unwrap();
-        serializer.serialize_str(str)
+        let mut buffer = const_hex::Buffer::<65, true>::new();
+        serializer.serialize_str(buffer.format(&self.to_bytes()))
     }
 }
 

--- a/crates/serde-ext/src/hex.rs
+++ b/crates/serde-ext/src/hex.rs
@@ -88,6 +88,7 @@ impl<'de, const N: usize> DeserializeAs<'de, [u8; N]> for Hex {
 
 impl<const N: usize> SerializeAs<[u8; N]> for Hex {
     fn serialize_as<S: Serializer>(source: &[u8; N], serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_str(&const_hex::encode_prefixed(source))
+        let mut buffer = const_hex::Buffer::<N, true>::new();
+        serializer.serialize_str(buffer.format(source))
     }
 }


### PR DESCRIPTION
# Description
`const_hex` offers a way to serialize bytes into a fixed size stack allocated buffer. 

The new version is twice as fast (in benchmarks):
```
to_string/current       time:   [23.257 ns 23.766 ns 24.292 ns]
to_string/buffer        time:   [11.992 ns 12.068 ns 12.173 ns]
```

Benefits comes from avoiding the heap, avoiding the `.unwrap` and avoiding the utf8 check as it uses the unchecked version internally; finally, it should also result in a smaller binary size (though it will not be noticeable).

# Changes
Use `const_hex::Buffer::<N, PREFIX>::new()` for all code serializing fixed sized bytes.
Also cleans up 2 implementations for variable length bytes serialization.

## How to test
all tests should still pass as this should not introduce any behavior changes.