### PR TITLE
Use the widening mul_ratio helper in the driver fee-to-sell-token conversion

### DIFF
--- a/crates/driver/src/domain/competition/solution/fee.rs
+++ b/crates/driver/src/domain/competition/solution/fee.rs
@@ -34,6 +34,7 @@ use {
     },
     bigdecimal::Zero,
     eth_domain_types as eth,
+    number::u256_ext::U256Ext,
 };
 
 impl Fulfillment {
@@ -207,14 +208,16 @@ impl Fulfillment {
     ) -> Result<eth::TokenAmount, Error> {
         let fee_in_sell_token = match self.order().side {
             Side::Buy => self.protocol_fee(prices, protocol_fee)?,
-            Side::Sell => self
-                .protocol_fee(prices, protocol_fee)?
-                .0
-                .checked_mul(prices.buy)
-                .ok_or(Math::Overflow)?
-                .checked_div(prices.sell)
-                .ok_or(Math::DivisionByZero)?
-                .into(),
+            Side::Sell => {
+                if prices.sell.is_zero() {
+                    return Err(Math::DivisionByZero.into());
+                }
+                self.protocol_fee(prices, protocol_fee)?
+                    .0
+                    .checked_mul_ratio(&prices.buy, &prices.sell)
+                    .ok_or(Math::Overflow)?
+                    .into()
+            }
         };
         Ok(fee_in_sell_token)
     }


### PR DESCRIPTION
# Description
Companion to #4669. The driver's `protocol_fee_in_sell_token` converts a buy-token fee into the sell token by multiplying with the solution's clearing prices in 256 bits, the same unwidened pattern that zeroed 26 executions on xdai when a solver scaled its prices to 1e60. Here the input is a `/solve` response rather than solver-authored calldata, so nothing has broken yet, but an overflow silently discards an otherwise valid solution and puts an arbitrary cap on how solvers may scale their solution prices.

The conversion now goes through `number::U256Ext::checked_mul_ratio`, the shared helper #4669 introduced (the driver's own `util::math` wrappers were folded into it there).

# Changes
- `protocol_fee_in_sell_token` uses `checked_mul_ratio` with an explicit zero-divisor guard, preserving the `DivisionByZero` vs `Overflow` distinction

# How to test
Existing tests. The conversion now delegates to `checked_mul_ratio`, whose unit tests already cover the widening and rounding behavior; a fixture-heavy test at this level would only re-prove the helper.

# Related issues
Fixes #4670
