### PR TITLE
Return Result from the mul-ratio helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6858,6 +6858,7 @@ dependencies = [
  "ruint",
  "serde",
  "serde_with",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/crates/autopilot/src/domain/settlement/trade/math.rs
+++ b/crates/autopilot/src/domain/settlement/trade/math.rs
@@ -39,19 +39,14 @@ impl Trade {
         match self.side {
             order::Side::Buy => {
                 // scale limit sell to support partially fillable orders
-                if price_limits.buy.0.is_zero() || prices.sell.is_zero() {
-                    return Err(error::Math::DivisionByZero);
-                }
                 let limit_sell = price_limits
                     .sell
                     .0
-                    .checked_mul_ratio(&self.executed.into(), &price_limits.buy.0)
-                    .ok_or(error::Math::Overflow)?;
+                    .checked_mul_ratio(&self.executed.into(), &price_limits.buy.0)?;
                 let sold = self
                     .executed
                     .0
-                    .checked_mul_ratio(&prices.buy, &prices.sell)
-                    .ok_or(error::Math::Overflow)?;
+                    .checked_mul_ratio(&prices.buy, &prices.sell)?;
                 limit_sell.checked_sub(sold).ok_or(error::Math::Negative)
             }
             order::Side::Sell => {
@@ -61,19 +56,14 @@ impl Trade {
                 // traded buy amounts
                 // smallest allowed executed_buy_amount per settlement contract is
                 // executed_sell_amount * ceil(price_limits.buy / price_limits.sell)
-                if price_limits.sell.0.is_zero() || prices.buy.is_zero() {
-                    return Err(error::Math::DivisionByZero);
-                }
                 let limit_buy = self
                     .executed
                     .0
-                    .checked_mul_ratio_ceil(&price_limits.buy.0, &price_limits.sell.0)
-                    .ok_or(error::Math::Overflow)?;
+                    .checked_mul_ratio_ceil(&price_limits.buy.0, &price_limits.sell.0)?;
                 let bought = self
                     .executed
                     .0
-                    .checked_mul_ratio_ceil(&prices.sell, &prices.buy)
-                    .ok_or(error::Math::Overflow)?;
+                    .checked_mul_ratio_ceil(&prices.sell, &prices.buy)?;
                 bought.checked_sub(limit_buy).ok_or(error::Math::Negative)
             }
         }
@@ -110,14 +100,10 @@ impl Trade {
     ) -> Result<eth::SellTokenAmount, Error> {
         let fee_in_sell_token = match self.side {
             order::Side::Buy => fee.0,
-            order::Side::Sell => {
-                if self.prices.uniform.sell.is_zero() {
-                    return Err(error::Math::DivisionByZero.into());
-                }
-                fee.0
-                    .checked_mul_ratio(&self.prices.uniform.buy, &self.prices.uniform.sell)
-                    .ok_or(error::Math::Overflow)?
-            }
+            order::Side::Sell => fee
+                .0
+                .checked_mul_ratio(&self.prices.uniform.buy, &self.prices.uniform.sell)
+                .map_err(error::Math::from)?,
         };
         Ok(eth::SellTokenAmount(fee_in_sell_token))
     }
@@ -187,15 +173,10 @@ impl Trade {
     fn sell_amount(&self) -> Result<eth::TokenAmount, error::Math> {
         Ok(match self.side {
             order::Side::Sell => self.executed.0,
-            order::Side::Buy => {
-                if self.prices.custom.sell.is_zero() {
-                    return Err(error::Math::DivisionByZero);
-                }
-                self.executed
-                    .0
-                    .checked_mul_ratio(&self.prices.custom.buy, &self.prices.custom.sell)
-                    .ok_or(error::Math::Overflow)?
-            }
+            order::Side::Buy => self
+                .executed
+                .0
+                .checked_mul_ratio(&self.prices.custom.buy, &self.prices.custom.sell)?,
         }
         .into())
     }
@@ -207,15 +188,10 @@ impl Trade {
     /// Settlement contract uses `ceil` division for buy amount calculation.
     fn buy_amount(&self) -> Result<eth::TokenAmount, error::Math> {
         Ok(match self.side {
-            order::Side::Sell => {
-                if self.prices.custom.buy.is_zero() {
-                    return Err(error::Math::DivisionByZero);
-                }
-                self.executed
-                    .0
-                    .checked_mul_ratio_ceil(&self.prices.custom.sell, &self.prices.custom.buy)
-                    .ok_or(error::Math::Overflow)?
-            }
+            order::Side::Sell => self
+                .executed
+                .0
+                .checked_mul_ratio_ceil(&self.prices.custom.sell, &self.prices.custom.buy)?,
             order::Side::Buy => self.executed.0,
         }
         .into())
@@ -552,6 +528,15 @@ pub mod error {
         DivisionByZero,
         #[error("negative")]
         Negative,
+    }
+
+    impl From<number::MathError> for Math {
+        fn from(err: number::MathError) -> Self {
+            match err {
+                number::MathError::DivisionByZero => Self::DivisionByZero,
+                number::MathError::Overflow => Self::Overflow,
+            }
+        }
     }
 }
 

--- a/crates/driver/src/domain/competition/solution/fee.rs
+++ b/crates/driver/src/domain/competition/solution/fee.rs
@@ -208,16 +208,12 @@ impl Fulfillment {
     ) -> Result<eth::TokenAmount, Error> {
         let fee_in_sell_token = match self.order().side {
             Side::Buy => self.protocol_fee(prices, protocol_fee)?,
-            Side::Sell => {
-                if prices.sell.is_zero() {
-                    return Err(Math::DivisionByZero.into());
-                }
-                self.protocol_fee(prices, protocol_fee)?
-                    .0
-                    .checked_mul_ratio(&prices.buy, &prices.sell)
-                    .ok_or(Math::Overflow)?
-                    .into()
-            }
+            Side::Sell => self
+                .protocol_fee(prices, protocol_fee)?
+                .0
+                .checked_mul_ratio(&prices.buy, &prices.sell)
+                .map_err(Math::from)?
+                .into(),
         };
         Ok(fee_in_sell_token)
     }

--- a/crates/driver/src/domain/competition/solution/mod.rs
+++ b/crates/driver/src/domain/competition/solution/mod.rs
@@ -717,6 +717,15 @@ pub mod error {
         Negative,
     }
 
+    impl From<number::MathError> for Math {
+        fn from(err: number::MathError) -> Self {
+            match err {
+                number::MathError::DivisionByZero => Self::DivisionByZero,
+                number::MathError::Overflow => Self::Overflow,
+            }
+        }
+    }
+
     #[derive(Debug, thiserror::Error)]
     pub enum Solution {
         #[error("invalid clearing prices")]

--- a/crates/number/Cargo.toml
+++ b/crates/number/Cargo.toml
@@ -13,6 +13,7 @@ num = { workspace = true }
 ruint = { workspace = true, features = ["num-bigint"] }
 serde = { workspace = true }
 serde_with = { workspace = true }
+thiserror = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/number/src/lib.rs
+++ b/crates/number/src/lib.rs
@@ -4,4 +4,6 @@ pub mod ratio_ext;
 pub mod serialization;
 pub mod testing;
 pub mod u256_ext;
+
+pub use u256_ext::MathError;
 pub mod units;

--- a/crates/number/src/u256_ext.rs
+++ b/crates/number/src/u256_ext.rs
@@ -5,6 +5,15 @@ use {
     num::{BigInt, BigRational, BigUint, One},
 };
 
+/// Why a checked arithmetic computation failed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum MathError {
+    #[error("division by zero")]
+    DivisionByZero,
+    #[error("result does not fit in 256 bits")]
+    Overflow,
+}
+
 /// Extension trait for U256 to add utility methods.
 pub trait U256Ext: Sized {
     /// Ceiling division: (self + other - 1) / other
@@ -35,14 +44,12 @@ pub trait U256Ext: Sized {
     fn checked_mul_f64(&self, factor: f64) -> Option<Self>;
 
     /// Computes `self * mul / div` rounding down, widening the intermediate
-    /// product to 512 bits so it cannot overflow. Returns `None` if `div` is
-    /// zero or the final result does not fit in 256 bits.
-    fn checked_mul_ratio(&self, mul: &Self, div: &Self) -> Option<Self>;
+    /// product to 512 bits so it cannot overflow.
+    fn checked_mul_ratio(&self, mul: &Self, div: &Self) -> Result<Self, MathError>;
 
     /// Computes `self * mul / div` rounding up, widening the intermediate
-    /// product to 512 bits so it cannot overflow. Returns `None` if `div` is
-    /// zero or the final result does not fit in 256 bits.
-    fn checked_mul_ratio_ceil(&self, mul: &Self, div: &Self) -> Option<Self>;
+    /// product to 512 bits so it cannot overflow.
+    fn checked_mul_ratio_ceil(&self, mul: &Self, div: &Self) -> Result<Self, MathError>;
 
     /// Convert to BigRational.
     fn to_big_rational(&self) -> BigRational;
@@ -65,31 +72,34 @@ impl U256Ext for U256 {
         (!other.is_zero()).then(|| self.div_ceil(*other))
     }
 
-    fn checked_mul_ratio(&self, mul: &Self, div: &Self) -> Option<Self> {
+    fn checked_mul_ratio(&self, mul: &Self, div: &Self) -> Result<Self, MathError> {
         if div.is_zero() {
-            return None;
+            return Err(MathError::DivisionByZero);
         }
         // fast path when the product fits 256 bits
         if let Some(product) = self.checked_mul(*mul) {
-            return Some(product / div);
+            return Ok(product / div);
         }
         let product = self.widening_mul(*mul);
-        U256::uint_try_from(product / U512::from(*div)).ok()
+        U256::uint_try_from(product / U512::from(*div)).map_err(|_| MathError::Overflow)
     }
 
-    fn checked_mul_ratio_ceil(&self, mul: &Self, div: &Self) -> Option<Self> {
+    fn checked_mul_ratio_ceil(&self, mul: &Self, div: &Self) -> Result<Self, MathError> {
         if div.is_zero() {
-            return None;
+            return Err(MathError::DivisionByZero);
         }
         // fast path when the product fits 256 bits
         if let Some(product) = self.checked_mul(*mul) {
             let (quotient, remainder) = product.div_rem(*div);
-            return quotient.checked_add(U256::from(!remainder.is_zero()));
+            return quotient
+                .checked_add(U256::from(!remainder.is_zero()))
+                .ok_or(MathError::Overflow);
         }
         let (quotient, remainder) = self.widening_mul(*mul).div_rem(U512::from(*div));
         U256::uint_try_from(quotient)
-            .ok()?
+            .map_err(|_| MathError::Overflow)?
             .checked_add(U256::from(!remainder.is_zero()))
+            .ok_or(MathError::Overflow)
     }
 
     fn checked_mul_f64(&self, factor: f64) -> Option<Self> {
@@ -253,9 +263,15 @@ mod tests {
     #[test]
     fn mul_ratio_rejects_zero_divisor_and_overflowing_result() {
         let two = U256::from(2);
-        assert_eq!(two.checked_mul_ratio(&two, &U256::ZERO), None);
-        assert_eq!(U256::MAX.checked_mul_ratio(&two, &U256::from(1)), None);
-        assert_eq!(U256::MAX.checked_mul_ratio(&two, &two), Some(U256::MAX));
+        assert_eq!(
+            two.checked_mul_ratio(&two, &U256::ZERO),
+            Err(MathError::DivisionByZero)
+        );
+        assert_eq!(
+            U256::MAX.checked_mul_ratio(&two, &U256::from(1)),
+            Err(MathError::Overflow)
+        );
+        assert_eq!(U256::MAX.checked_mul_ratio(&two, &two), Ok(U256::MAX));
     }
 
     #[test]
@@ -264,20 +280,20 @@ mod tests {
         let three = U256::from(3);
         let two = U256::from(2);
         // 7 * 2 / 3 = 4.67
-        assert_eq!(seven.checked_mul_ratio(&two, &three), Some(U256::from(4)));
+        assert_eq!(seven.checked_mul_ratio(&two, &three), Ok(U256::from(4)));
         assert_eq!(
             seven.checked_mul_ratio_ceil(&two, &three),
-            Some(U256::from(5))
+            Ok(U256::from(5))
         );
         // exact division does not round up
         assert_eq!(
             U256::from(6).checked_mul_ratio_ceil(&two, &three),
-            Some(U256::from(4))
+            Ok(U256::from(4))
         );
         // large values on the fast path
         assert_eq!(
             U256::from(u128::MAX).checked_mul_ratio(&two, &U256::from(4)),
-            Some(U256::from(u128::MAX / 2))
+            Ok(U256::from(u128::MAX / 2))
         );
     }
 }


### PR DESCRIPTION
# Description
This PR addresses #4671's review comments. `checked_mul_ratio` and `checked_mul_ratio_ceil` detect a zero divisor internally but returned `Option`, so every call site that wanted to report `DivisionByZero` separately from `Overflow` had to check the divisor a second time before calling. The helpers now return `Result` carrying the failure reason, and the duplicated pre-checks are gone.

# Changes
- new `MathError` exported from the `number` crate (generic, not tied to mul-ratio, so future checked ops can reuse it), both helpers return `Result<U256, MathError>` instead of `Option`
- the autopilot and driver `Math` error enums get `From<MathError>` impls, replacing the per-call-site zero-divisor pre-checks
- call sites that discard the error keep erasing it with `unwrap_or_default()`

# How to test
Updated unit tests.
