### PR TITLE
Add a metric for settlement fee and surplus calculation failures

### DIFF
--- a/crates/autopilot/src/domain/mod.rs
+++ b/crates/autopilot/src/domain/mod.rs
@@ -21,6 +21,11 @@ pub struct Metrics {
     /// Tracks settlements that couldn't be matched to the database solutions.
     #[metric(labels("solver_address"))]
     pub inconsistent_settlements: prometheus::IntCounterVec,
+
+    /// Tracks trades whose surplus, fee or fee breakdown calculation failed
+    /// and fell back to zeroed values.
+    #[metric(labels("kind"))]
+    pub settlement_math_errors: prometheus::IntCounterVec,
 }
 
 impl Metrics {

--- a/crates/autopilot/src/domain/mod.rs
+++ b/crates/autopilot/src/domain/mod.rs
@@ -32,4 +32,17 @@ impl Metrics {
     fn get() -> &'static Self {
         Metrics::instance(observe::metrics::get_storage_registry()).unwrap()
     }
+
+    /// Publishes every `settlement_math_errors` series at zero. A counter that
+    /// only appears with the first failure is born reading one, leaving
+    /// `increase()` nothing to subtract from, so the alert would miss that
+    /// first failure and only catch the second one.
+    pub(crate) fn init_settlement_math_errors() {
+        for kind in ["surplus", "fee", "fee_breakdown"] {
+            Self::get()
+                .settlement_math_errors
+                .with_label_values(&[kind])
+                .reset();
+        }
+    }
 }

--- a/crates/autopilot/src/domain/settlement/mod.rs
+++ b/crates/autopilot/src/domain/settlement/mod.rs
@@ -106,6 +106,10 @@ impl Settlement {
                             trade = %trade.uid(),
                             "possible incomplete surplus calculation",
                         );
+                        Metrics::get()
+                            .settlement_math_errors
+                            .with_label_values(&["surplus"])
+                            .inc();
                         num::zero()
                     });
             surplus = surplus + trade_surplus;
@@ -118,6 +122,10 @@ impl Settlement {
                         trade = %trade.uid(),
                         "possible incomplete fee calculation",
                     );
+                    Metrics::get()
+                        .settlement_math_errors
+                        .with_label_values(&["fee"])
+                        .inc();
                     num::zero()
                 });
             fee = fee + trade_fee;
@@ -128,6 +136,10 @@ impl Settlement {
                     trade = %trade.uid(),
                     "possible incomplete fee breakdown calculation",
                 );
+                Metrics::get()
+                    .settlement_math_errors
+                    .with_label_values(&["fee_breakdown"])
+                    .inc();
                 trade::FeeBreakdown {
                     total: eth::Asset {
                         token: trade.sell_token(),

--- a/crates/autopilot/src/domain/settlement/observer.rs
+++ b/crates/autopilot/src/domain/settlement/observer.rs
@@ -12,7 +12,10 @@
 
 use {
     crate::{
-        domain::settlement::{self, Settlement},
+        domain::{
+            Metrics,
+            settlement::{self, Settlement},
+        },
         infra,
     },
     anyhow::{Context, Result, anyhow},
@@ -31,6 +34,7 @@ impl Observer {
     /// Creates a new Observer and asynchronously schedules the first update
     /// run.
     pub fn new(eth: infra::Ethereum, persistence: infra::Persistence) -> Self {
+        Metrics::init_settlement_math_errors();
         Self { eth, persistence }
     }
 


### PR DESCRIPTION
# Description
Fee and surplus math failures in the settlement observer only show up as warn logs. During the xdai incident (#4669) the observer persisted zeroed fees for two days before the solvers team spotted them in the DB, nobody was alerted.

We want an alert. Alerting off the warn line means matching its exact text, either through a Vector `log_to_metric` transform or a vmalert LogsQL rule. That coupling is fragile: reword the message and the metric silently stops counting while the alert keeps evaluating a flat zero, exactly the failure mode an alert must not have. A counter incremented next to the calculation cannot drift out of sync with the code.

The counter is also published at zero when the observer starts. A counter series does not exist in Prometheus until its first increment, so a series born with the first failure already reads one, `increase()` has nothing to subtract from, and the alert would sit quiet until a second failure arrived.

# Changes
- `settlement_math_errors` counter, labeled by calculation kind (`surplus`, `fee`, `fee_breakdown`), incremented whenever `summarize()` falls back to zeroed values
- all three series are published at zero when the settlement observer is constructed

# How to test
Existing tests. The alert rule on the new metric follows in the infrastructure repo:

```
sum by (network, kind) (increase(gp_v2_autopilot_domain_settlement_math_errors{cow_fi_environment="prod"}[6h])) > 0
```
