### PR TITLE
Add gas price for trade verification simulations

### DIFF
--- a/crates/price-estimation/src/trade_verifier.rs
+++ b/crates/price-estimation/src/trade_verifier.rs
@@ -212,7 +212,11 @@ impl TradeVerifier {
                 settle_call.calldata.clone(),
             )
             .from(*solver_contract.address())
-            .gas(self.simulator.max_gas_limit());
+            .gas(self.simulator.max_gas_limit())
+            // Verify the trade at a realistic gas price. Otherwise tokens that
+            // behave differently when they detect a gas price of 0 could make
+            // us verify a price that is not actually executable on-chain.
+            .gas_price(self.simulator.simulation_gas_price());
 
         Ok(SwapCall {
             tx_request: call.into_transaction_request(),

--- a/crates/simulator/src/simulation_builder.rs
+++ b/crates/simulator/src/simulation_builder.rs
@@ -92,6 +92,15 @@ impl SettlementSimulator {
         self.0.provider.clone()
     }
 
+    /// Gas price for simulations. Nodes default `eth_call`s without one to 0
+    /// and some sneaky tokens detect that to behave differently than they would
+    /// on-chain. Doubling the base fee leaves headroom in case it moved on
+    /// since we last saw a block; otherwise nodes reject the call for
+    /// having a fee cap below the base fee.
+    pub fn simulation_gas_price(&self) -> u128 {
+        u128::from(self.0.current_block.borrow().base_fee) * 2
+    }
+
     pub fn settlement_address(&self) -> Address {
         *self.0.settlement.address()
     }


### PR DESCRIPTION
# Description
Sets the gas price for simulations, this side steps code specific using `gas_price` set to 0 as a "sentinel" for simulations. For example: https://gist.wavey.info/B4lu8GXEyJQvlu4E5nJuyugF

Context: https://nomevlabs.slack.com/archives/C0361CDD1FZ/p1785144982673229

# Changes

* Set the gas_price for trade verification
