### PR TITLE
Single JSON serialization for DB and S3

### DIFF
--- a/crates/autopilot/src/database/auction.rs
+++ b/crates/autopilot/src/database/auction.rs
@@ -2,6 +2,7 @@ use {
     super::Postgres,
     crate::{boundary, domain, infra::persistence::dto},
     anyhow::{Context, Result},
+    bytes::Bytes,
     chrono::{DateTime, Utc},
     futures::{StreamExt, TryStreamExt},
     model::{order::Order, quote::QuoteId},
@@ -116,21 +117,17 @@ impl Postgres {
     pub async fn replace_current_auction(
         &self,
         new_auction_id: dto::AuctionId,
-        new_auction_data: dto::RawAuctionData,
+        json: Bytes,
     ) -> Result<()> {
         let _timer = super::Metrics::get()
             .database_queries
             .with_label_values(&["insert_auction_with_id"])
             .start_timer();
 
-        let data = tokio::task::spawn_blocking(move || {
-            serde_json::to_string(&new_auction_data).context("failed to serialize auction")
-        })
-        .await
-        .context("auction serialization task panicked")??;
+        let data = std::str::from_utf8(&json).context("serialized auction is not valid UTF-8")?;
 
         let mut ex = self.pool.acquire().await?;
-        database::auction::insert_auction_with_id(&mut ex, new_auction_id, &data).await?;
+        database::auction::insert_auction_with_id(&mut ex, new_auction_id, data).await?;
         Ok(())
     }
 }

--- a/crates/autopilot/src/infra/persistence/dto/auction.rs
+++ b/crates/autopilot/src/infra/persistence/dto/auction.rs
@@ -9,23 +9,24 @@ use {
     std::collections::BTreeMap,
 };
 
-pub fn from_domain(auction: domain::RawAuctionData) -> RawAuctionData {
+/// Converts the auction into the shape that gets archived to the DB and S3.
+///
+/// Takes the auction by reference so the caller can keep using it afterwards
+/// without a deep clone.
+pub fn from_domain(auction: &domain::RawAuctionData) -> RawAuctionData {
     RawAuctionData {
         block: auction.block,
         orders: auction
             .orders
-            .into_iter()
+            .iter()
             .map(super::order::from_domain)
             .collect(),
         prices: auction
             .prices
-            .into_iter()
-            .map(|(key, value)| (*key, value.get().0))
+            .iter()
+            .map(|(key, value)| (**key, value.get().0))
             .collect(),
-        surplus_capturing_jit_order_owners: auction
-            .surplus_capturing_jit_order_owners
-            .into_iter()
-            .collect(),
+        surplus_capturing_jit_order_owners: auction.surplus_capturing_jit_order_owners.clone(),
     }
 }
 

--- a/crates/autopilot/src/infra/persistence/dto/order.rs
+++ b/crates/autopilot/src/infra/persistence/dto/order.rs
@@ -44,7 +44,9 @@ pub struct Order {
     pub quote: Option<Quote>,
 }
 
-pub fn from_domain(order: domain::Order) -> Order {
+/// Takes the order by reference so callers that still need the domain order
+/// afterwards don't have to deep-clone it just to convert it.
+pub fn from_domain(order: &domain::Order) -> Order {
     Order {
         uid: order.uid.into(),
         sell_token: order.sell.token.into(),
@@ -53,7 +55,8 @@ pub fn from_domain(order: domain::Order) -> Order {
         buy_amount: order.buy.amount.into(),
         protocol_fees: order
             .protocol_fees
-            .into_iter()
+            .iter()
+            .copied()
             .map(FeePolicy::from_domain)
             .collect(),
         created: order.created,
@@ -63,18 +66,24 @@ pub fn from_domain(order: domain::Order) -> Order {
         owner: order.owner,
         partially_fillable: order.partially_fillable,
         executed: order.executed.into(),
-        pre_interactions: order.pre_interactions.into_iter().map(Into::into).collect(),
-        post_interactions: order
-            .post_interactions
-            .into_iter()
+        pre_interactions: order
+            .pre_interactions
+            .iter()
+            .cloned()
             .map(Into::into)
             .collect(),
-        sell_token_balance: order.sell_token_balance.into(),
-        buy_token_balance: order.buy_token_balance.into(),
+        post_interactions: order
+            .post_interactions
+            .iter()
+            .cloned()
+            .map(Into::into)
+            .collect(),
+        sell_token_balance: order.sell_token_balance.clone().into(),
+        buy_token_balance: order.buy_token_balance.clone().into(),
         class: boundary::OrderClass::Limit,
-        app_data: order.app_data.into(),
-        signature: order.signature.into(),
-        quote: order.quote.map(Quote::from_domain),
+        app_data: order.app_data.clone().into(),
+        signature: order.signature.clone().into(),
+        quote: order.quote.as_ref().map(Quote::from_domain),
     }
 }
 
@@ -346,7 +355,7 @@ pub struct Quote {
 }
 
 impl Quote {
-    fn from_domain(quote: domain::Quote) -> Self {
+    fn from_domain(quote: &domain::Quote) -> Self {
         Quote {
             sell_amount: quote.sell_amount.0,
             buy_amount: quote.buy_amount.0,

--- a/crates/autopilot/src/infra/persistence/mod.rs
+++ b/crates/autopilot/src/infra/persistence/mod.rs
@@ -83,12 +83,6 @@ impl Persistence {
         let (sender, mut receiver) = mpsc::unbounded_channel::<AuctionUpload>();
         tokio::task::spawn(async move {
             while let Some(upload) = receiver.recv().await {
-                // Started after `recv` so queue wait isn't counted as write time.
-                let _timer = Metrics::get()
-                    .auction_archive
-                    .with_label_values(&["database"])
-                    .start_timer();
-
                 if let Err(err) = db
                     .replace_current_auction(upload.auction_id, upload.json)
                     .await
@@ -215,12 +209,6 @@ impl Persistence {
             return;
         };
         tokio::task::spawn(async move {
-            // Covers gzip as well as the PUT, since `upload_json_bytes` compresses.
-            let _timer = Metrics::get()
-                .auction_archive
-                .with_label_values(&["s3"])
-                .start_timer();
-
             match s3.upload_json_bytes(id.to_string(), json).await {
                 Ok(key) => tracing::info!(?key, "uploaded auction to s3"),
                 Err(err) => tracing::warn!(?err, "failed to upload auction to s3"),
@@ -1061,16 +1049,6 @@ struct Metrics {
     /// Timing of db queries.
     #[metric(name = "persistence_database_queries", labels("type"))]
     database_queries: prometheus::HistogramVec,
-
-    /// Time spent writing an already serialized auction to each archive sink.
-    /// Both sinks run in background tasks, so this is off the run loop's
-    /// critical path.
-    #[metric(
-        name = "persistence_auction_archive",
-        labels("sink"),
-        buckets(0.01, 0.05, 0.1, 0.25, 0.5, 0.75, 1.0, 1.5, 2.0, 3.0, 5.0)
-    )]
-    auction_archive: prometheus::HistogramVec,
 }
 
 impl Metrics {

--- a/crates/autopilot/src/infra/persistence/mod.rs
+++ b/crates/autopilot/src/infra/persistence/mod.rs
@@ -6,13 +6,13 @@ use {
             self,
             settlement::{SettlementEvent, TradeEvent, transaction::EncodedTrade},
         },
-        infra::persistence::dto::RawAuctionData,
     },
     ::winner_selection::state::RankedItem,
     alloy::primitives::B256,
     anyhow::Context,
     bigdecimal::{BigDecimal, ToPrimitive},
     boundary::database::byte_array::ByteArray,
+    bytes::Bytes,
     chrono::{DateTime, Utc},
     database::{
         events::EventIndex,
@@ -58,8 +58,8 @@ pub struct Persistence {
 
 struct AuctionUpload {
     auction_id: domain::auction::Id,
-    /// Contains everything buy the auction_id.
-    auction_data: RawAuctionData,
+    /// The serialized auction, containing everything but the auction_id.
+    json: Bytes,
 }
 
 impl Persistence {
@@ -83,8 +83,14 @@ impl Persistence {
         let (sender, mut receiver) = mpsc::unbounded_channel::<AuctionUpload>();
         tokio::task::spawn(async move {
             while let Some(upload) = receiver.recv().await {
+                // Started after `recv` so queue wait isn't counted as write time.
+                let _timer = Metrics::get()
+                    .auction_archive
+                    .with_label_values(&["database"])
+                    .start_timer();
+
                 if let Err(err) = db
-                    .replace_current_auction(upload.auction_id, upload.auction_data)
+                    .replace_current_auction(upload.auction_id, upload.json)
                     .await
                 {
                     tracing::error!(?err, "failed to replace auction in DB");
@@ -151,33 +157,71 @@ impl Persistence {
             .map_err(DatabaseError)
     }
 
-    /// Spawns a background task that replaces the current auction in the DB
-    /// with the new one.
-    pub fn replace_current_auction_in_db(
+    /// Archives the auction to the DB and, if configured, to S3.
+    ///
+    /// The auction is moved onto the blocking pool to avoid a deep clone and
+    /// handed back to the caller.
+    #[instrument(skip_all)]
+    pub async fn archive_auction(
         &self,
-        new_auction_id: domain::auction::Id,
-        new_auction_data: &domain::RawAuctionData,
-    ) {
+        id: domain::auction::Id,
+        auction: domain::RawAuctionData,
+    ) -> domain::RawAuctionData {
+        let span = tracing::Span::current();
+        let (auction, json) = {
+            // Only the conversion and serialization are on the run loop's critical
+            // path; both sinks below hand off to background tasks.
+            let _timer = observe::metrics::metrics()
+                .on_auction_overhead_start("autopilot", "serialize_auction");
+
+            tokio::task::spawn_blocking(move || {
+                let json = span.in_scope(|| {
+                    let auction_data = dto::auction::from_domain(&auction);
+                    serde_json::to_vec(&auction_data).map(Bytes::from_owner)
+                });
+                (auction, json)
+            })
+            .await
+            .expect("auction conversion task panicked")
+        };
+        let json = match json {
+            Ok(json) => json,
+            Err(err) => {
+                tracing::error!(?err, ?id, "failed to serialize auction");
+                return auction;
+            }
+        };
+
+        // Enqueued before spawning the S3 upload so the queue keeps seeing
+        // auctions in the order the run loop cut them.
         self.upload_queue
             .send(AuctionUpload {
-                auction_id: new_auction_id,
-                auction_data: dto::auction::from_domain(new_auction_data.clone()),
+                auction_id: id,
+                json: json.clone(),
             })
             .expect("upload queue should be alive at all times");
+
+        if !auction.orders.is_empty() {
+            self.upload_auction_to_s3(id, json);
+        }
+
+        auction
     }
 
-    /// Spawns a background task that uploads the auction to S3.
-    pub fn upload_auction_to_s3(&self, id: domain::auction::Id, auction: &domain::RawAuctionData) {
-        if auction.orders.is_empty() {
-            return;
-        }
+    /// Spawns a background task that uploads the already serialized auction to
+    /// S3.
+    fn upload_auction_to_s3(&self, id: domain::auction::Id, json: Bytes) {
         let Some(s3) = self.s3.clone() else {
             return;
         };
-        let auction = auction.clone();
         tokio::task::spawn(async move {
-            let auction_dto = dto::auction::from_domain(auction);
-            match s3.upload(id.to_string(), auction_dto).await {
+            // Covers gzip as well as the PUT, since `upload_json_bytes` compresses.
+            let _timer = Metrics::get()
+                .auction_archive
+                .with_label_values(&["s3"])
+                .start_timer();
+
+            match s3.upload_json_bytes(id.to_string(), json).await {
                 Ok(key) => tracing::info!(?key, "uploaded auction to s3"),
                 Err(err) => tracing::warn!(?err, "failed to upload auction to s3"),
             }
@@ -1017,6 +1061,16 @@ struct Metrics {
     /// Timing of db queries.
     #[metric(name = "persistence_database_queries", labels("type"))]
     database_queries: prometheus::HistogramVec,
+
+    /// Time spent writing an already serialized auction to each archive sink.
+    /// Both sinks run in background tasks, so this is off the run loop's
+    /// critical path.
+    #[metric(
+        name = "persistence_auction_archive",
+        labels("sink"),
+        buckets(0.01, 0.05, 0.1, 0.25, 0.5, 0.75, 1.0, 1.5, 2.0, 3.0, 5.0)
+    )]
+    auction_archive: prometheus::HistogramVec,
 }
 
 impl Metrics {

--- a/crates/autopilot/src/infra/persistence/mod.rs
+++ b/crates/autopilot/src/infra/persistence/mod.rs
@@ -153,53 +153,43 @@ impl Persistence {
 
     /// Archives the auction to the DB and, if configured, to S3.
     ///
-    /// The auction is moved onto the blocking pool to avoid a deep clone and
-    /// handed back to the caller.
+    /// Only the conversion into the archival shape is on the run loop's
+    /// critical path; the serialization and both sinks happen in background
+    /// tasks. The auction is taken by reference so the conversion doesn't
+    /// need a deep clone.
     #[instrument(skip_all)]
-    pub async fn archive_auction(
-        &self,
-        id: domain::auction::Id,
-        auction: domain::RawAuctionData,
-    ) -> domain::RawAuctionData {
-        let span = tracing::Span::current();
-        let (auction, json) = {
-            // Only the conversion and serialization are on the run loop's critical
-            // path; both sinks below hand off to background tasks.
+    pub fn archive_auction(&self, id: domain::auction::Id, auction: &domain::RawAuctionData) {
+        let auction_data = {
             let _timer = observe::metrics::metrics()
-                .on_auction_overhead_start("autopilot", "serialize_auction");
-
-            tokio::task::spawn_blocking(move || {
-                let json = span.in_scope(|| {
-                    let auction_data = dto::auction::from_domain(&auction);
-                    serde_json::to_vec(&auction_data).map(Bytes::from_owner)
-                });
-                (auction, json)
-            })
-            .await
-            .expect("auction conversion task panicked")
-        };
-        let json = match json {
-            Ok(json) => json,
-            Err(err) => {
-                tracing::error!(?err, ?id, "failed to serialize auction");
-                return auction;
-            }
+                .on_auction_overhead_start("autopilot", "convert_auction");
+            dto::auction::from_domain(auction)
         };
 
-        // Enqueued before spawning the S3 upload so the queue keeps seeing
-        // auctions in the order the run loop cut them.
-        self.upload_queue
-            .send(AuctionUpload {
-                auction_id: id,
-                json: json.clone(),
+        let upload_to_s3 = !auction.orders.is_empty();
+        let this = self.clone();
+        let span = tracing::Span::current();
+        tokio::task::spawn_blocking(move || {
+            span.in_scope(|| {
+                let json = match serde_json::to_vec(&auction_data).map(Bytes::from) {
+                    Ok(json) => json,
+                    Err(err) => {
+                        tracing::error!(?err, ?id, "failed to serialize auction");
+                        return;
+                    }
+                };
+
+                this.upload_queue
+                    .send(AuctionUpload {
+                        auction_id: id,
+                        json: json.clone(),
+                    })
+                    .expect("upload queue should be alive at all times");
+
+                if upload_to_s3 {
+                    this.upload_auction_to_s3(id, json);
+                }
             })
-            .expect("upload queue should be alive at all times");
-
-        if !auction.orders.is_empty() {
-            self.upload_auction_to_s3(id, json);
-        }
-
-        auction
+        });
     }
 
     /// Spawns a background task that uploads the already serialized auction to

--- a/crates/autopilot/src/infra/solvers/dto/solve.rs
+++ b/crates/autopilot/src/infra/solvers/dto/solve.rs
@@ -50,12 +50,7 @@ impl Request {
             observe::metrics::metrics().on_auction_overhead_start("autopilot", "serialize_request");
         let helper = RequestHelper {
             id: auction.id,
-            orders: auction
-                .orders
-                .clone()
-                .into_iter()
-                .map(dto::order::from_domain)
-                .collect(),
+            orders: auction.orders.iter().map(dto::order::from_domain).collect(),
             tokens: auction
                 .prices
                 .iter()

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -315,8 +315,7 @@ impl RunLoop {
         Metrics::auction(id);
 
         // always update the auction because the tests use this as a readiness probe
-        self.persistence.replace_current_auction_in_db(id, &auction);
-        self.persistence.upload_auction_to_s3(id, &auction);
+        let auction = self.persistence.archive_auction(id, auction).await;
 
         if auction.orders.is_empty() {
             // Updating liveness probe to not report unhealthy due to this optimization

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -315,7 +315,7 @@ impl RunLoop {
         Metrics::auction(id);
 
         // always update the auction because the tests use this as a readiness probe
-        let auction = self.persistence.archive_auction(id, auction).await;
+        self.persistence.archive_auction(id, &auction);
 
         if auction.orders.is_empty() {
             // Updating liveness probe to not report unhealthy due to this optimization


### PR DESCRIPTION
# Description
Serialize the raw auction data a single data, instead of one per persistence method

# Changes

* Replaces the S3 and DB upload functions with a single one that serializes the JSON once

## How to test
Ran it last night in mainnet prod, the dip around 22 was when it was deployed

<img width="2004" height="646" alt="Screenshot 2026-07-29 at 09-03-33 Edit panel - Critical Latency Metrics - Dashboards - Amazon Managed Grafana" src="https://github.com/user-attachments/assets/fe7ebb31-5c68-4ae6-a100-5905e5db5f08" />

