### PR TITLE
don't instrument long lived tasks

### DIFF
--- a/crates/account-balances/src/cached.rs
+++ b/crates/account-balances/src/cached.rs
@@ -119,40 +119,45 @@ impl Balances {
 
         let task = async move {
             while let Some(block) = stream.next().await {
-                let balances_to_update = {
+                async {
+                    let balances_to_update = {
+                        let mut cache = cache.lock().unwrap();
+                        cache.last_seen_block = block.number;
+                        cache
+                            .data
+                            .iter()
+                            .filter_map(|(query, entry)| {
+                                // Only update balances that have been requested recently.
+                                let oldest_allowed_request =
+                                    cache.last_seen_block.saturating_sub(EVICTION_TIME);
+                                (entry.requested_at >= oldest_allowed_request)
+                                    .then_some(query.clone())
+                            })
+                            .collect_vec()
+                    };
+
+                    let results = inner.get_balances(&balances_to_update).await;
+
                     let mut cache = cache.lock().unwrap();
-                    cache.last_seen_block = block.number;
-                    cache
-                        .data
-                        .iter()
-                        .filter_map(|(query, entry)| {
-                            // Only update balances that have been requested recently.
-                            let oldest_allowed_request =
-                                cache.last_seen_block.saturating_sub(EVICTION_TIME);
-                            (entry.requested_at >= oldest_allowed_request).then_some(query.clone())
-                        })
-                        .collect_vec()
-                };
-
-                let results = inner.get_balances(&balances_to_update).await;
-
-                let mut cache = cache.lock().unwrap();
-                balances_to_update
-                    .into_iter()
-                    .zip(results)
-                    .for_each(|(query, result)| {
-                        if let Ok(balance) = result {
-                            cache.update_balance(&query, balance, block.number);
-                        }
+                    balances_to_update
+                        .into_iter()
+                        .zip(results)
+                        .for_each(|(query, result)| {
+                            if let Ok(balance) = result {
+                                cache.update_balance(&query, balance, block.number);
+                            }
+                        });
+                    cache.data.retain(|_, value| {
+                        // Only keep balances where we know we have the most recent data.
+                        value.updated_at >= block.number
                     });
-                cache.data.retain(|_, value| {
-                    // Only keep balances where we know we have the most recent data.
-                    value.updated_at >= block.number
-                });
+                }
+                .instrument(tracing::info_span!("balance_cache"))
+                .await;
             }
             tracing::error!("block stream terminated unexpectedly");
         };
-        tokio::spawn(task.instrument(tracing::info_span!("balance_cache")));
+        tokio::spawn(task);
     }
 }
 

--- a/crates/account-balances/src/cached.rs
+++ b/crates/account-balances/src/cached.rs
@@ -2,7 +2,7 @@ use {
     crate::{BalanceFetching, Query, TransferSimulationError},
     alloy_primitives::{Address, U256},
     anyhow::Result,
-    ethrpc::block_stream::{CurrentBlockWatcher, into_stream},
+    ethrpc::block_stream::{BlockInfo, CurrentBlockWatcher, into_stream},
     futures::StreamExt,
     itertools::Itertools,
     model::order::SellTokenSource,
@@ -10,7 +10,7 @@ use {
         collections::HashMap,
         sync::{Arc, Mutex},
     },
-    tracing::{Instrument, instrument},
+    tracing::instrument,
 };
 
 type BlockNumber = u64;
@@ -119,45 +119,51 @@ impl Balances {
 
         let task = async move {
             while let Some(block) = stream.next().await {
-                async {
-                    let balances_to_update = {
-                        let mut cache = cache.lock().unwrap();
-                        cache.last_seen_block = block.number;
-                        cache
-                            .data
-                            .iter()
-                            .filter_map(|(query, entry)| {
-                                // Only update balances that have been requested recently.
-                                let oldest_allowed_request =
-                                    cache.last_seen_block.saturating_sub(EVICTION_TIME);
-                                (entry.requested_at >= oldest_allowed_request)
-                                    .then_some(query.clone())
-                            })
-                            .collect_vec()
-                    };
-
-                    let results = inner.get_balances(&balances_to_update).await;
-
-                    let mut cache = cache.lock().unwrap();
-                    balances_to_update
-                        .into_iter()
-                        .zip(results)
-                        .for_each(|(query, result)| {
-                            if let Ok(balance) = result {
-                                cache.update_balance(&query, balance, block.number);
-                            }
-                        });
-                    cache.data.retain(|_, value| {
-                        // Only keep balances where we know we have the most recent data.
-                        value.updated_at >= block.number
-                    });
-                }
-                .instrument(tracing::info_span!("balance_cache"))
-                .await;
+                Self::refresh_balances(inner.as_ref(), &cache, block).await;
             }
             tracing::error!("block stream terminated unexpectedly");
         };
         tokio::spawn(task);
+    }
+
+    /// Updates all balances there were used recently enough. All other
+    /// balances get evicted from the cache.
+    #[instrument(skip_all)]
+    async fn refresh_balances(
+        fetcher: &dyn BalanceFetching,
+        cache: &Mutex<BalanceCache>,
+        block: BlockInfo,
+    ) {
+        let balances_to_update = {
+            let mut cache = cache.lock().unwrap();
+            cache.last_seen_block = block.number;
+            cache
+                .data
+                .iter()
+                .filter_map(|(query, entry)| {
+                    // Only update balances that have been requested recently.
+                    let oldest_allowed_request =
+                        cache.last_seen_block.saturating_sub(EVICTION_TIME);
+                    (entry.requested_at >= oldest_allowed_request).then_some(query.clone())
+                })
+                .collect_vec()
+        };
+
+        let results = fetcher.get_balances(&balances_to_update).await;
+
+        let mut cache = cache.lock().unwrap();
+        balances_to_update
+            .into_iter()
+            .zip(results)
+            .for_each(|(query, result)| {
+                if let Ok(balance) = result {
+                    cache.update_balance(&query, balance, block.number);
+                }
+            });
+        cache.data.retain(|_, value| {
+            // Only keep balances where we know we have the most recent data.
+            value.updated_at >= block.number
+        });
     }
 }
 

--- a/crates/account-balances/src/simulation.rs
+++ b/crates/account-balances/src/simulation.rs
@@ -11,7 +11,6 @@ use {
     ethrpc::{Web3, alloy::ProviderLabelingExt},
     futures::future,
     model::order::SellTokenSource,
-    tracing::instrument,
 };
 
 pub struct Balances {
@@ -77,7 +76,6 @@ impl Balances {
 
 #[async_trait::async_trait]
 impl BalanceFetching for Balances {
-    #[instrument(skip_all)]
     async fn get_balances(&self, queries: &[Query]) -> Vec<Result<U256>> {
         // TODO(nlordell): Use `Multicall` here to use fewer node round-trips
         let futures = queries
@@ -128,7 +126,6 @@ impl BalanceFetching for Balances {
         Ok(())
     }
 
-    #[instrument(skip(self))]
     async fn allowance(
         &self,
         owner: Address,

--- a/crates/autopilot/src/database/mod.rs
+++ b/crates/autopilot/src/database/mod.rs
@@ -6,7 +6,7 @@ use {
         num::{NonZeroU32, NonZeroUsize},
         time::Duration,
     },
-    tracing::{Instrument, instrument},
+    tracing::instrument,
 };
 
 mod auction;

--- a/crates/autopilot/src/database/mod.rs
+++ b/crates/autopilot/src/database/mod.rs
@@ -6,7 +6,7 @@ use {
         num::{NonZeroU32, NonZeroUsize},
         time::Duration,
     },
-    tracing::Instrument,
+    tracing::{Instrument, instrument},
 };
 
 mod auction;
@@ -76,6 +76,7 @@ impl Postgres {
         Self::new("postgresql://", Default::default()).await
     }
 
+    #[instrument(skip_all)]
     pub async fn update_database_metrics(&self) -> sqlx::Result<()> {
         let metrics = Metrics::get();
 
@@ -96,6 +97,7 @@ impl Postgres {
         Ok(())
     }
 
+    #[instrument(skip_all)]
     pub async fn update_large_tables_stats(&self) -> sqlx::Result<()> {
         let mut ex = self.pool.acquire().await?;
         for &table in database::LARGE_TABLES {
@@ -167,11 +169,10 @@ impl Metrics {
 }
 
 pub fn run_database_metrics_work(db: Postgres) {
-    let span = tracing::info_span!("database_metrics");
     // Spawn the task for updating large table statistics
-    tokio::spawn(update_large_tables_stats(db.clone()).instrument(span.clone()));
+    tokio::spawn(update_large_tables_stats(db.clone()));
     // Spawn the task for database metrics
-    tokio::task::spawn(database_metrics(db).instrument(span));
+    tokio::task::spawn(database_metrics(db));
 }
 
 async fn database_metrics(db: Postgres) -> ! {

--- a/crates/autopilot/src/database/order_events.rs
+++ b/crates/autopilot/src/database/order_events.rs
@@ -6,10 +6,12 @@ use {
     database::{byte_array::ByteArray, order_events},
     sqlx::{Acquire, Error, PgConnection},
     tokio::time::Instant,
+    tracing::instrument,
 };
 
 impl super::Postgres {
     /// Deletes events before the provided timestamp.
+    #[instrument(skip_all)]
     pub async fn delete_order_events_before(&self, timestamp: DateTime<Utc>) -> Result<u64, Error> {
         order_events::delete_order_events_before(&self.pool, timestamp).await
     }

--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -535,11 +535,7 @@ pub async fn run(config: Configuration, shutdown_controller: ShutdownController)
         db_write.clone(),
     );
 
-    tokio::task::spawn(
-        order_events_cleaner
-            .run_forever()
-            .instrument(tracing::info_span!("order_events_cleaner")),
-    );
+    tokio::task::spawn(order_events_cleaner.run_forever());
 
     let market_makable_token_list_configuration = TokenListConfiguration {
         url: config.trusted_tokens.url.clone(),

--- a/crates/event-indexing/src/maintenance.rs
+++ b/crates/event-indexing/src/maintenance.rs
@@ -87,7 +87,6 @@ impl ServiceMaintenance {
 
     pub async fn run_maintenance_on_new_block(self, current_block_stream: CurrentBlockWatcher) {
         self.run_maintenance_for_blocks(block_stream::into_stream(current_block_stream))
-            .instrument(tracing::info_span!("service_maintenance"))
             .await
             .expect("maintenance task terminated with error");
     }

--- a/crates/liquidity-sources/src/recent_block_cache.rs
+++ b/crates/liquidity-sources/src/recent_block_cache.rs
@@ -203,21 +203,22 @@ where
         block_stream: CurrentBlockWatcher,
         label: String,
     ) {
-        tokio::task::spawn(
-            async move {
-                let mut stream = ethrpc::block_stream::into_stream(block_stream);
-                while let Some(block) = stream.next().await {
-                    let Some(inner) = inner.upgrade() else {
-                        tracing::debug!("cache no longer in use; terminate GC task");
-                        break;
-                    };
-                    if let Err(err) = inner.update_cache_at_block(block.number).await {
-                        tracing::warn!(?err, "failed to update cache");
-                    }
+        tokio::task::spawn(async move {
+            let mut stream = ethrpc::block_stream::into_stream(block_stream);
+            while let Some(block) = stream.next().await {
+                let Some(inner) = inner.upgrade() else {
+                    tracing::debug!("cache no longer in use; terminate GC task");
+                    break;
+                };
+                if let Err(err) = inner
+                    .update_cache_at_block(block.number)
+                    .instrument(tracing::info_span!("cache_maintenance", cache = %label))
+                    .await
+                {
+                    tracing::warn!(?err, "failed to update cache");
                 }
             }
-            .instrument(tracing::info_span!("cache_maintenance", cache = label)),
-        );
+        });
     }
 }
 

--- a/crates/price-estimation/src/native_price_cache.rs
+++ b/crates/price-estimation/src/native_price_cache.rs
@@ -476,12 +476,14 @@ impl NativePriceUpdater {
         let update_task = async move {
             while let Some(updater) = weak.upgrade() {
                 let now = Instant::now();
-                updater.single_update(prefetch_time).await;
+                updater
+                    .single_update(prefetch_time)
+                    .instrument(tracing::info_span!("native_price_updater"))
+                    .await;
                 drop(updater);
                 tokio::time::sleep(update_interval.saturating_sub(now.elapsed())).await;
             }
-        }
-        .instrument(tracing::info_span!("native_price_updater"));
+        };
         tokio::spawn(update_task);
 
         updater

--- a/crates/shared/src/token_list.rs
+++ b/crates/shared/src/token_list.rs
@@ -9,7 +9,7 @@ use {
         sync::{Arc, RwLock},
         time::Duration,
     },
-    tracing::{Instrument, instrument},
+    tracing::instrument,
 };
 
 #[derive(Clone, Debug, Default)]

--- a/crates/shared/src/token_list.rs
+++ b/crates/shared/src/token_list.rs
@@ -85,7 +85,7 @@ impl AutoUpdatingTokenList {
                     }
                 }
             };
-            tokio::task::spawn(updater.instrument(tracing::info_span!("auto_updating_token_list")));
+            tokio::task::spawn(updater);
         }
 
         Self { tokens }


### PR DESCRIPTION
# Description
Spans are tree structures that are kept alive until the root of the span goes away. Currently we have a bunch of background tasks that run forever and keep the same span root alive for days. From the perspective of tracing and especially opentelemetry the entire background task is considered a single unit of work.

I'm pretty sure I came across an article about exactly this anti pattern (instrumenting long lived tasks with the exact same span) but unfortunately I was not able to find it to link here. 

Handling those leads to many errors like this where the tempo machinery complains that a given trace is too large:
> level=warn ts=2026-07-29T07:08:12.908405317Z caller=rate_limited_logger.go:38 tenant=single-tenant msg=TRACE_TOO_LARGE max=5000000 size=99226 trace=9d02f3f099c26373766e8cf7feb21e9b

This becomes especially obvious when you search for those specific trace ids. Vector is able to show that the same span exists for a very long time.
<img width="1840" height="501" alt="Screenshot 2026-07-29 at 08 22 32" src="https://github.com/user-attachments/assets/811568ef-d1be-470a-a585-d119ab01b92c" />

But searching that specific trace in tempo will crash the infra.

I'm also hoping that this might at least reduce the insane CPU usage of the tempo ingesters. Every ingester pod, which we have 3 of, has CPU spikes every 10m which increase the CPU usage by 2 cores per pod for 2m. I'm hoping that this might be a side effect from our crazy large spans.
<img width="1182" height="385" alt="Screenshot 2026-07-29 at 08 33 52" src="https://github.com/user-attachments/assets/1ba0e774-2684-402f-89f1-d025459e1699" />

# Changes
Instead of instrumenting long running background tasks like this:
```
async {
    loop { do_work().await; }
}.instrument(tracing::info_span!("background_task"))
```
we now do this to keep individual tracing spans short lived:
```
loop {
    do_work().instrument(tracing::info_span!("background_task")).await;
}
```
Note that the new pattern is not always completely obvious. In some cases the loop already only calls 1 function that does work which either already had the `instrument` macro applied or got it in this PR.

I also removed tracing spans on individual balance fetch requests as those already blow up the span size on their own.

## How to test
From the perspective of consuming the logs basically nothing changes so I think it's fine to merge as is instead of deploying this to prod for hours to observe the effects.