### PR TITLE
Fix latest tagging in hotfix/release

### DIFF
--- a/.github/workflows/hotfix.yml
+++ b/.github/workflows/hotfix.yml
@@ -29,12 +29,21 @@ jobs:
       - name: Get latest release version tag
         id: fetch_tag
         run: |
-          LATEST_VERSION=$(curl -s https://api.github.com/repos/$GITHUB_REPOSITORY/releases/latest | jq -r '.tag_name')
-          if ! [[ "$LATEST_VERSION" =~ ^v[0-9]+\.[0-9]+\..* ]]; then
-            echo "Invalid tag format, cannot bump version of: $LATEST_VERSION"
+          # Get the latest 10 releases, they come ordered by date by default,
+          # extract the tags, sort them and get the latest one (by version)
+          LATEST_VERSION=$(gh api "repos/$GITHUB_REPOSITORY/releases?per_page=10"  \
+            --jq '.[] | select(.draft == false and .prerelease == false) | .tag_name' \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+            | sort -V \
+            | tail -1)
+          if [[ -z "$LATEST_VERSION" ]]; then
+            echo "Could not determine the latest release version tag"
             exit 1
           fi
+          echo "Latest release version: $LATEST_VERSION"
           echo "latest=$LATEST_VERSION" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.HOTFIX_ACTION_TOKEN }}
 
       - name: Determine next patch version
         id: bump
@@ -43,6 +52,13 @@ jobs:
           IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION_NO_PREFIX"
           NEW_PATCH=$((PATCH + 1))
           NEW_TAG="v$MAJOR.$MINOR.$NEW_PATCH"
+          # A tag can exist without a release (e.g. an earlier run that failed
+          # after pushing the tag), in which case bumping the patch is not enough.
+          if git rev-parse -q --verify "refs/tags/$NEW_TAG" >/dev/null; then
+            echo "Tag $NEW_TAG already exists but has no release; resolve manually"
+            exit 1
+          fi
+          echo "Next hotfix version: $NEW_TAG"
           echo "tag=$NEW_TAG" >> $GITHUB_OUTPUT
         env:
           VERSION: ${{ steps.fetch_tag.outputs.latest }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,12 +20,21 @@ jobs:
       - name: Fetch latest release version tag
         id: fetch_tag
         run: |
-          LATEST_VERSION=$(curl -s https://api.github.com/repos/cowprotocol/services/releases/latest | jq -r '.tag_name')
-          if ! [[ "$LATEST_VERSION" =~ ^v[0-9]+\.[0-9]+\..* ]]; then
-            echo "Invalid tag format, cannot bump version of: $LATEST_VERSION"
+          # Get the latest 10 releases, they come ordered by date by default,
+          # extract the tags, sort them and get the latest one (by version)
+          LATEST_VERSION=$(gh api "repos/$GITHUB_REPOSITORY/releases?per_page=10"  \
+            --jq '.[] | select(.draft == false and .prerelease == false) | .tag_name' \
+            | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+            | sort -V \
+            | tail -1)
+          if [[ -z "$LATEST_VERSION" ]]; then
+            echo "Could not determine the latest release version tag"
             exit 1
           fi
+          echo "Latest release version: $LATEST_VERSION"
           echo "latest=$LATEST_VERSION" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check for changes since last tag
         run: |


### PR DESCRIPTION
# Description
Fixes hotfix/release tagging to rely on the latest *version* instead of the "latest" whatever is available.
This bug led to the following being mischaracterized as part of 2.371 when we're releasing 2.372
* https://github.com/cowprotocol/services/pull/4680
* https://github.com/cowprotocol/services/pull/4682

# Changes

* Use the `gh api` to fetch the latest 10 releases, sort by version, use the latest one to compute the next version

## How to test
Run a PR with this, candidate will be https://github.com/cowprotocol/services/pull/4679