### PR TITLE
Drop solver_competitions table

### DIFF
--- a/database/README.md
+++ b/database/README.md
@@ -457,18 +457,6 @@ Indexes:
 - PRIMARY KEY: btree(`auction_id`, `solver`, `solution_uid`)
 - settlement\_executions\_time\_range\_index: btree(`start_timestamp`, `end_timestamp`)
 
-### solver\_competitions
-
-Stores an overview of the solver competition. It contains orders in the auction along with prices for every relevant token as well as all valid solutions submitted by solvers together with their quality.
-
- Column | Type   | Nullable | Details
---------|--------|----------|--------
- id     | bigint | not null | id of the auction that the solver competition belongs to
- json   | jsonb  | nullable | overview of the solver competition with unspecified format
-
-Indexes:
-- PRIMARY KEY: btree(`id`)
-
 ### trades
 
 This table contains data of [`Trade`](https://github.com/cowprotocol/contracts/blob/main/src/contracts/GPv2Settlement.sol#L49-L58) events issued by the settlement contract after a successful settlement.

--- a/database/sql/V115__drop_solver_competitions.sql
+++ b/database/sql/V115__drop_solver_competitions.sql
@@ -1,0 +1,5 @@
+-- Drop the solver_competitions table, which was kept only to provide frontend with solver-ids
+-- since https://github.com/cowprotocol/cowswap/pull/7871 this is no longer the case
+-- and since https://github.com/cowprotocol/services/pull/4657 this has been made effective
+-- turning this table obsolete
+DROP TABLE IF EXISTS solver_competitions;


### PR DESCRIPTION
# Description

Drop the solver_competitions table, which was kept only to provide frontend with solver-ids since https://github.com/cowprotocol/cowswap/pull/7871 this is no longer the case and since https://github.com/cowprotocol/services/pull/4657 this has been made effective turning this table obsolete

# Changes

* Drop the `solver_competitions` table

