### PR TITLE
fair RPC batching layer

### DIFF
--- a/crates/ethrpc/src/alloy/buffering.rs
+++ b/crates/ethrpc/src/alloy/buffering.rs
@@ -10,23 +10,35 @@
 //! read from. The background task then does the batching, forwards the requests
 //! to the next layer, and reports the results of the individual calls back via
 //! another channel.
+//!
+//! To prevent a single caller from monopolizing the pipeline (e.g. the balance
+//! cache dumping thousands of requests just before the auction assembler needs
+//! a handful), each enqueued call is tagged with the tokio task id of the
+//! caller. The background worker keeps a queue per caller and assembles
+//! batches by round-robin across those queues. Fairness is best-effort: it
+//! depends on each subsystem driving its RPC calls from a stable task rather
+//! than spawning a fresh task per request.
 use {
     crate::Config,
     alloy_json_rpc::{RequestPacket, Response, ResponsePacket, SerializedRequest},
     alloy_transport::{RpcError, TransportError, TransportErrorKind},
     futures::{
-        channel::{mpsc, oneshot},
+        channel::{
+            mpsc::{self, TryRecvError},
+            oneshot,
+        },
         stream::StreamExt as _,
     },
     std::{
-        collections::{HashMap, VecDeque},
+        collections::{HashMap, VecDeque, hash_map::Entry},
         fmt::Debug,
         marker::PhantomData,
         pin::Pin,
+        sync::Arc,
         task::{Context, Poll},
+        time::Duration,
     },
-    tokio::task::JoinHandle,
-    tokio_stream::StreamExt,
+    tokio::{sync::Semaphore, task::JoinHandle},
     tower::{Layer, Service},
 };
 
@@ -62,13 +74,23 @@ where
 #[derive(Debug, Clone)]
 pub(crate) struct BatchCallProvider<S> {
     inner: PhantomData<S>,
-    calls: mpsc::UnboundedSender<CallContext>,
+    calls: mpsc::UnboundedSender<CallContext<SerializedRequest, Result<Response, TransportError>>>,
 }
 
-type CallContext = (
-    oneshot::Sender<Result<Response, TransportError>>,
-    SerializedRequest,
-);
+/// Identifies which tokio task enqueued a call. `None` covers contexts
+/// without a task id (e.g. calls issued from blocking tasks).
+/// The tokio runtime reuses ids under certain conditions. In practice
+/// we should not run into those cases but even if we do the worst thing
+/// that can happen is that we think the old task sent more requests
+/// which is not a huge issue.
+type CallerId = Option<tokio::task::Id>;
+
+struct CallContext<REQ, RESP> {
+    /// tokio task that issued this request
+    caller: CallerId,
+    request: REQ,
+    response_sender: oneshot::Sender<RESP>,
+}
 
 type ResponseSender = oneshot::Sender<Result<Response, RpcError<TransportErrorKind>>>;
 
@@ -136,102 +158,279 @@ where
         &self,
         request: SerializedRequest,
     ) -> oneshot::Receiver<Result<Response, TransportError>> {
-        let (sender, receiver) = oneshot::channel();
+        let (response_sender, receiver) = oneshot::channel();
+        // Tag with the caller's tokio task id so the worker can interleave
+        // requests from different subsystems fairly.
+        let caller = tokio::task::try_id();
         // Theoreticallly we could propagate the error to the caller, however
         // this is a critical error we can't recover from (i.e. we'll not be
         // able to send any more RPC calls). That's why we panic ASAP to immediately
         // cause a restart of the pod if this is running in kubernetes.
         self.calls
-            .unbounded_send((sender, request))
+            .unbounded_send(CallContext {
+                caller,
+                request,
+                response_sender,
+            })
             .expect("worker task unexpectedly dropped");
         receiver
     }
 
     /// Start a background worker for batching buffered requests.
+    ///
+    /// The worker keeps one queue per caller (keyed by the tokio task id
+    /// captured at enqueue time). Each batch is assembled by round-robin
+    /// across those queues, which prevents a single caller from monopolizing
+    /// the pipeline when many requests are enqueued in a burst.
     fn background_worker(
         mut inner: S,
         config: Config,
-        calls: mpsc::UnboundedReceiver<CallContext>,
+        mut calls: mpsc::UnboundedReceiver<
+            CallContext<SerializedRequest, Result<Response, TransportError>>,
+        >,
     ) -> JoinHandle<()> {
-        let process_batch = move |batch: Vec<(ResponseSender, SerializedRequest)>| {
-            // Clones service via [`std::mem::replace`] as recommended by
-            // <https://docs.rs/tower/latest/tower/trait.Service.html#be-careful-when-cloning-inner-services>
-            let clone: S = inner.clone();
-            let mut inner = std::mem::replace(&mut inner, clone);
+        let semaphore = Arc::new(Semaphore::new(config.ethrpc_max_concurrent_requests));
+        let max_batch_size = config.ethrpc_max_batch_size;
+        let batch_delay = config.ethrpc_batch_delay;
 
-            // Map<Id, Senders> because even with random IDs we might get duplicates,
-            // (e.g. some ID outgrew another and now they overlap) in that case
-            // we use the Deque to enforce FIFO and hope the node didn't re-order responses
-            let mut senders: HashMap<_, BatchRequestEntry> = HashMap::with_capacity(batch.len());
-            let mut requests = Vec::with_capacity(batch.len());
+        tokio::task::spawn(async move {
+            let mut queue =
+                FairQueue::<SerializedRequest, Result<Response, TransportError>>::default();
 
-            async move {
-                for (sender, request) in batch {
-                    if sender.is_canceled() {
-                        tracing::trace!(request_id = %request.id(), "canceled sender");
-                        continue;
-                    }
-
-                    match senders.entry(request.id().clone()) {
-                        std::collections::hash_map::Entry::Occupied(mut occupied_entry) => {
-                            occupied_entry.get_mut().push_back(sender);
-                        }
-                        std::collections::hash_map::Entry::Vacant(vacant_entry) => {
-                            vacant_entry.insert(BatchRequestEntry::new(sender));
-                        }
-                    }
-                    requests.push(request);
-                }
-
-                if requests.is_empty() {
-                    tracing::trace!("all callers stopped awaiting their request");
+            loop {
+                if !queue
+                    .collect_requests(&mut calls, max_batch_size, batch_delay)
+                    .await
+                {
+                    tracing::debug!("rpc batching channel closed");
                     return;
                 }
 
-                let result = inner
-                    .call(RequestPacket::Batch(requests))
-                    .await
-                    .map(|response| match response {
-                        ResponsePacket::Batch(res) => res,
-                        ResponsePacket::Single(res) => {
-                            tracing::warn!("received single response for batch request");
-                            vec![res]
-                        }
-                    });
+                let batch = queue.build_fair_batch(max_batch_size);
 
-                match result {
-                    Ok(responses) => {
-                        for response in responses {
-                            tracing::trace!(response_id = %response.id, "attempting to remove response");
-                            let Some(entry) = senders.get_mut(&response.id) else {
-                                tracing::warn!(response_id = %response.id, "missing sender for response");
-                                continue;
-                            };
-                            let Some(sender) = entry.pop_front() else {
-                                tracing::warn!(response_id = %response.id, "more responses than senders (may have lost some sender)");
-                                continue;
-                            };
-                            tracing::debug!(response_id = %response.id, "sending response");
-                            let _ = sender.send(Ok(response));
-                        }
-                    }
-                    Err(err) => {
-                        let err = format!("batch call failed: {err:?}");
-                        senders
-                            .into_values()
-                            .flat_map(|sender| sender.into_iter())
-                            .for_each(|sender| {
-                                let _ = sender.send(Err(TransportErrorKind::custom_str(&err)));
-                            });
+                // wait for a concurrency slot to apply backpressure
+                let permit = semaphore
+                    .clone()
+                    .acquire_owned()
+                    .await
+                    .expect("semaphore never closed");
+
+                // Clone the inner service per batch as recommended in
+                // <https://docs.rs/tower/latest/tower/trait.Service.html#be-careful-when-cloning-inner-services>.
+                let clone = inner.clone();
+                let this_inner = std::mem::replace(&mut inner, clone);
+
+                tokio::task::spawn(async move {
+                    // move permit into the task so we only return it when
+                    // task is done
+                    let _permit = permit;
+                    process_batch(this_inner, batch).await;
+                });
+            }
+        })
+    }
+}
+
+/// Fair FIFO queue of pending calls partitioned by caller. Items are
+/// enqueued into per-caller sub-queues and dequeued round-robin, so a
+/// single caller with a large backlog cannot monopolize the pipeline.
+///
+/// Invariant: a caller is in `round_robin` iff its entry in `per_caller`
+/// is non-empty, and `len` equals the sum of all per-caller queue lengths.
+struct FairQueue<REQ, RESP> {
+    per_caller: HashMap<CallerId, VecDeque<(REQ, oneshot::Sender<RESP>)>>,
+    round_robin: VecDeque<CallerId>,
+    len: usize,
+}
+
+impl<REQ, RESP> Default for FairQueue<REQ, RESP> {
+    fn default() -> Self {
+        Self {
+            per_caller: Default::default(),
+            round_robin: Default::default(),
+            len: 0,
+        }
+    }
+}
+
+impl<REQ, RESP> FairQueue<REQ, RESP> {
+    /// Enqueues request and adds caller to the round-robin queue if necessary.
+    fn enqueue(&mut self, call: CallContext<REQ, RESP>) {
+        let queue = self.per_caller.entry(call.caller).or_default();
+        let first = queue.is_empty();
+        queue.push_back((call.request, call.response_sender));
+        if first {
+            self.round_robin.push_back(call.caller);
+        }
+        self.len += 1;
+    }
+
+    /// Pop the next call in round-robin order, if any.
+    fn pop(&mut self) -> Option<(REQ, oneshot::Sender<RESP>)> {
+        let caller = self.round_robin.pop_front()?;
+        let queue = self
+            .per_caller
+            .get_mut(&caller)
+            .expect("caller in round_robin has a non-empty per-caller queue");
+        let item = queue
+            .pop_front()
+            .expect("caller in round_robin has a non-empty per-caller queue");
+        if queue.is_empty() {
+            self.per_caller.remove(&caller);
+        } else {
+            self.round_robin.push_back(caller);
+        }
+        self.len -= 1;
+        Some(item)
+    }
+
+    fn len(&self) -> usize {
+        self.len
+    }
+
+    fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Drains the items from `calls` into the fair queue until we have at least
+    /// `max_batch_size` items or waited for `batch_delay` after starting to
+    /// build a batch.
+    /// 1. drain all immediately available items from `calls`
+    /// 2. if we still have no items, await the next one
+    /// 3. if we don't have at least `max_batch_size` items yet, await for
+    ///    `batch_delay` time longer (to avoid tiny batches)
+    ///
+    /// Returns `true` if the `calls` channels is still alive and continuing
+    /// to process requests makes sense.
+    async fn collect_requests(
+        &mut self,
+        calls: &mut mpsc::UnboundedReceiver<CallContext<REQ, RESP>>,
+        max_batch_size: usize,
+        batch_delay: Duration,
+    ) -> bool {
+        loop {
+            match calls.try_recv() {
+                Ok(call) => self.enqueue(call),
+                Err(TryRecvError::Closed) => {
+                    return false;
+                }
+                Err(TryRecvError::Empty) => break,
+            }
+        }
+
+        // wait for the next request to appear. do this outside the select
+        // loop below to only start the timeout when we actually have an item
+        // in the pipeline
+        if self.is_empty() {
+            let Some(call) = calls.next().await else {
+                return false;
+            };
+            self.enqueue(call);
+        }
+
+        if self.len() < max_batch_size && !batch_delay.is_zero() {
+            let deadline = tokio::time::sleep(batch_delay);
+            tokio::pin!(deadline);
+            while self.len() < max_batch_size {
+                tokio::select! {
+                    _ = &mut deadline => break,
+                    msg = calls.next() => {
+                        let Some(call) = msg else {
+                            return false;
+                        };
+                        self.enqueue(call);
                     }
                 }
             }
-        };
-        tokio::task::spawn(
-            calls
-                .chunks_timeout(config.ethrpc_max_batch_size, config.ethrpc_batch_delay)
-                .for_each_concurrent(config.ethrpc_max_concurrent_requests, process_batch),
-        )
+        }
+
+        true
+    }
+
+    /// Batches at most `max_batch_size` items in a round-robin fashion to
+    /// prevent individual callers from starving all the others.
+    fn build_fair_batch(&mut self, max_batch_size: usize) -> Vec<(REQ, oneshot::Sender<RESP>)> {
+        let mut batch = Vec::with_capacity(self.len().min(max_batch_size));
+        while batch.len() < max_batch_size {
+            let Some((request, sender)) = self.pop() else {
+                break;
+            };
+            if !sender.is_canceled() {
+                // only add to batch if caller is still waiting for response
+                batch.push((request, sender));
+            }
+        }
+        batch
+    }
+}
+
+async fn process_batch<S>(mut inner: S, batch: Vec<(SerializedRequest, ResponseSender)>)
+where
+    S: Service<RequestPacket, Response = ResponsePacket, Error = TransportError>,
+{
+    // Map<Id, Senders> because even with random IDs we might get duplicates,
+    // (e.g. some ID outgrew another and now they overlap) in that case
+    // we use the Deque to enforce FIFO and hope the node didn't re-order responses
+    let mut senders: HashMap<_, BatchRequestEntry> = HashMap::with_capacity(batch.len());
+    let mut requests = Vec::with_capacity(batch.len());
+
+    for (request, sender) in batch {
+        if sender.is_canceled() {
+            tracing::trace!(request_id = %request.id(), "canceled sender");
+            continue;
+        }
+        match senders.entry(request.id().clone()) {
+            Entry::Occupied(mut occupied_entry) => {
+                occupied_entry.get_mut().push_back(sender);
+            }
+            Entry::Vacant(vacant_entry) => {
+                vacant_entry.insert(BatchRequestEntry::new(sender));
+            }
+        }
+        requests.push(request);
+    }
+
+    if requests.is_empty() {
+        tracing::trace!("all callers stopped awaiting their request");
+        return;
+    }
+
+    let result = inner
+        .call(RequestPacket::Batch(requests))
+        .await
+        .map(|response| match response {
+            ResponsePacket::Batch(res) => res,
+            ResponsePacket::Single(res) => {
+                tracing::warn!("received single response for batch request");
+                vec![res]
+            }
+        });
+
+    match result {
+        Ok(responses) => {
+            for response in responses {
+                tracing::trace!(response_id = %response.id, "attempting to remove response");
+                let Some(entry) = senders.get_mut(&response.id) else {
+                    tracing::warn!(response_id = %response.id, "missing sender for response");
+                    continue;
+                };
+                let Some(sender) = entry.pop_front() else {
+                    tracing::warn!(response_id = %response.id, "more responses than senders (may have lost some sender)");
+                    continue;
+                };
+                tracing::debug!(response_id = %response.id, "sending response");
+                let _ = sender.send(Ok(response));
+            }
+        }
+        Err(err) => {
+            let err = format!("batch call failed: {err:?}");
+            senders
+                .into_values()
+                .flat_map(|sender| sender.into_iter())
+                .for_each(|sender| {
+                    let _ = sender.send(Err(TransportErrorKind::custom_str(&err)));
+                });
+        }
     }
 }
 
@@ -288,7 +487,7 @@ where
 
 #[cfg(test)]
 mod test {
-    use {crate::alloy::buffering::BatchRequestEntry, futures::channel::oneshot};
+    use {super::*, futures::FutureExt as _};
 
     #[test]
     fn test_batch_request_entry_pop_twice() {
@@ -318,5 +517,97 @@ mod test {
 
         let third_pop = entry.pop_front();
         assert!(third_pop.is_none());
+    }
+
+    /// Tests that the fair queue builds batches in a round robin fashion.
+    /// Also tests that the associated response senders send the data to
+    /// the correct caller.
+    #[tokio::test]
+    async fn batching_does_round_robin() {
+        let (request_sender, mut receiver) = mpsc::unbounded();
+        let mut queue = FairQueue::default();
+
+        fn call_context(index: u64) -> (CallContext<u64, u64>, oneshot::Receiver<u64>) {
+            let (response_sender, receiver) = oneshot::channel();
+            let context = CallContext {
+                caller: tokio::task::try_id(),
+                request: index,
+                response_sender,
+            };
+            (context, receiver)
+        }
+
+        // spammy producer that enques 100 calls before other
+        // tasks even start
+        let mut response_receivers: Vec<_> = (0..100)
+            .map(|id| {
+                let (context, receiver) = call_context(id);
+                request_sender.unbounded_send(context).unwrap();
+                receiver
+            })
+            .collect();
+
+        for id in 100..103 {
+            let request_sender2 = request_sender.clone();
+
+            // enqueue calls from new separate tasks to give each one
+            // its own queue to test round robin (keyed by task id)
+            #[allow(clippy::async_yields_async)]
+            let receiver = tokio::task::spawn(async move {
+                let (context, receiver) = call_context(id);
+                request_sender2.unbounded_send(context).unwrap();
+                receiver
+            })
+            .await
+            .unwrap();
+            response_receivers.push(receiver);
+        }
+
+        let should_continue = queue
+            .collect_requests(&mut receiver, 5, Default::default())
+            .now_or_never()
+            .expect("if we have enough requests already enqueued this is actually sync");
+        assert!(should_continue);
+
+        let batch = queue.build_fair_batch(5);
+
+        // ASSERT THAT BATCH WAS FAIR (ROUND ROBIN)
+        assert_eq!(batch.len(), 5);
+        let mut iter = batch.into_iter();
+        // first request of spammy producer
+        let (request, sender) = iter.next().unwrap();
+        assert_eq!(request, 0);
+        sender.send(0).unwrap();
+
+        // requests of other producers
+        let (request, sender) = iter.next().unwrap();
+        assert_eq!(request, 100);
+        sender.send(100).unwrap();
+        let (request, sender) = iter.next().unwrap();
+        assert_eq!(request, 101);
+        sender.send(101).unwrap();
+        let (request, sender) = iter.next().unwrap();
+        assert_eq!(request, 102);
+        sender.send(102).unwrap();
+
+        // round robin wrapped around so this is the second request of the spammy
+        // producer
+        let (request, sender) = iter.next().unwrap();
+        assert_eq!(request, 1);
+        sender.send(1).unwrap();
+
+        // ASSERT THAT RESPONSES REACHED THE CORRECT CALLERS
+        let mut responses = response_receivers.into_iter();
+        // first 2 calls of the spammy producer resolved
+        assert_eq!(responses.next().unwrap().now_or_never().unwrap(), Ok(0));
+        assert_eq!(responses.next().unwrap().now_or_never().unwrap(), Ok(1));
+        // next 98 calls fo the spammy producer did not resolve yet
+        for _ in 0..98 {
+            assert!(responses.next().unwrap().now_or_never().is_none());
+        }
+        // requests of other producers resolved
+        assert_eq!(responses.next().unwrap().now_or_never().unwrap(), Ok(100));
+        assert_eq!(responses.next().unwrap().now_or_never().unwrap(), Ok(101));
+        assert_eq!(responses.next().unwrap().now_or_never().unwrap(), Ok(102));
     }
 }

--- a/crates/ethrpc/src/alloy/buffering.rs
+++ b/crates/ethrpc/src/alloy/buffering.rs
@@ -11,13 +11,11 @@
 //! to the next layer, and reports the results of the individual calls back via
 //! another channel.
 //!
-//! To prevent a single caller from monopolizing the pipeline (e.g. the balance
-//! cache dumping thousands of requests just before the auction assembler needs
-//! a handful), each enqueued call is tagged with the tokio task id of the
-//! caller. The background worker keeps a queue per caller and assembles
-//! batches by round-robin across those queues. Fairness is best-effort: it
-//! depends on each subsystem driving its RPC calls from a stable task rather
-//! than spawning a fresh task per request.
+//! To prevent a single caller from monopolizing the pipeline, each enqueued
+//! call is tagged with the tokio task id of the caller. The background worker
+//! keeps a queue per caller and assembles batches by round-robin across those
+//! queues. Fairness is best-effort: it depends on each subsystem driving its
+//! RPC calls from a stable task rather than spawning a fresh task per request.
 use {
     crate::Config,
     alloy_json_rpc::{RequestPacket, Response, ResponsePacket, SerializedRequest},

--- a/crates/ethrpc/src/alloy/buffering.rs
+++ b/crates/ethrpc/src/alloy/buffering.rs
@@ -196,6 +196,15 @@ where
                 FairQueue::<SerializedRequest, Result<Response, TransportError>>::default();
 
             loop {
+                // first wait for a concurrency slot to become available.
+                // that way we end up with the most up-to-data batch
+                // possible in the end.
+                let permit = semaphore
+                    .clone()
+                    .acquire_owned()
+                    .await
+                    .expect("semaphore never closed");
+
                 if !queue
                     .collect_requests(&mut calls, max_batch_size, batch_delay)
                     .await
@@ -205,13 +214,6 @@ where
                 }
 
                 let batch = queue.build_fair_batch(max_batch_size);
-
-                // wait for a concurrency slot to apply backpressure
-                let permit = semaphore
-                    .clone()
-                    .acquire_owned()
-                    .await
-                    .expect("semaphore never closed");
 
                 // Clone the inner service per batch as recommended in
                 // <https://docs.rs/tower/latest/tower/trait.Service.html#be-careful-when-cloning-inner-services>.

--- a/crates/ethrpc/src/alloy/buffering.rs
+++ b/crates/ethrpc/src/alloy/buffering.rs
@@ -83,11 +83,11 @@ pub(crate) struct BatchCallProvider<S> {
 /// which is not a huge issue.
 type CallerId = Option<tokio::task::Id>;
 
-struct CallContext<REQ, RESP> {
+struct CallContext<Req, Resp> {
     /// tokio task that issued this request
     caller: CallerId,
-    request: REQ,
-    response_sender: oneshot::Sender<RESP>,
+    request: Req,
+    response_sender: oneshot::Sender<Resp>,
 }
 
 type ResponseSender = oneshot::Sender<Result<Response, RpcError<TransportErrorKind>>>;
@@ -237,13 +237,13 @@ where
 ///
 /// Invariant: a caller is in `round_robin` iff its entry in `per_caller`
 /// is non-empty, and `len` equals the sum of all per-caller queue lengths.
-struct FairQueue<REQ, RESP> {
-    per_caller: HashMap<CallerId, VecDeque<(REQ, oneshot::Sender<RESP>)>>,
+struct FairQueue<Req, Resp> {
+    per_caller: HashMap<CallerId, VecDeque<(Req, oneshot::Sender<Resp>)>>,
     round_robin: VecDeque<CallerId>,
     len: usize,
 }
 
-impl<REQ, RESP> Default for FairQueue<REQ, RESP> {
+impl<Req, Resp> Default for FairQueue<Req, Resp> {
     fn default() -> Self {
         Self {
             per_caller: Default::default(),
@@ -253,9 +253,9 @@ impl<REQ, RESP> Default for FairQueue<REQ, RESP> {
     }
 }
 
-impl<REQ, RESP> FairQueue<REQ, RESP> {
+impl<Req, Resp> FairQueue<Req, Resp> {
     /// Enqueues request and adds caller to the round-robin queue if necessary.
-    fn enqueue(&mut self, call: CallContext<REQ, RESP>) {
+    fn enqueue(&mut self, call: CallContext<Req, Resp>) {
         let queue = self.per_caller.entry(call.caller).or_default();
         let first = queue.is_empty();
         queue.push_back((call.request, call.response_sender));
@@ -266,7 +266,7 @@ impl<REQ, RESP> FairQueue<REQ, RESP> {
     }
 
     /// Pop the next call in round-robin order, if any.
-    fn pop(&mut self) -> Option<(REQ, oneshot::Sender<RESP>)> {
+    fn pop(&mut self) -> Option<(Req, oneshot::Sender<Resp>)> {
         let caller = self.round_robin.pop_front()?;
         let queue = self
             .per_caller
@@ -304,7 +304,7 @@ impl<REQ, RESP> FairQueue<REQ, RESP> {
     /// to process requests makes sense.
     async fn collect_requests(
         &mut self,
-        calls: &mut mpsc::UnboundedReceiver<CallContext<REQ, RESP>>,
+        calls: &mut mpsc::UnboundedReceiver<CallContext<Req, Resp>>,
         max_batch_size: usize,
         batch_delay: Duration,
     ) -> bool {
@@ -349,7 +349,7 @@ impl<REQ, RESP> FairQueue<REQ, RESP> {
 
     /// Batches at most `max_batch_size` items in a round-robin fashion to
     /// prevent individual callers from starving all the others.
-    fn build_fair_batch(&mut self, max_batch_size: usize) -> Vec<(REQ, oneshot::Sender<RESP>)> {
+    fn build_fair_batch(&mut self, max_batch_size: usize) -> Vec<(Req, oneshot::Sender<Resp>)> {
         let mut batch = Vec::with_capacity(self.len().min(max_batch_size));
         while batch.len() < max_batch_size {
             let Some((request, sender)) = self.pop() else {


### PR DESCRIPTION
# Description
When we inspect `Solvable_orders::update()` - the function responsible for assembling the final auction - with tempo we see that sometimes fetching balances takes a very long time (>100ms). This is very bad since we only issue very few RPC requests fetching new balances because basically all balances we need are already cached.
The reason why this takes so long is that the background task that updates balances whenever we see a new block saturates the RPC buffering layer. What happens is effectively this:
1. new block appears
2. balance cache immediately sends 1000 requests to the batching layer
3. `Solvable_orders::update()` processes orders
    a. it finds a missing balance - gets enqueued AFTER the 1000 already enqueue requests
4. 1000 requests of balances background task get processed (>100ms)
5. `Solvable_orders::update()` RPC calls get resolved (~few ms)

That's why simply delaying the balances cache background task for 1 or 2 seconds causes `Solvable_orders::update()` to be significantly faster and less spikey.
<img width="1202" height="297" alt="Screenshot 2026-07-31 at 12 49 43" src="https://github.com/user-attachments/assets/3eafbb87-b2fc-4a83-8676-0cd49ff9d933" />

There are a few ways how to handle this:
* simply delay balances queries
    * obviously hacky
* introduce some notification mechanism between auction building and balances
    * slightly less hacky but gets awkward when we deal with chains that have multiple blocks between auctions
* buffer balances queries (e.g. at most n calls in flight at one time)
    * requires tons of changes and only addresses the issue for the balances task

# Changes
What I ended up going for was to simply make the buffering layer fairer.
Instead of every caller sending requests to 1 global queue which allows 1 spammy producer to significantly delay other producers we now store requests in 1 queue per producer (identified by tokio task id). Then when it comes time to assemble the batches we send over the wire we simply do round robin across all sub-queues.
That way the problem should be resolved for all producers without actually having to change any callers or introduce additional communication channels.

To facilitate this the batching logic provided in futures (`calls.chunks_timeout(config.ethrpc_max_batch_size, config.ethrpc_batch_delay)`) needed to be replaced with handrolled logic but the behavior was preserved.

The last change is that we now spawn a separate task per batch instead of doing everything in 1 task. This allows multiple cores to work on those tasks in parallel and was informed by the fact that the task regularly blocks the IO worker for >50ms when we are processing huge requests or responses (instrumented with [dial9](https://github.com/dial9-rs/dial9)).

## How to test
added basic unit test to verify that the round robin logic works

I temporarily tested 2 variants of this PR in prod:
1. the version of the PR (spawn 1 task per batch)
2. 1 worker task that polls all batch futures concurrently via `FuturesUnordered`

There is definitely a noticeable improvement but unfortunately not as large as simply delaying the balances cache task. This PR still makes sense to me as it addresses a fundamental issue and whatever change we apply to the balance caching task (if we even do anything) would still cooperate with this PR.
<img width="1896" height="337" alt="Screenshot 2026-08-03 at 07 55 25" src="https://github.com/user-attachments/assets/72af293e-2c89-4d88-8d27-404e5ac87cbf" />