### PR TITLE
add network name to tempo

### DIFF
--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -132,6 +132,12 @@ pub async fn start(args: impl Iterator<Item = String>) {
         .validate()
         .expect("failed to validate configuration file");
 
+    let chain_name = config
+        .shared
+        .chain_id
+        .and_then(|id| Chain::try_from(id).ok())
+        .map(|chain| chain.name())
+        .unwrap_or("unknown");
     let tracing_config = config
         .shared
         .tracing
@@ -140,7 +146,7 @@ pub async fn start(args: impl Iterator<Item = String>) {
         .map(|endpoint| {
             observe::TracingConfig::new(
                 endpoint.clone(),
-                "autopilot".into(),
+                format!("autopilot-{chain_name}"),
                 config.shared.tracing.exporter_timeout,
                 config.shared.tracing.level,
             )

--- a/crates/driver/src/run.rs
+++ b/crates/driver/src/run.rs
@@ -7,7 +7,7 @@ use {
         infra::{
             self,
             Api,
-            blockchain::{self, Ethereum, gas},
+            blockchain::{self, Ethereum, RpcError, gas},
             cli,
             config,
             liquidity,
@@ -48,14 +48,20 @@ pub async fn run(
 /// Run the driver. This function exists to avoid multiple monomorphizations of
 /// the `run` code, which bloats the binaries and increases compile times.
 async fn run_with(args: cli::Args, addr_sender: Option<oneshot::Sender<SocketAddr>>) {
+    let ethrpc_res = ethrpc(&args).await;
+    let chain_name = ethrpc_res
+        .as_ref()
+        .map(|ethrpc| ethrpc.chain().name())
+        .unwrap_or("unknown");
+
     infra::observe::init(observe::Config::new(
         &args.log,
         args.stderr_threshold,
         args.use_json_logs,
-        tracing_config(&args.tracing, "driver".into()),
+        tracing_config(&args.tracing, format!("driver-{chain_name}")),
     ));
 
-    let ethrpc = ethrpc(&args).await;
+    let ethrpc = ethrpc_res.expect("connect ethereum RPC");
     let config = config::file::load(ethrpc.chain(), &args.config).await;
 
     let version = observe::version::git_version();
@@ -188,15 +194,13 @@ fn simulator(
     simulator
 }
 
-async fn ethrpc(args: &cli::Args) -> blockchain::Rpc {
+async fn ethrpc(args: &cli::Args) -> Result<blockchain::Rpc, RpcError> {
     let args = blockchain::RpcArgs {
         url: args.ethrpc.clone(),
         max_batch_size: args.ethrpc_max_batch_size,
         max_concurrent_requests: args.ethrpc_max_concurrent_requests,
     };
-    blockchain::Rpc::try_new(args)
-        .await
-        .expect("connect ethereum RPC")
+    blockchain::Rpc::try_new(args).await
 }
 
 async fn solvers(config: &config::Config, eth: &Ethereum) -> Vec<Solver> {

--- a/crates/orderbook/src/run.rs
+++ b/crates/orderbook/src/run.rs
@@ -55,6 +55,12 @@ pub async fn start(args: impl Iterator<Item = String>) {
         .expect("failed to load configuration file")
         .validate()
         .expect("failed to validate configuration file");
+    let chain_name = config
+        .shared
+        .chain_id
+        .and_then(|id| Chain::try_from(id).ok())
+        .map(|chain| chain.name())
+        .unwrap_or("unknown");
     let tracing_config = config
         .shared
         .tracing
@@ -63,7 +69,7 @@ pub async fn start(args: impl Iterator<Item = String>) {
         .map(|endpoint| {
             observe::TracingConfig::new(
                 endpoint.clone(),
-                "orderbook".into(),
+                format!("orderbook-{chain_name}"),
                 config.shared.tracing.exporter_timeout,
                 config.shared.tracing.level,
             )


### PR DESCRIPTION
# Description
Since we enabled tempo on more networks it's hard to figure out from which network a span was emitted because we don't have the chain name anywhere.

# Changes
add the network name to the tempo's service name so that we can differentiate the traces in the tempo UI