### PR TITLE
evict balance cache based on time instead of blocks

### DIFF
--- a/crates/account-balances/src/cached.rs
+++ b/crates/account-balances/src/cached.rs
@@ -330,7 +330,7 @@ mod tests {
         let mut inner = MockBalanceFetching::new();
         inner
             .expect_get_balances()
-            .times(2)
+            .times(3)
             .returning(|_| vec![Ok(U256::ONE)]);
 
         let fetcher = Balances::new(Arc::new(inner), TEST_EVICTION_TIME);
@@ -361,7 +361,7 @@ mod tests {
         tokio::time::sleep(TEST_EVICTION_TIME + tokio::time::Duration::from_millis(20)).await;
 
         // Next block triggers a refresh that evicts the stale entry during list
-        // construction and skips the `inner` call entirely.
+        // construction (3rd call to `inner`, with empty slice).
         sender
             .send(BlockInfo {
                 number: 2,

--- a/crates/account-balances/src/cached.rs
+++ b/crates/account-balances/src/cached.rs
@@ -64,14 +64,22 @@ pub struct Balances {
     /// Cached entries that haven't been requested for this long get evicted
     /// on the next block refresh.
     eviction_time: Duration,
+    /// Cap the refresh rate so that fast chains don't burn CPU. New blocks
+    /// that arrive during this window get coalesced into a single refresh.
+    min_refresh_interval: Duration,
 }
 
 impl Balances {
-    pub fn new(inner: Arc<dyn BalanceFetching>, eviction_time: Duration) -> Self {
+    pub fn new(
+        inner: Arc<dyn BalanceFetching>,
+        eviction_time: Duration,
+        min_refresh_interval: Duration,
+    ) -> Self {
         Self {
             inner,
             balance_cache: Default::default(),
             eviction_time,
+            min_refresh_interval,
         }
     }
 }
@@ -102,11 +110,13 @@ impl Balances {
         let inner = self.inner.clone();
         let cache = self.balance_cache.clone();
         let eviction_time = self.eviction_time;
+        let min_refresh_interval = self.min_refresh_interval;
         let mut stream = into_stream(block_stream);
 
         let task = async move {
             while stream.next().await.is_some() {
                 Self::refresh_balances(inner.as_ref(), &cache, eviction_time).await;
+                tokio::time::sleep(min_refresh_interval).await;
             }
             tracing::error!("block stream terminated unexpectedly");
         };
@@ -213,6 +223,7 @@ mod tests {
     };
 
     const TEST_EVICTION_TIME: Duration = Duration::from_millis(100);
+    const TEST_MIN_REFRESH_INTERVAL: Duration = Duration::from_millis(1);
 
     fn query(token: u8) -> Query {
         Query {
@@ -233,7 +244,11 @@ mod tests {
             .withf(|arg| arg == [query(1)])
             .returning(|_| vec![Ok(U256::ONE)]);
 
-        let fetcher = Balances::new(Arc::new(inner), TEST_EVICTION_TIME);
+        let fetcher = Balances::new(
+            Arc::new(inner),
+            TEST_EVICTION_TIME,
+            TEST_MIN_REFRESH_INTERVAL,
+        );
         // 1st call to `inner`.
         let result = fetcher.get_balances(&[query(1)]).await;
         assert_eq!(result[0].as_ref().unwrap(), &U256::ONE);
@@ -251,7 +266,11 @@ mod tests {
             .withf(|arg| arg == [query(1)])
             .returning(|_| vec![Err(anyhow::anyhow!("some error"))]);
 
-        let fetcher = Balances::new(Arc::new(inner), TEST_EVICTION_TIME);
+        let fetcher = Balances::new(
+            Arc::new(inner),
+            TEST_EVICTION_TIME,
+            TEST_MIN_REFRESH_INTERVAL,
+        );
         // 1st call to `inner`.
         assert!(fetcher.get_balances(&[query(1)]).await[0].is_err());
         // 2nd call to `inner`.
@@ -270,7 +289,11 @@ mod tests {
             .withf(|arg| arg == [query(1)])
             .returning(|_| vec![Ok(U256::ONE)]);
 
-        let fetcher = Balances::new(Arc::new(inner), TEST_EVICTION_TIME);
+        let fetcher = Balances::new(
+            Arc::new(inner),
+            TEST_EVICTION_TIME,
+            TEST_MIN_REFRESH_INTERVAL,
+        );
         fetcher.spawn_background_task(receiver);
 
         // 1st call to `inner`. Balance gets cached.
@@ -307,7 +330,11 @@ mod tests {
             .withf(|arg| arg == [query(2)])
             .returning(|_| vec![Ok(U256::from(2))]);
 
-        let fetcher = Balances::new(Arc::new(inner), TEST_EVICTION_TIME);
+        let fetcher = Balances::new(
+            Arc::new(inner),
+            TEST_EVICTION_TIME,
+            TEST_MIN_REFRESH_INTERVAL,
+        );
         // 1st call to `inner` putting balance 1 into the cache.
         let result = fetcher.get_balances(&[query(1)]).await;
         assert_eq!(result[0].as_ref().unwrap(), &U256::ONE);
@@ -333,7 +360,11 @@ mod tests {
             .times(3)
             .returning(|_| vec![Ok(U256::ONE)]);
 
-        let fetcher = Balances::new(Arc::new(inner), TEST_EVICTION_TIME);
+        let fetcher = Balances::new(
+            Arc::new(inner),
+            TEST_EVICTION_TIME,
+            TEST_MIN_REFRESH_INTERVAL,
+        );
         fetcher.spawn_background_task(receiver);
 
         let cached_entry = || {

--- a/crates/account-balances/src/cached.rs
+++ b/crates/account-balances/src/cached.rs
@@ -2,35 +2,29 @@ use {
     crate::{BalanceFetching, Query, TransferSimulationError},
     alloy_primitives::{Address, U256},
     anyhow::Result,
-    ethrpc::block_stream::{BlockInfo, CurrentBlockWatcher, into_stream},
+    ethrpc::block_stream::{CurrentBlockWatcher, into_stream},
     futures::StreamExt,
     itertools::Itertools,
     model::order::SellTokenSource,
     std::{
         collections::HashMap,
         sync::{Arc, Mutex},
+        time::{Duration, Instant},
     },
     tracing::instrument,
 };
 
-type BlockNumber = u64;
-
-/// Balances get removed from the cache after this many blocks without being
-/// requested.
-const EVICTION_TIME: BlockNumber = 5;
-
 #[derive(Default)]
 struct BalanceCache {
-    last_seen_block: BlockNumber,
     data: HashMap<Query, BalanceEntry>,
 }
 
 impl BalanceCache {
     /// Retrieves cached balance and updates the `requested_at` field.
-    fn get_cached_balance(&mut self, query: &Query) -> Option<U256> {
+    fn get_cached_balance(&mut self, query: &Query, now: Instant) -> Option<U256> {
         match self.data.get_mut(query) {
             Some(entry) => {
-                entry.requested_at = self.last_seen_block;
+                entry.requested_at = now;
                 Some(entry.balance)
             }
             None => None,
@@ -39,26 +33,19 @@ impl BalanceCache {
 
     /// Only updates existing balances. This should always be used in the
     /// background task.
-    fn update_balance(&mut self, query: &Query, balance: U256, update_block: BlockNumber) {
-        if update_block < self.last_seen_block {
-            // This should never realistically happen.
-            return;
-        }
-
+    fn update_balance(&mut self, query: &Query, balance: U256) {
         if let Some(entry) = self.data.get_mut(query) {
-            entry.updated_at = update_block;
             entry.balance = balance;
         }
     }
 
     /// Only inserts new balances. This should always be used when we needed to
     /// fetch a balance because it was requested by a backend component.
-    fn insert_balance(&mut self, query: Query, balance: U256, requested_at: BlockNumber) {
+    fn insert_balance(&mut self, query: Query, balance: U256) {
         self.data.insert(
             query,
             BalanceEntry {
-                requested_at,
-                updated_at: requested_at,
+                requested_at: Instant::now(),
                 balance,
             },
         );
@@ -67,21 +54,24 @@ impl BalanceCache {
 
 #[derive(Debug, Clone)]
 struct BalanceEntry {
-    requested_at: BlockNumber,
-    updated_at: BlockNumber,
+    requested_at: Instant,
     balance: U256,
 }
 
 pub struct Balances {
     inner: Arc<dyn BalanceFetching>,
     balance_cache: Arc<Mutex<BalanceCache>>,
+    /// Cached entries that haven't been requested for this long get evicted
+    /// on the next block refresh.
+    eviction_time: Duration,
 }
 
 impl Balances {
-    pub fn new(inner: Arc<dyn BalanceFetching>) -> Self {
+    pub fn new(inner: Arc<dyn BalanceFetching>, eviction_time: Duration) -> Self {
         Self {
             inner,
             balance_cache: Default::default(),
+            eviction_time,
         }
     }
 }
@@ -91,62 +81,59 @@ struct CacheResponse {
     cached: Vec<(usize, Result<U256>)>,
     // Indices of queries that were not in the cache.
     missing: Vec<usize>,
-    requested_at: BlockNumber,
 }
 
 impl Balances {
     fn get_cached_balances(&self, queries: &[Query]) -> CacheResponse {
         let mut cache = self.balance_cache.lock().unwrap();
+        let now = Instant::now();
         let (cached, missing) = queries
             .iter()
             .enumerate()
-            .partition_map(|(i, query)| match cache.get_cached_balance(query) {
+            .partition_map(|(i, query)| match cache.get_cached_balance(query, now) {
                 Some(balance) => itertools::Either::Left((i, Ok(balance))),
                 None => itertools::Either::Right(i),
             });
-        CacheResponse {
-            cached,
-            missing,
-            requested_at: cache.last_seen_block,
-        }
+        CacheResponse { cached, missing }
     }
 
     /// Spawns task that refreshes the cached balances on every new block.
     pub fn spawn_background_task(&self, block_stream: CurrentBlockWatcher) {
         let inner = self.inner.clone();
         let cache = self.balance_cache.clone();
+        let eviction_time = self.eviction_time;
         let mut stream = into_stream(block_stream);
 
         let task = async move {
-            while let Some(block) = stream.next().await {
-                Self::refresh_balances(inner.as_ref(), &cache, block).await;
+            while stream.next().await.is_some() {
+                Self::refresh_balances(inner.as_ref(), &cache, eviction_time).await;
             }
             tracing::error!("block stream terminated unexpectedly");
         };
         tokio::spawn(task);
     }
 
-    /// Updates all balances there were used recently enough. All other
-    /// balances get evicted from the cache.
+    /// Evicts entries that haven't been requested within `eviction_time` and
+    /// refreshes the remaining cached balances.
     #[instrument(skip_all)]
     async fn refresh_balances(
         fetcher: &dyn BalanceFetching,
         cache: &Mutex<BalanceCache>,
-        block: BlockInfo,
+        eviction_time: Duration,
     ) {
         let balances_to_update = {
             let mut cache = cache.lock().unwrap();
-            cache.last_seen_block = block.number;
-            cache
-                .data
-                .iter()
-                .filter_map(|(query, entry)| {
-                    // Only update balances that have been requested recently.
-                    let oldest_allowed_request =
-                        cache.last_seen_block.saturating_sub(EVICTION_TIME);
-                    (entry.requested_at >= oldest_allowed_request).then_some(query.clone())
-                })
-                .collect_vec()
+            let now = Instant::now();
+            let mut to_update = Vec::with_capacity(cache.data.len());
+            cache.data.retain(|query, entry| {
+                let recently_requested =
+                    now.saturating_duration_since(entry.requested_at) <= eviction_time;
+                if recently_requested {
+                    to_update.push(query.clone());
+                }
+                recently_requested
+            });
+            to_update
         };
 
         let results = fetcher.get_balances(&balances_to_update).await;
@@ -157,13 +144,9 @@ impl Balances {
             .zip(results)
             .for_each(|(query, result)| {
                 if let Ok(balance) = result {
-                    cache.update_balance(&query, balance, block.number);
+                    cache.update_balance(&query, balance);
                 }
             });
-        cache.data.retain(|_, value| {
-            // Only keep balances where we know we have the most recent data.
-            value.updated_at >= block.number
-        });
     }
 }
 
@@ -174,7 +157,6 @@ impl BalanceFetching for Balances {
         let CacheResponse {
             mut cached,
             missing,
-            requested_at,
         } = self.get_cached_balances(queries);
 
         if missing.is_empty() {
@@ -188,7 +170,7 @@ impl BalanceFetching for Balances {
             let mut cache = self.balance_cache.lock().unwrap();
             for (query, result) in missing_queries.into_iter().zip(new_balances.iter()) {
                 if let Ok(balance) = result {
-                    cache.insert_balance(query, *balance, requested_at)
+                    cache.insert_balance(query, *balance)
                 }
             }
         }
@@ -230,6 +212,8 @@ mod tests {
         model::order::SellTokenSource,
     };
 
+    const TEST_EVICTION_TIME: Duration = Duration::from_millis(100);
+
     fn query(token: u8) -> Query {
         Query {
             owner: Address::repeat_byte(1),
@@ -249,7 +233,7 @@ mod tests {
             .withf(|arg| arg == [query(1)])
             .returning(|_| vec![Ok(U256::ONE)]);
 
-        let fetcher = Balances::new(Arc::new(inner));
+        let fetcher = Balances::new(Arc::new(inner), TEST_EVICTION_TIME);
         // 1st call to `inner`.
         let result = fetcher.get_balances(&[query(1)]).await;
         assert_eq!(result[0].as_ref().unwrap(), &U256::ONE);
@@ -267,7 +251,7 @@ mod tests {
             .withf(|arg| arg == [query(1)])
             .returning(|_| vec![Err(anyhow::anyhow!("some error"))]);
 
-        let fetcher = Balances::new(Arc::new(inner));
+        let fetcher = Balances::new(Arc::new(inner), TEST_EVICTION_TIME);
         // 1st call to `inner`.
         assert!(fetcher.get_balances(&[query(1)]).await[0].is_err());
         // 2nd call to `inner`.
@@ -286,7 +270,7 @@ mod tests {
             .withf(|arg| arg == [query(1)])
             .returning(|_| vec![Ok(U256::ONE)]);
 
-        let fetcher = Balances::new(Arc::new(inner));
+        let fetcher = Balances::new(Arc::new(inner), TEST_EVICTION_TIME);
         fetcher.spawn_background_task(receiver);
 
         // 1st call to `inner`. Balance gets cached.
@@ -323,7 +307,7 @@ mod tests {
             .withf(|arg| arg == [query(2)])
             .returning(|_| vec![Ok(U256::from(2))]);
 
-        let fetcher = Balances::new(Arc::new(inner));
+        let fetcher = Balances::new(Arc::new(inner), TEST_EVICTION_TIME);
         // 1st call to `inner` putting balance 1 into the cache.
         let result = fetcher.get_balances(&[query(1)]).await;
         assert_eq!(result[0].as_ref().unwrap(), &U256::ONE);
@@ -346,10 +330,10 @@ mod tests {
         let mut inner = MockBalanceFetching::new();
         inner
             .expect_get_balances()
-            .times(7)
+            .times(2)
             .returning(|_| vec![Ok(U256::ONE)]);
 
-        let fetcher = Balances::new(Arc::new(inner));
+        let fetcher = Balances::new(Arc::new(inner), TEST_EVICTION_TIME);
         fetcher.spawn_background_task(receiver);
 
         let cached_entry = || {
@@ -362,17 +346,29 @@ mod tests {
         let result = fetcher.get_balances(&[query(1)]).await;
         assert_eq!(result[0].as_ref().unwrap(), &U256::ONE);
 
-        for block in 1..=EVICTION_TIME + 1 {
-            assert!(cached_entry().is_some());
-            // New block gets detected.
-            sender
-                .send(BlockInfo {
-                    number: block,
-                    ..Default::default()
-                })
-                .unwrap();
-            tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
-        }
+        // Trigger a refresh while the entry is still within the eviction window.
+        // Balance stays in the cache and gets refreshed (2nd call to `inner`).
+        sender
+            .send(BlockInfo {
+                number: 1,
+                ..Default::default()
+            })
+            .unwrap();
+        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+        assert!(cached_entry().is_some());
+
+        // Wait past the eviction window without touching the entry.
+        tokio::time::sleep(TEST_EVICTION_TIME + tokio::time::Duration::from_millis(20)).await;
+
+        // Next block triggers a refresh that evicts the stale entry during list
+        // construction and skips the `inner` call entirely.
+        sender
+            .send(BlockInfo {
+                number: 2,
+                ..Default::default()
+            })
+            .unwrap();
+        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
         assert!(cached_entry().is_none());
     }
 }

--- a/crates/account-balances/src/lib.rs
+++ b/crates/account-balances/src/lib.rs
@@ -9,7 +9,10 @@ use {
         interaction::InteractionData,
         order::{Order, SellTokenSource},
     },
-    std::sync::{Arc, LazyLock},
+    std::{
+        sync::{Arc, LazyLock},
+        time::Duration,
+    },
 };
 
 mod cached;
@@ -94,7 +97,16 @@ pub fn cached(
     balance_simulator: BalanceSimulator,
     blocks: CurrentBlockWatcher,
 ) -> Arc<dyn BalanceFetching> {
-    let cached = Arc::new(cached::Balances::new(fetcher(web3, balance_simulator)));
+    /// How long a cached balance may go without being requested before it is
+    /// evicted from the cache on the next block refresh.
+    /// This should be longer than a normal auction to prevent the autopilot
+    /// from purging the cache before running the next auction.
+    const CACHE_EVICTION_TIME: Duration = Duration::from_secs(20);
+
+    let cached = Arc::new(cached::Balances::new(
+        fetcher(web3, balance_simulator),
+        CACHE_EVICTION_TIME,
+    ));
     cached.spawn_background_task(blocks);
     cached
 }

--- a/crates/account-balances/src/lib.rs
+++ b/crates/account-balances/src/lib.rs
@@ -102,10 +102,14 @@ pub fn cached(
     /// This should be longer than a normal auction to prevent the autopilot
     /// from purging the cache before running the next auction.
     const CACHE_EVICTION_TIME: Duration = Duration::from_secs(20);
+    /// Cap the refresh rate so that fast chains don't burn CPU refetching
+    /// balances every single block.
+    const MIN_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
 
     let cached = Arc::new(cached::Balances::new(
         fetcher(web3, balance_simulator),
         CACHE_EVICTION_TIME,
+        MIN_REFRESH_INTERVAL,
     ));
     cached.spawn_background_task(blocks);
     cached

--- a/crates/account-balances/src/lib.rs
+++ b/crates/account-balances/src/lib.rs
@@ -96,20 +96,13 @@ pub fn cached(
     web3: &Web3,
     balance_simulator: BalanceSimulator,
     blocks: CurrentBlockWatcher,
+    eviction_time: Duration,
+    min_update_interval: Duration,
 ) -> Arc<dyn BalanceFetching> {
-    /// How long a cached balance may go without being requested before it is
-    /// evicted from the cache on the next block refresh.
-    /// This should be longer than a normal auction to prevent the autopilot
-    /// from purging the cache before running the next auction.
-    const CACHE_EVICTION_TIME: Duration = Duration::from_secs(20);
-    /// Cap the refresh rate so that fast chains don't burn CPU refetching
-    /// balances every single block.
-    const MIN_REFRESH_INTERVAL: Duration = Duration::from_secs(1);
-
     let cached = Arc::new(cached::Balances::new(
         fetcher(web3, balance_simulator),
-        CACHE_EVICTION_TIME,
-        MIN_REFRESH_INTERVAL,
+        eviction_time,
+        min_update_interval,
     ));
     cached.spawn_background_task(blocks);
     cached

--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -270,6 +270,8 @@ pub async fn run(config: Configuration, shutdown_controller: ShutdownController)
             balance_overrider,
         ),
         eth.current_block().clone(),
+        config.balance_cache.eviction_time,
+        config.balance_cache.min_update_interval,
     );
 
     let gas_estimators: Vec<gas_price_estimation::GasEstimatorType> = config

--- a/crates/configs/src/autopilot/mod.rs
+++ b/crates/configs/src/autopilot/mod.rs
@@ -10,6 +10,7 @@ use {
             solver::Solver,
             trusted_tokens::TrustedTokensConfig,
         },
+        balance_cache::BalanceCacheConfig,
         banned_users::BannedUsersConfig,
         database::DatabasePoolConfig,
         http_client::HttpClient,
@@ -163,6 +164,10 @@ pub struct Configuration {
     /// 1inch, quote verification, balance overrides, etc.).
     #[serde(default)]
     pub price_estimation: PriceEstimation,
+
+    /// Settings for the on-chain balance cache.
+    #[serde(default)]
+    pub balance_cache: BalanceCacheConfig,
 }
 
 impl Configuration {
@@ -227,6 +232,7 @@ impl Configuration {
             http_client: Default::default(),
             order_quoting: TestDefault::test_default(),
             price_estimation: TestDefault::test_default(),
+            balance_cache: TestDefault::test_default(),
         }
     }
 
@@ -258,6 +264,7 @@ impl Configuration {
             http_client: Default::default(),
             order_quoting: TestDefault::test_default(),
             price_estimation: TestDefault::test_default(),
+            balance_cache: TestDefault::test_default(),
         }
     }
 

--- a/crates/configs/src/balance_cache.rs
+++ b/crates/configs/src/balance_cache.rs
@@ -1,0 +1,74 @@
+use {
+    serde::{Deserialize, Serialize},
+    std::time::Duration,
+};
+
+fn default_eviction_time() -> Duration {
+    Duration::from_secs(20)
+}
+
+fn default_min_update_interval() -> Duration {
+    Duration::from_secs(1)
+}
+
+/// Settings for the on-chain balance cache used by services that fetch trader
+/// balances during auction preparation or quoting.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct BalanceCacheConfig {
+    /// Cached balances that have not been queried within this duration get
+    /// evicted on the next background refresh. Should be longer than a typical
+    /// auction so that the entries survive across auctions.
+    #[serde(with = "humantime_serde", default = "default_eviction_time")]
+    pub eviction_time: Duration,
+
+    /// Minimum time between two background refreshes of the cache. New blocks
+    /// arriving inside this window are coalesced into a single refresh so that
+    /// fast chains don't burn CPU refetching balances every block.
+    #[serde(with = "humantime_serde", default = "default_min_update_interval")]
+    pub min_update_interval: Duration,
+}
+
+impl Default for BalanceCacheConfig {
+    fn default() -> Self {
+        Self {
+            eviction_time: default_eviction_time(),
+            min_update_interval: default_min_update_interval(),
+        }
+    }
+}
+
+#[cfg(any(test, feature = "test-util"))]
+impl crate::test_util::TestDefault for BalanceCacheConfig {
+    fn test_default() -> Self {
+        // Disable throttling in tests so the cache reacts to every block.
+        Self {
+            eviction_time: default_eviction_time(),
+            min_update_interval: Duration::ZERO,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialize_defaults() {
+        let toml = "";
+        let config: BalanceCacheConfig = toml::from_str(toml).unwrap();
+        assert_eq!(config.eviction_time, Duration::from_secs(20));
+        assert_eq!(config.min_update_interval, Duration::from_secs(1));
+    }
+
+    #[test]
+    fn deserialize_full() {
+        let toml = r#"
+        eviction-time = "30s"
+        min-update-interval = "500ms"
+        "#;
+        let config: BalanceCacheConfig = toml::from_str(toml).unwrap();
+        assert_eq!(config.eviction_time, Duration::from_secs(30));
+        assert_eq!(config.min_update_interval, Duration::from_millis(500));
+    }
+}

--- a/crates/configs/src/lib.rs
+++ b/crates/configs/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod autopilot;
+pub mod balance_cache;
 pub mod banned_users;
 pub mod database;
 pub mod deserialize_env;

--- a/crates/configs/src/orderbook/mod.rs
+++ b/crates/configs/src/orderbook/mod.rs
@@ -1,5 +1,6 @@
 use {
     crate::{
+        balance_cache::BalanceCacheConfig,
         banned_users::BannedUsersConfig,
         database::DatabasePoolConfig,
         fee_factor::FeeFactor,
@@ -126,6 +127,10 @@ pub struct Configuration {
     /// auction's submission deadline block has been reached.
     #[serde(default)]
     pub hide_competition_before_deadline: bool,
+
+    /// Settings for the on-chain balance cache.
+    #[serde(default)]
+    pub balance_cache: BalanceCacheConfig,
 }
 
 impl Configuration {
@@ -216,6 +221,7 @@ pub mod test_util {
                 price_estimation: PriceEstimation::test_default(),
                 order_simulation_timeout: Duration::from_secs(2),
                 hide_competition_before_deadline: false,
+                balance_cache: TestDefault::test_default(),
             }
         }
     }
@@ -383,6 +389,7 @@ mod tests {
             http_client: Default::default(),
             price_estimation: Default::default(),
             order_simulation_timeout: default_simulation_timeout(),
+            balance_cache: Default::default(),
         };
 
         let serialized = toml::to_string_pretty(&config).unwrap();

--- a/crates/driver/src/infra/api/mod.rs
+++ b/crates/driver/src/infra/api/mod.rs
@@ -40,6 +40,7 @@ pub struct Api {
     pub mempools: Mempools,
     pub addr: SocketAddr,
     pub bad_token_detector: risk_detector::bad_tokens::Detector,
+    pub balance_cache: configs::balance_cache::BalanceCacheConfig,
     /// If this channel is specified, the bound address will be sent to it. This
     /// allows the driver to bind to 0.0.0.0:0 during testing.
     pub addr_sender: Option<oneshot::Sender<SocketAddr>>,
@@ -59,6 +60,8 @@ impl Api {
             self.eth.web3(),
             self.eth.balance_simulator().clone(),
             self.eth.current_block().clone(),
+            self.balance_cache.eviction_time,
+            self.balance_cache.min_update_interval,
         );
 
         let tokens = tokens::Fetcher::new(&self.eth);

--- a/crates/driver/src/infra/config/file/load.rs
+++ b/crates/driver/src/infra/config/file/load.rs
@@ -359,6 +359,7 @@ pub async fn load(chain: Chain, path: &Path) -> infra::Config {
         app_data_fetching: config.app_data_fetching,
         tx_gas_limit: config.tx_gas_limit,
         http: config.http,
+        balance_cache: config.balance_cache,
     }
 }
 

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -89,6 +89,10 @@ struct Config {
     /// Http client factory config
     #[serde(default)]
     http: configs::http_client::HttpClient,
+
+    /// Settings for the on-chain balance cache.
+    #[serde(default)]
+    balance_cache: configs::balance_cache::BalanceCacheConfig,
 }
 
 #[serde_as]

--- a/crates/driver/src/infra/config/mod.rs
+++ b/crates/driver/src/infra/config/mod.rs
@@ -30,4 +30,5 @@ pub struct Config {
     pub app_data_fetching: AppDataFetching,
     pub tx_gas_limit: eth::U256,
     pub http: configs::http_client::HttpClient,
+    pub balance_cache: configs::balance_cache::BalanceCacheConfig,
 }

--- a/crates/driver/src/run.rs
+++ b/crates/driver/src/run.rs
@@ -136,6 +136,7 @@ async fn run_with(args: cli::Args, addr_sender: Option<oneshot::Sender<SocketAdd
             config.simulation_bad_token_max_age,
             &eth,
         ),
+        balance_cache: config.balance_cache,
         eth,
         addr: args.addr,
         addr_sender,

--- a/crates/e2e/src/setup/colocation.rs
+++ b/crates/e2e/src/setup/colocation.rs
@@ -238,6 +238,9 @@ gas-price-cap = "1000000000000"
 
 [[submission.mempool]]
 url = "{NODE_HOST}"
+
+[balance-cache]
+min-update-interval = "0s"
 "#,
         contracts.gp_settlement.address(),
         contracts.weth.address(),

--- a/crates/orderbook/src/run.rs
+++ b/crates/orderbook/src/run.rs
@@ -203,16 +203,6 @@ pub async fn run(config: Configuration) {
         postgres_write.clone()
     };
 
-    let balance_fetcher = account_balances::fetcher(
-        &web3,
-        BalanceSimulator::new(
-            settlement_contract.clone(),
-            balances_contract.clone(),
-            vault_relayer,
-            balance_overrider.clone(),
-        ),
-    );
-
     let gas_estimators: Vec<gas_price_estimation::GasEstimatorType> = config
         .shared
         .gas_estimators
@@ -226,6 +216,19 @@ pub async fn run(config: Configuration) {
         .stream(config.shared.node_url.clone(), web3.provider.clone())
         .await
         .unwrap();
+
+    let balance_fetcher = account_balances::cached(
+        &web3,
+        BalanceSimulator::new(
+            settlement_contract.clone(),
+            balances_contract.clone(),
+            vault_relayer,
+            balance_overrider.clone(),
+        ),
+        current_block_stream.clone(),
+        config.balance_cache.eviction_time,
+        config.balance_cache.min_update_interval,
+    );
 
     let gas_price_estimator = Arc::new(InstrumentedGasEstimator::new(
         gas_price_estimation::create_priority_estimator(


### PR DESCRIPTION
# Description
Currently the time to cut auctions on arbitrum and bnb is significantly higher than on more used chains (~400ms vs. 200ms). The reason is that the cache currently evicts balances that have not been requested for 5 blocks which is like 1.5s on arbitrum for example. So when the autopilot run loop eventually finishes the balances have long been evicted and we need to re-fetch everything while building the auction.

# Changes
Keep balances for 20s to definitely span at least 1 full auction so that the balances are always ready when building a new auction.

## How to test
Temporarily deployed to arbitrum. As expected the time to build an auction dropped from ~400ms to ~50ms. On the flip side the total number of RPC requests trippled because it now actually continuously updates the balances the entire time.
<img width="1410" height="612" alt="Screenshot 2026-08-03 at 19 25 36" src="https://github.com/user-attachments/assets/4495e2eb-ec84-4e63-86f0-b2f16b838821" />
<img width="1427" height="791" alt="Screenshot 2026-08-03 at 19 25 43" src="https://github.com/user-attachments/assets/9e40f630-41c1-4f27-b615-5a0d3761dc7d" />

If we also throttle the balance updates to once per second we are improving many metrics even more and even drop the number of RPC calls per second. With both changes applied we drop the total auction overhead from ~700ms to ~150ms.
<img width="1412" height="616" alt="Screenshot 2026-08-03 at 19 52 08" src="https://github.com/user-attachments/assets/40658df6-2181-4820-b13d-8d62f1e86766" />
<img width="1430" height="801" alt="Screenshot 2026-08-03 at 19 52 13" src="https://github.com/user-attachments/assets/bc2ef18a-8968-47c9-853a-1605772d769b" />
