### PR TITLE
Persist settlement gas cost

### DIFF
--- a/crates/autopilot/src/infra/persistence/mod.rs
+++ b/crates/autopilot/src/infra/persistence/mod.rs
@@ -822,6 +822,15 @@ impl Persistence {
             )
             .await?;
 
+            database::settlements::update_settlement_gas(
+                &mut ex,
+                block_number,
+                log_index,
+                u256_to_big_decimal(&gas.0),
+                u256_to_big_decimal(&gas_price.0.0),
+            )
+            .await?;
+
             store_order_events(
                 &mut ex,
                 fee_breakdown.keys().cloned(),

--- a/crates/autopilot/src/infra/persistence/mod.rs
+++ b/crates/autopilot/src/infra/persistence/mod.rs
@@ -819,6 +819,8 @@ impl Persistence {
                 log_index,
                 solver,
                 settlement.solution_uid(),
+                // We're not expecting this to actually happen, BUT, since this is the cost of a
+                // transaction we'll double count this value if 1 transaction has 2 settlements
                 u256_to_big_decimal(&gas.0),
                 u256_to_big_decimal(&gas_price.0.0),
             )

--- a/crates/autopilot/src/infra/persistence/mod.rs
+++ b/crates/autopilot/src/infra/persistence/mod.rs
@@ -813,19 +813,12 @@ impl Persistence {
                 "settlement update",
             );
 
-            database::settlements::update_settlement_solver(
+            database::settlements::update_settlement_solver_and_gas(
                 &mut ex,
                 block_number,
                 log_index,
                 solver,
                 settlement.solution_uid(),
-            )
-            .await?;
-
-            database::settlements::update_settlement_gas(
-                &mut ex,
-                block_number,
-                log_index,
                 u256_to_big_decimal(&gas.0),
                 u256_to_big_decimal(&gas_price.0.0),
             )

--- a/crates/database/src/settlements.rs
+++ b/crates/database/src/settlements.rs
@@ -67,9 +67,6 @@ WHERE block_number = $2 AND log_index = $3
         .map(|_| ())
 }
 
-/// Stores the winning solver together with the actual gas cost of the
-/// settlement transaction (read from the transaction receipt). See migration
-/// `V116` for the gas columns.
 #[instrument(skip_all)]
 pub async fn update_settlement_solver_and_gas(
     ex: &mut PgConnection,

--- a/crates/database/src/settlements.rs
+++ b/crates/database/src/settlements.rs
@@ -1,5 +1,6 @@
 use {
     crate::{Address, PgTransaction, TransactionHash},
+    bigdecimal::BigDecimal,
     sqlx::{Executor, PgConnection},
     tracing::instrument,
 };
@@ -87,6 +88,31 @@ WHERE block_number = $3 AND log_index = $4
         .execute(ex)
         .await
         .map(|_| ())
+}
+
+/// Stores the actual gas cost (read from the transaction receipt) of a settled
+/// transaction. See migration `V116`.
+#[instrument(skip_all)]
+pub async fn update_settlement_gas(
+    ex: &mut PgConnection,
+    block_number: i64,
+    log_index: i64,
+    gas_used: BigDecimal,
+    effective_gas_price: BigDecimal,
+) -> Result<(), sqlx::Error> {
+    const QUERY: &str = r#"
+UPDATE settlements
+SET gas_used = $1, effective_gas_price = $2
+WHERE block_number = $3 AND log_index = $4
+    ;"#;
+    sqlx::query(QUERY)
+        .bind(gas_used)
+        .bind(effective_gas_price)
+        .bind(block_number)
+        .bind(log_index)
+        .execute(ex)
+        .await?;
+    Ok(())
 }
 
 /// Deletes all database data that referenced the deleted settlement events.

--- a/crates/database/src/settlements.rs
+++ b/crates/database/src/settlements.rs
@@ -67,29 +67,6 @@ WHERE block_number = $2 AND log_index = $3
         .map(|_| ())
 }
 
-#[instrument(skip_all)]
-pub async fn update_settlement_solver(
-    ex: &mut PgConnection,
-    block_number: i64,
-    log_index: i64,
-    solver: Address,
-    solution_uid: i64,
-) -> Result<(), sqlx::Error> {
-    const QUERY: &str = r#"
-UPDATE settlements
-SET solver = $1, solution_uid = $2
-WHERE block_number = $3 AND log_index = $4
-    ;"#;
-    sqlx::query(QUERY)
-        .bind(solver)
-        .bind(solution_uid)
-        .bind(block_number)
-        .bind(log_index)
-        .execute(ex)
-        .await
-        .map(|_| ())
-}
-
 /// Stores the winning solver together with the actual gas cost of the
 /// settlement transaction (read from the transaction receipt). See migration
 /// `V116` for the gas columns.
@@ -148,7 +125,6 @@ mod tests {
             events::{Event, EventIndex, Settlement},
         },
         sqlx::Connection,
-        std::str::FromStr,
     };
 
     async fn all_settlement_tx_hashes(
@@ -241,64 +217,5 @@ mod tests {
         let settlement = get_settlements_without_auction(&mut db).await.unwrap();
 
         assert!(settlement.is_empty());
-    }
-
-    #[tokio::test]
-    #[ignore]
-    async fn postgres_settlement_solver_and_gas() {
-        type Row = (Address, Option<i64>, Option<BigDecimal>, Option<BigDecimal>);
-        const QUERY: &str = r#"
-SELECT solver, solution_uid, gas_used, effective_gas_price
-FROM settlements
-WHERE block_number = $1 AND log_index = $2
-    ;"#;
-
-        let mut db = PgConnection::connect("postgresql://").await.unwrap();
-        let mut db = db.begin().await.unwrap();
-        crate::clear_DANGER_(&mut db).await.unwrap();
-
-        let event = EventIndex::default();
-        crate::events::insert_settlement(&mut db, &event, &Default::default())
-            .await
-            .unwrap();
-
-        let row: Row = sqlx::query_as(QUERY)
-            .bind(event.block_number)
-            .bind(event.log_index)
-            .fetch_one(&mut *db)
-            .await
-            .unwrap();
-        assert_eq!(row, (ByteArray([0u8; 20]), None, None, None));
-
-        let solver = ByteArray([1u8; 20]);
-        // `u256::MAX`, the widest value `numeric(78, 0)` needs to accept.
-        let gas_used = BigDecimal::from_str(
-            "115792089237316195423570985008687907853269984665640564039457584007913129639935",
-        )
-        .unwrap();
-        let effective_gas_price = BigDecimal::from(42_000_000_000u64);
-
-        update_settlement_solver_and_gas(
-            &mut db,
-            event.block_number,
-            event.log_index,
-            solver,
-            7,
-            gas_used.clone(),
-            effective_gas_price.clone(),
-        )
-        .await
-        .unwrap();
-
-        let row: Row = sqlx::query_as(QUERY)
-            .bind(event.block_number)
-            .bind(event.log_index)
-            .fetch_one(&mut *db)
-            .await
-            .unwrap();
-        assert_eq!(
-            row,
-            (solver, Some(7), Some(gas_used), Some(effective_gas_price))
-        );
     }
 }

--- a/crates/database/src/settlements.rs
+++ b/crates/database/src/settlements.rs
@@ -90,29 +90,34 @@ WHERE block_number = $3 AND log_index = $4
         .map(|_| ())
 }
 
-/// Stores the actual gas cost (read from the transaction receipt) of a settled
-/// transaction. See migration `V116`.
+/// Stores the winning solver together with the actual gas cost of the
+/// settlement transaction (read from the transaction receipt). See migration
+/// `V116` for the gas columns.
 #[instrument(skip_all)]
-pub async fn update_settlement_gas(
+pub async fn update_settlement_solver_and_gas(
     ex: &mut PgConnection,
     block_number: i64,
     log_index: i64,
+    solver: Address,
+    solution_uid: i64,
     gas_used: BigDecimal,
     effective_gas_price: BigDecimal,
 ) -> Result<(), sqlx::Error> {
     const QUERY: &str = r#"
 UPDATE settlements
-SET gas_used = $1, effective_gas_price = $2
-WHERE block_number = $3 AND log_index = $4
+SET solver = $1, solution_uid = $2, gas_used = $3, effective_gas_price = $4
+WHERE block_number = $5 AND log_index = $6
     ;"#;
     sqlx::query(QUERY)
+        .bind(solver)
+        .bind(solution_uid)
         .bind(gas_used)
         .bind(effective_gas_price)
         .bind(block_number)
         .bind(log_index)
         .execute(ex)
-        .await?;
-    Ok(())
+        .await
+        .map(|_| ())
 }
 
 /// Deletes all database data that referenced the deleted settlement events.
@@ -143,6 +148,7 @@ mod tests {
             events::{Event, EventIndex, Settlement},
         },
         sqlx::Connection,
+        std::str::FromStr,
     };
 
     async fn all_settlement_tx_hashes(
@@ -235,5 +241,64 @@ mod tests {
         let settlement = get_settlements_without_auction(&mut db).await.unwrap();
 
         assert!(settlement.is_empty());
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn postgres_settlement_solver_and_gas() {
+        type Row = (Address, Option<i64>, Option<BigDecimal>, Option<BigDecimal>);
+        const QUERY: &str = r#"
+SELECT solver, solution_uid, gas_used, effective_gas_price
+FROM settlements
+WHERE block_number = $1 AND log_index = $2
+    ;"#;
+
+        let mut db = PgConnection::connect("postgresql://").await.unwrap();
+        let mut db = db.begin().await.unwrap();
+        crate::clear_DANGER_(&mut db).await.unwrap();
+
+        let event = EventIndex::default();
+        crate::events::insert_settlement(&mut db, &event, &Default::default())
+            .await
+            .unwrap();
+
+        let row: Row = sqlx::query_as(QUERY)
+            .bind(event.block_number)
+            .bind(event.log_index)
+            .fetch_one(&mut *db)
+            .await
+            .unwrap();
+        assert_eq!(row, (ByteArray([0u8; 20]), None, None, None));
+
+        let solver = ByteArray([1u8; 20]);
+        // `u256::MAX`, the widest value `numeric(78, 0)` needs to accept.
+        let gas_used = BigDecimal::from_str(
+            "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+        )
+        .unwrap();
+        let effective_gas_price = BigDecimal::from(42_000_000_000u64);
+
+        update_settlement_solver_and_gas(
+            &mut db,
+            event.block_number,
+            event.log_index,
+            solver,
+            7,
+            gas_used.clone(),
+            effective_gas_price.clone(),
+        )
+        .await
+        .unwrap();
+
+        let row: Row = sqlx::query_as(QUERY)
+            .bind(event.block_number)
+            .bind(event.log_index)
+            .fetch_one(&mut *db)
+            .await
+            .unwrap();
+        assert_eq!(
+            row,
+            (solver, Some(7), Some(gas_used), Some(effective_gas_price))
+        );
     }
 }

--- a/crates/database/src/solver_competition_v2.rs
+++ b/crates/database/src/solver_competition_v2.rs
@@ -694,9 +694,17 @@ mod tests {
         settlements::update_settlement_auction(&mut db, 1, 0, 1)
             .await
             .unwrap();
-        settlements::update_settlement_solver(&mut db, 1, 0, ByteArray([1u8; 20]), 0)
-            .await
-            .unwrap();
+        settlements::update_settlement_solver_and_gas(
+            &mut db,
+            1,
+            0,
+            ByteArray([1u8; 20]),
+            0,
+            BigDecimal::from(100_000),
+            BigDecimal::from(1_000_000_000),
+        )
+        .await
+        .unwrap();
 
         // competition_auctions
         let auction = auction::Auction {
@@ -791,12 +799,14 @@ mod tests {
         settlements::update_settlement_auction(&mut db, block_number, log_index, auction_id)
             .await
             .unwrap();
-        settlements::update_settlement_solver(
+        settlements::update_settlement_solver_and_gas(
             &mut db,
             block_number,
             log_index,
             ByteArray([1u8; 20]),
             0,
+            BigDecimal::from(100_000),
+            BigDecimal::from(1_000_000_000),
         )
         .await
         .unwrap();
@@ -999,9 +1009,17 @@ mod tests {
             .await
             .unwrap();
         // associate with solution 3
-        settlements::update_settlement_solver(&mut db, 5, 0, Default::default(), 3)
-            .await
-            .unwrap();
+        settlements::update_settlement_solver_and_gas(
+            &mut db,
+            5,
+            0,
+            Default::default(),
+            3,
+            BigDecimal::from(100_000),
+            BigDecimal::from(1_000_000_000),
+        )
+        .await
+        .unwrap();
 
         // when an order gets marked as settled we dont consider it inflight anymore
         let later_block_with_settlement = fetch_in_flight_orders(&mut db, 5).await.unwrap();


### PR DESCRIPTION
# Description
Start storing settlement gas cost in the DB, the goal for this PR is to reduce the effort of reviewing the whole feature.

# Changes

* Starts persisting the settlement gas cost to the DB

