### PR TITLE
feat(chain-types): generic auction loop, seam traits, and the Scoring/Cycle split

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2713,10 +2713,14 @@ name = "chain-types"
 version = "0.1.0"
 dependencies = [
  "alloy-primitives",
+ "anyhow",
+ "async-trait",
  "num 0.4.3",
  "number",
  "ruint",
  "thiserror 1.0.69",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/chain-types/Cargo.toml
+++ b/crates/chain-types/Cargo.toml
@@ -6,10 +6,16 @@ description = "Per-chain type vocabulary and arithmetic traits for chain-generic
 
 [dependencies]
 alloy-primitives = { workspace = true }
+anyhow = { workspace = true }
+async-trait = { workspace = true }
 num = { workspace = true }
 number = { workspace = true }
 ruint = { workspace = true, features = ["num-traits"] }
 thiserror = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt"] }
 
 [lints]
 workspace = true

--- a/crates/chain-types/src/evm.rs
+++ b/crates/chain-types/src/evm.rs
@@ -2,7 +2,7 @@
 
 pub use alloy_primitives::{Address, U256};
 use {
-    crate::{Amount, ChainTypes, MathError, MathResult},
+    crate::{Amount, ChainTypes, MathError, MathResult, Scoring},
     alloy_primitives::{U512, ruint::UintTryFrom},
     number::u256_ext::U256Ext,
 };
@@ -44,8 +44,11 @@ pub struct Evm;
 
 impl ChainTypes for Evm {
     type AccountId = Address;
-    type Amount = U256;
     type OrderUid = OrderUid;
+}
+
+impl Scoring for Evm {
+    type Amount = U256;
     type TokenId = Address;
 
     const NATIVE_PRICE_DENOMINATOR: U256 = U256::from_limbs([10u64.pow(18), 0, 0, 0]);

--- a/crates/chain-types/src/lib.rs
+++ b/crates/chain-types/src/lib.rs
@@ -152,13 +152,12 @@ pub trait CycleTrigger<C: Cycle>: Send {
     /// returns the tip to build on.
     async fn next_cycle(&mut self) -> C::Tip;
 
-    /// Latest observed tip without waiting. single_run reads it after
-    /// ranking to derive the submission deadline.
+    /// Latest observed tip without waiting. The loop reads it after ranking
+    /// to derive the submission deadline.
     fn current_tip(&self) -> C::Tip;
 }
 
-/// Produces the cut auction for a tip. Wraps the maintenance cutoff, the
-/// solvable orders cache and the auction cutting.
+/// Produces the cut auction for a tip.
 #[async_trait]
 pub trait AuctionProvider<C: Cycle>: Send + Sync {
     /// Brings indexers and the solvable orders cache up to date with the

--- a/crates/chain-types/src/lib.rs
+++ b/crates/chain-types/src/lib.rs
@@ -1,25 +1,42 @@
-//! Per-chain type vocabulary for chain-generic protocol logic.
+//! Per-chain type vocabulary and the chain-generic auction loop.
 //!
 //! Chain-generic algorithms need identifiers they can hash and compare,
 //! amounts they can do checked arithmetic on, and a small set of
-//! chain-specific hooks. This crate defines that vocabulary ([`ChainTypes`],
-//! [`Amount`]) together with its EVM and Solana instantiations.
+//! chain-specific hooks. This crate layers that vocabulary into
+//! [`ChainTypes`] (shared identifiers), [`Scoring`] (the amount type and the
+//! scoring hooks) and [`Cycle`] (the auction-loop types), together with its
+//! EVM and Solana instantiations.
+//!
+//! [`AuctionLoop`] drives one settlement competition per cycle through a
+//! fixed phase order, generic over [`Cycle`] and its six seam traits. The
+//! loop owns the phase ordering and the auction dedupe and knows nothing
+//! chain specific. Leadership is a chain agnostic concern handled by the
+//! caller, so the loop always runs as if it were the leader.
 
 pub mod evm;
 pub mod solana;
 
-use std::{fmt::Debug, hash::Hash};
-
 pub use num::traits::{Bounded, CheckedAdd, CheckedSub, SaturatingAdd, Zero};
+use {
+    async_trait::async_trait,
+    std::{collections::HashSet, fmt::Debug, hash::Hash},
+    tracing::Instrument,
+};
 
-/// The per-chain type vocabulary and hooks.
+/// Shared identity vocabulary of one settlement chain: the identifiers every
+/// chain-generic algorithm names regardless of what it computes.
 pub trait ChainTypes: Copy + Debug + Eq + Hash + Send + Sync + 'static {
-    /// Token identifier (EVM: 20-byte address, Solana: 32-byte mint).
-    type TokenId: Copy + Debug + Eq + Hash + Send + Sync;
     /// Account identifier, used for solvers and order owners.
     type AccountId: Copy + Debug + Eq + Hash + Send + Sync;
     /// Order identifier (EVM: 56-byte UID, Solana: 32-byte intent hash).
     type OrderUid: Copy + Debug + Eq + Hash + Send + Sync;
+}
+
+/// The scoring half of the vocabulary: the amount type and the chain-specific
+/// hooks the surplus math needs.
+pub trait Scoring: ChainTypes {
+    /// Token identifier (EVM: 20-byte address, Solana: 32-byte mint).
+    type TokenId: Copy + Debug + Eq + Hash + Send + Sync;
     /// Amount type used for token amounts, prices, and scores.
     type Amount: Amount;
 
@@ -86,4 +103,567 @@ pub enum MathError {
     DivisionByZero,
     #[error("negative")]
     Negative,
+}
+
+/// The loop half of the vocabulary: the types [`AuctionLoop`] itself has to
+/// name. Everything else stays inside the seam implementations.
+pub trait Cycle: ChainTypes {
+    /// Chain progress marker (EVM block, Solana slot). Cycles are triggered
+    /// by it, caches sync to it and the auction dedupe compares it.
+    type Tip: Clone + PartialEq + Debug + Send + Sync + 'static;
+
+    /// The cut auction fanned out to solvers. PartialEq implements the
+    /// "same auction on the same tip solves nothing new" dedupe and must
+    /// ignore the allocated id.
+    type Auction: AuctionInfo<Self> + Clone + PartialEq + Send + Sync + 'static;
+
+    /// One solution proposed by one driver. Opaque to the loop, it only
+    /// moves solutions from the competition into winner selection.
+    type Solution: Send + 'static;
+
+    /// Winner selection output over all solutions of one auction. Shared by
+    /// the observer (persist outcome) and the executor (dispatch winners).
+    type Ranking: RankingInfo<Self> + Send + Sync + 'static;
+}
+
+/// What the loop needs to know about an auction.
+pub trait AuctionInfo<C: Cycle> {
+    fn id(&self) -> i64;
+}
+
+/// What the loop needs to know about a ranking.
+pub trait RankingInfo<C: Cycle> {
+    /// Number of winning solutions.
+    fn winner_count(&self) -> usize;
+
+    /// Orders of all winning solutions, marked Executing.
+    fn winning_order_uids(&self) -> HashSet<C::OrderUid>;
+
+    /// Orders of ranked non winning solutions. The loop subtracts the
+    /// winning set before marking them Considered.
+    fn considered_order_uids(&self) -> HashSet<C::OrderUid>;
+}
+
+/// Yields the tip to build the next auction on. Wraps the wake sources
+/// (new tip, new orders) and the staleness resync.
+#[async_trait]
+pub trait CycleTrigger<C: Cycle>: Send {
+    /// Blocks until something happened that warrants a new cycle and
+    /// returns the tip to build on.
+    async fn next_cycle(&mut self) -> C::Tip;
+
+    /// Latest observed tip without waiting. single_run reads it after
+    /// ranking to derive the submission deadline.
+    fn current_tip(&self) -> C::Tip;
+}
+
+/// Produces the cut auction for a tip. Wraps the maintenance cutoff, the
+/// solvable orders cache and the auction cutting.
+#[async_trait]
+pub trait AuctionProvider<C: Cycle>: Send + Sync {
+    /// Brings indexers and the solvable orders cache up to date with the
+    /// tip. Errors are logged by the loop but do not stop the cycle, the
+    /// auction is then cut from slightly stale caches.
+    async fn sync_to_tip(&self, tip: &C::Tip) -> anyhow::Result<()>;
+
+    /// Cuts the auction for the tip, allocating an id and archiving it.
+    /// None when there is nothing to solve.
+    async fn cut_auction(&self, tip: &C::Tip) -> Option<C::Auction>;
+}
+
+/// Fans the auction out to all drivers and returns attributable solutions.
+#[async_trait]
+pub trait SolverCompetition<C: Cycle>: Send + Sync {
+    async fn solve(&self, auction: &C::Auction) -> Vec<C::Solution>;
+}
+
+/// Scores, filters and ranks solutions, marking winners.
+pub trait WinnerSelection<C: Cycle>: Send + Sync {
+    fn arbitrate(&self, solutions: Vec<C::Solution>, auction: &C::Auction) -> C::Ranking;
+}
+
+/// Dispatches winning solutions for execution.
+#[async_trait]
+pub trait SettlementExecutor<C: Cycle>: Send + Sync {
+    /// Submission cutoff for settlements of an auction ranked at the given
+    /// tip.
+    fn submission_deadline(&self, tip: &C::Tip) -> u64;
+
+    /// Dispatches every winner. Implementations submit in the background,
+    /// the loop does not wait for settlement results.
+    async fn execute(&self, auction_id: i64, ranking: &C::Ranking, deadline: u64);
+}
+
+/// Competition bookkeeping around the settlement outcome.
+#[async_trait]
+pub trait SettlementObserver<C: Cycle>: Send + Sync {
+    /// All auction orders entered the competition.
+    fn orders_ready(&self, auction: &C::Auction);
+
+    /// Persists the competition outcome (auction, solutions, scores, fees).
+    /// Errors abort the cycle before any settlement is dispatched.
+    async fn competition_ranked(
+        &self,
+        auction: &C::Auction,
+        tip: &C::Tip,
+        ranking: &C::Ranking,
+        deadline: u64,
+    ) -> anyhow::Result<()>;
+
+    /// Winning orders are Executing, other ranked orders Considered.
+    fn orders_matched(&self, executing: HashSet<C::OrderUid>, considered: HashSet<C::OrderUid>);
+
+    /// Final per cycle reporting after settlements were dispatched.
+    fn competition_ended(&self, auction: &C::Auction, ranking: &C::Ranking);
+}
+
+/// Chain generic auction loop. Owns the seams and the dedupe state, drives
+/// the phases in a fixed order.
+pub struct AuctionLoop<C: Cycle> {
+    trigger: Box<dyn CycleTrigger<C>>,
+    provider: Box<dyn AuctionProvider<C>>,
+    competition: Box<dyn SolverCompetition<C>>,
+    winner_selection: Box<dyn WinnerSelection<C>>,
+    executor: Box<dyn SettlementExecutor<C>>,
+    observer: Box<dyn SettlementObserver<C>>,
+    prev_auction: Option<C::Auction>,
+    prev_tip: Option<C::Tip>,
+}
+
+impl<C: Cycle> AuctionLoop<C> {
+    pub fn new(
+        trigger: Box<dyn CycleTrigger<C>>,
+        provider: Box<dyn AuctionProvider<C>>,
+        competition: Box<dyn SolverCompetition<C>>,
+        winner_selection: Box<dyn WinnerSelection<C>>,
+        executor: Box<dyn SettlementExecutor<C>>,
+        observer: Box<dyn SettlementObserver<C>>,
+    ) -> Self {
+        Self {
+            trigger,
+            provider,
+            competition,
+            winner_selection,
+            executor,
+            observer,
+            prev_auction: None,
+            prev_tip: None,
+        }
+    }
+
+    /// One iteration of the outer loop.
+    pub async fn run_cycle(&mut self) {
+        // wait for a state change worth a new auction
+        let tip = self.trigger.next_cycle().await;
+
+        // maintenance and cache cutoff for the tip
+        if let Err(err) = self.provider.sync_to_tip(&tip).await {
+            tracing::warn!(?err, "failed to update auction");
+        }
+
+        let Some(auction) = self.next_auction(&tip).await else {
+            return;
+        };
+        let auction_id = auction.id();
+        self.single_run(&auction)
+            .instrument(tracing::info_span!("auction", auction_id = %auction_id))
+            .await;
+    }
+
+    /// Cuts the next auction and dedupes against the previous cycle.
+    async fn next_auction(&mut self, tip: &C::Tip) -> Option<C::Auction> {
+        let auction = self.provider.cut_auction(tip).await?;
+
+        // Only rerun the competition if the auction or tip changed. The tip
+        // marker is only written when the auction was unchanged, so the
+        // dedupe kicks in one cycle after the auction first repeats.
+        let previous = self.prev_auction.replace(auction.clone());
+        if previous.as_ref() == Some(&auction)
+            && self.prev_tip.replace(tip.clone()).as_ref() == Some(tip)
+        {
+            return None;
+        }
+
+        Some(auction)
+    }
+
+    /// Runs one competition for the auction.
+    async fn single_run(&self, auction: &C::Auction) {
+        // mark all auction orders as ready
+        self.observer.orders_ready(auction);
+
+        // collect solutions from all drivers
+        let solutions = self.competition.solve(auction).await;
+        if solutions.is_empty() {
+            return;
+        }
+
+        let ranking = self.winner_selection.arbitrate(solutions, auction);
+        tracing::debug!(winners = ranking.winner_count(), "ranked solutions");
+
+        // the deadline derives from the tip observed after ranking
+        let ranking_tip = self.trigger.current_tip();
+        let deadline = self.executor.submission_deadline(&ranking_tip);
+
+        // storing the outcome must finish before any settlement starts
+        if let Err(err) = self
+            .observer
+            .competition_ranked(auction, &ranking_tip, &ranking, deadline)
+            .await
+        {
+            tracing::error!(?err, "failed to post-process competition");
+            return;
+        }
+
+        // winning orders are Executing, other ranked orders Considered
+        let executing = ranking.winning_order_uids();
+        let considered = ranking
+            .considered_order_uids()
+            .into_iter()
+            .filter(|uid| !executing.contains(uid))
+            .collect();
+        self.observer.orders_matched(executing, considered);
+
+        // dispatch winners for execution in the background
+        self.executor
+            .execute(auction.id(), &ranking, deadline)
+            .await;
+
+        self.observer.competition_ended(auction, &ranking);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::{
+            AuctionInfo,
+            AuctionLoop,
+            AuctionProvider,
+            ChainTypes,
+            Cycle,
+            CycleTrigger,
+            RankingInfo,
+            SettlementExecutor,
+            SettlementObserver,
+            SolverCompetition,
+            WinnerSelection,
+        },
+        async_trait::async_trait,
+        std::{
+            collections::{HashSet, VecDeque},
+            sync::{Arc, Mutex},
+        },
+    };
+
+    type Log = Arc<Mutex<Vec<String>>>;
+
+    fn record(log: &Log, entry: impl Into<String>) {
+        log.lock().unwrap().push(entry.into());
+    }
+
+    fn sorted(uids: HashSet<u64>) -> Vec<u64> {
+        let mut uids: Vec<_> = uids.into_iter().collect();
+        uids.sort();
+        uids
+    }
+
+    // test only chain proving the orchestration runs on anything satisfying
+    // the vocabulary
+
+    #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+    struct MockChain;
+
+    #[derive(Clone, Copy, PartialEq, Debug)]
+    struct MockTip(u64);
+
+    #[derive(Clone, Debug)]
+    struct MockAuction {
+        id: i64,
+        orders: Vec<u64>,
+    }
+
+    impl PartialEq for MockAuction {
+        // dedupe ignores the allocated id
+        fn eq(&self, other: &Self) -> bool {
+            self.orders == other.orders
+        }
+    }
+
+    struct MockSolution;
+
+    struct MockRanking {
+        winning: Vec<u64>,
+        considered: Vec<u64>,
+    }
+
+    impl ChainTypes for MockChain {
+        type AccountId = u64;
+        type OrderUid = u64;
+    }
+
+    impl Cycle for MockChain {
+        type Auction = MockAuction;
+        type Ranking = MockRanking;
+        type Solution = MockSolution;
+        type Tip = MockTip;
+    }
+
+    impl AuctionInfo<MockChain> for MockAuction {
+        fn id(&self) -> i64 {
+            self.id
+        }
+    }
+
+    impl RankingInfo<MockChain> for MockRanking {
+        fn winner_count(&self) -> usize {
+            usize::from(!self.winning.is_empty())
+        }
+
+        fn winning_order_uids(&self) -> HashSet<u64> {
+            self.winning.iter().copied().collect()
+        }
+
+        fn considered_order_uids(&self) -> HashSet<u64> {
+            self.considered.iter().copied().collect()
+        }
+    }
+
+    struct MockTrigger {
+        log: Log,
+        tips: VecDeque<MockTip>,
+        current: MockTip,
+    }
+
+    #[async_trait]
+    impl CycleTrigger<MockChain> for MockTrigger {
+        async fn next_cycle(&mut self) -> MockTip {
+            let tip = self.tips.pop_front().expect("test drove too many cycles");
+            record(&self.log, format!("next_cycle tip={}", tip.0));
+            tip
+        }
+
+        fn current_tip(&self) -> MockTip {
+            record(&self.log, format!("current_tip tip={}", self.current.0));
+            self.current
+        }
+    }
+
+    struct MockProvider {
+        log: Log,
+        auctions: Mutex<VecDeque<Option<MockAuction>>>,
+    }
+
+    #[async_trait]
+    impl AuctionProvider<MockChain> for MockProvider {
+        async fn sync_to_tip(&self, tip: &MockTip) -> anyhow::Result<()> {
+            record(&self.log, format!("sync tip={}", tip.0));
+            Ok(())
+        }
+
+        async fn cut_auction(&self, _tip: &MockTip) -> Option<MockAuction> {
+            let auction = self
+                .auctions
+                .lock()
+                .unwrap()
+                .pop_front()
+                .expect("test drove too many cuts");
+            match &auction {
+                Some(auction) => record(&self.log, format!("cut auction={}", auction.id)),
+                None => record(&self.log, "cut none"),
+            }
+            auction
+        }
+    }
+
+    struct MockCompetition {
+        log: Log,
+        solution_counts: Mutex<VecDeque<usize>>,
+    }
+
+    #[async_trait]
+    impl SolverCompetition<MockChain> for MockCompetition {
+        async fn solve(&self, auction: &MockAuction) -> Vec<MockSolution> {
+            let count = self
+                .solution_counts
+                .lock()
+                .unwrap()
+                .pop_front()
+                .expect("test drove too many solves");
+            record(
+                &self.log,
+                format!("solve auction={} solutions={count}", auction.id),
+            );
+            (0..count).map(|_| MockSolution).collect()
+        }
+    }
+
+    struct MockWinnerSelection {
+        log: Log,
+    }
+
+    impl WinnerSelection<MockChain> for MockWinnerSelection {
+        fn arbitrate(&self, solutions: Vec<MockSolution>, auction: &MockAuction) -> MockRanking {
+            record(
+                &self.log,
+                format!(
+                    "arbitrate auction={} solutions={}",
+                    auction.id,
+                    solutions.len()
+                ),
+            );
+            MockRanking {
+                winning: vec![1, 2],
+                // order 2 also appears in a winning solution, the loop must
+                // subtract it before marking Considered
+                considered: vec![2, 3],
+            }
+        }
+    }
+
+    struct MockExecutor {
+        log: Log,
+    }
+
+    #[async_trait]
+    impl SettlementExecutor<MockChain> for MockExecutor {
+        fn submission_deadline(&self, tip: &MockTip) -> u64 {
+            record(&self.log, format!("deadline tip={}", tip.0));
+            tip.0 + 100
+        }
+
+        async fn execute(&self, auction_id: i64, _ranking: &MockRanking, deadline: u64) {
+            record(
+                &self.log,
+                format!("execute auction={auction_id} deadline={deadline}"),
+            );
+        }
+    }
+
+    struct MockObserver {
+        log: Log,
+    }
+
+    #[async_trait]
+    impl SettlementObserver<MockChain> for MockObserver {
+        fn orders_ready(&self, auction: &MockAuction) {
+            record(&self.log, format!("ready auction={}", auction.id));
+        }
+
+        async fn competition_ranked(
+            &self,
+            auction: &MockAuction,
+            tip: &MockTip,
+            _ranking: &MockRanking,
+            deadline: u64,
+        ) -> anyhow::Result<()> {
+            record(
+                &self.log,
+                format!(
+                    "ranked auction={} tip={} deadline={deadline}",
+                    auction.id, tip.0
+                ),
+            );
+            Ok(())
+        }
+
+        fn orders_matched(&self, executing: HashSet<u64>, considered: HashSet<u64>) {
+            record(
+                &self.log,
+                format!(
+                    "matched executing={:?} considered={:?}",
+                    sorted(executing),
+                    sorted(considered)
+                ),
+            );
+        }
+
+        fn competition_ended(&self, auction: &MockAuction, _ranking: &MockRanking) {
+            record(&self.log, format!("ended auction={}", auction.id));
+        }
+    }
+
+    /// Drives the generic loop through five cycles over a mock chain and
+    /// asserts the exact phase sequence, including the dedupe and its one
+    /// cycle lag on the tip marker.
+    #[tokio::test]
+    async fn phases_run_in_the_order_of_the_real_loop() {
+        let log = Log::default();
+        let auction = |id| MockAuction {
+            id,
+            orders: vec![1, 2, 3],
+        };
+
+        let mut auction_loop: AuctionLoop<MockChain> = AuctionLoop::new(
+            Box::new(MockTrigger {
+                log: log.clone(),
+                tips: [MockTip(1), MockTip(1), MockTip(1), MockTip(2), MockTip(2)].into(),
+                current: MockTip(9),
+            }),
+            Box::new(MockProvider {
+                log: log.clone(),
+                auctions: Mutex::new(
+                    [
+                        Some(auction(1)),
+                        Some(auction(2)),
+                        Some(auction(3)),
+                        Some(auction(4)),
+                        Some(auction(5)),
+                    ]
+                    .into(),
+                ),
+            }),
+            Box::new(MockCompetition {
+                log: log.clone(),
+                solution_counts: Mutex::new([1, 0, 0].into()),
+            }),
+            Box::new(MockWinnerSelection { log: log.clone() }),
+            Box::new(MockExecutor { log: log.clone() }),
+            Box::new(MockObserver { log: log.clone() }),
+        );
+
+        for _ in 0..5 {
+            auction_loop.run_cycle().await;
+        }
+
+        let expected = vec![
+            // cycle 1, fresh auction, full competition
+            "next_cycle tip=1",
+            "sync tip=1",
+            "cut auction=1",
+            "ready auction=1",
+            "solve auction=1 solutions=1",
+            "arbitrate auction=1 solutions=1",
+            "current_tip tip=9",
+            "deadline tip=9",
+            "ranked auction=1 tip=9 deadline=109",
+            "matched executing=[1, 2] considered=[3]",
+            "execute auction=1 deadline=109",
+            "ended auction=1",
+            // cycle 2, identical auction on the same tip still runs once more
+            // because the tip marker is written one cycle behind the auction
+            // marker
+            "next_cycle tip=1",
+            "sync tip=1",
+            "cut auction=2",
+            "ready auction=2",
+            "solve auction=2 solutions=0",
+            // cycle 3, now the dedupe kicks in right after cutting
+            "next_cycle tip=1",
+            "sync tip=1",
+            "cut auction=3",
+            // cycle 4, same auction but a new tip reruns the competition
+            "next_cycle tip=2",
+            "sync tip=2",
+            "cut auction=4",
+            "ready auction=4",
+            "solve auction=4 solutions=0",
+            // cycle 5, the new tip repeats and dedupes one cycle later, same
+            // as cycle 3 did for the first tip
+            "next_cycle tip=2",
+            "sync tip=2",
+            "cut auction=5",
+        ];
+        assert_eq!(*log.lock().unwrap(), expected);
+    }
 }

--- a/crates/chain-types/src/solana.rs
+++ b/crates/chain-types/src/solana.rs
@@ -3,7 +3,7 @@
 //! No solana-sdk dependency: the algorithm only needs identifiers it can
 //! hash and compare, 32-byte newtypes suffice.
 
-use crate::{Amount, ChainTypes, MathError, MathResult};
+use crate::{Amount, ChainTypes, MathError, MathResult, Scoring};
 
 /// A Solana account address (token mint or solver identity).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -20,8 +20,11 @@ pub struct Solana;
 
 impl ChainTypes for Solana {
     type AccountId = Pubkey;
-    type Amount = u64;
     type OrderUid = IntentHash;
+}
+
+impl Scoring for Solana {
+    type Amount = u64;
     type TokenId = Pubkey;
 
     /// Lamports per SOL (9 decimals).

--- a/crates/winner-selection/src/arbitrator.rs
+++ b/crates/winner-selection/src/arbitrator.rs
@@ -3,12 +3,12 @@
 //! Implements the auction winner selection algorithm that picks the set of
 //! solutions which maximize surplus while enforcing uniform directional
 //! clearing prices. The algorithm is written once, generic over the chain's
-//! type vocabulary ([`ChainTypes`]).
+//! scoring vocabulary ([`Scoring`]).
 
 use {
     crate::{
         auction::AuctionContext,
-        chain::{Amount, ChainTypes, MathError, MathResult, SaturatingAdd, Zero},
+        chain::{Amount, MathError, MathResult, SaturatingAdd, Scoring, Zero},
         evm::Evm,
         primitives::{DirectedTokenPair, FeePolicy, Quote, Side},
         solution::{Order, RankType, Solution, Unscored},
@@ -24,7 +24,7 @@ use {
 };
 
 /// Auction arbitrator responsible for selecting winning solutions.
-pub struct Arbitrator<C: ChainTypes = Evm> {
+pub struct Arbitrator<C: Scoring = Evm> {
     /// Maximum number of winning solutions to select.
     pub max_winners: usize,
     /// Wrapped native token (WETH on mainnet, WXDAI on Gnosis, wSOL on
@@ -32,7 +32,7 @@ pub struct Arbitrator<C: ChainTypes = Evm> {
     pub wrapped_native: C::TokenId,
 }
 
-impl<C: ChainTypes> Arbitrator<C> {
+impl<C: Scoring> Arbitrator<C> {
     /// Runs the auction mechanism on solutions.
     ///
     /// Takes solutions and auction context, returns a ranking with winners.
@@ -618,7 +618,7 @@ impl<C: ChainTypes> Arbitrator<C> {
 /// Let's call a solution that only trades 1 directed token pair a baseline
 /// solution. Returns the best baseline solution (highest score) for
 /// each token pair if one exists.
-fn compute_baseline_scores<C: ChainTypes>(
+fn compute_baseline_scores<C: Scoring>(
     scores_by_solution: &ScoresBySolution<C>,
 ) -> ScoreByDirection<C> {
     let mut baseline_scores = HashMap::default();
@@ -640,7 +640,7 @@ fn compute_baseline_scores<C: ChainTypes>(
 }
 
 /// Result of partitioning solutions into fair and unfair.
-struct PartitionedSolutions<C: ChainTypes> {
+struct PartitionedSolutions<C: Scoring> {
     /// Solutions that passed fairness checks (with scores).
     kept: Vec<Solution<Scored<C::Amount>, C>>,
     /// Solutions that were filtered out as unfair (with scores).
@@ -649,7 +649,7 @@ struct PartitionedSolutions<C: ChainTypes> {
 
 /// Final ranking of all solutions.
 #[derive(Debug)]
-pub struct Ranking<C: ChainTypes = Evm> {
+pub struct Ranking<C: Scoring = Evm> {
     /// Solutions that were filtered out as unfair (with scores and FilteredOut
     /// rank).
     pub filtered_out: Vec<Solution<Ranked<C::Amount>, C>>,
@@ -658,7 +658,7 @@ pub struct Ranking<C: ChainTypes = Evm> {
     pub ranked: Vec<Solution<Ranked<C::Amount>, C>>,
 }
 
-impl<C: ChainTypes> Ranking<C> {
+impl<C: Scoring> Ranking<C> {
     /// All winning solutions.
     pub fn winners(&self) -> impl Iterator<Item = &Solution<Ranked<C::Amount>, C>> {
         self.ranked.iter().filter(|s| s.is_winner())
@@ -675,7 +675,7 @@ impl<C: ChainTypes> Ranking<C> {
 /// These can be either uniform (same for all orders) or custom (adjusted for
 /// protocol fees on a per-order basis).
 #[derive(Debug, Clone, Copy)]
-struct ClearingPrices<C: ChainTypes> {
+struct ClearingPrices<C: Scoring> {
     /// Price of sell token in terms of buy token.
     sell: C::Amount,
     /// Price of buy token in terms of sell token.
@@ -684,7 +684,7 @@ struct ClearingPrices<C: ChainTypes> {
 
 /// Price limits for an order or quote.
 #[derive(Debug, Clone, Copy)]
-struct PriceLimits<C: ChainTypes> {
+struct PriceLimits<C: Scoring> {
     /// Maximum sell amount.
     sell: C::Amount,
     /// Minimum buy amount.
@@ -693,18 +693,18 @@ struct PriceLimits<C: ChainTypes> {
 
 /// Key to uniquely identify every solution.
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
-struct SolutionKey<C: ChainTypes> {
+struct SolutionKey<C: Scoring> {
     solver: C::AccountId,
     solution_id: u64,
 }
 
 /// Solutions annotated with their total score.
-type ScoredSolutions<C> = Vec<Solution<Scored<<C as ChainTypes>::Amount>, C>>;
+type ScoredSolutions<C> = Vec<Solution<Scored<<C as Scoring>::Amount>, C>>;
 
 /// Scores of all trades in a solution aggregated by the directional
 /// token pair. E.g. all trades (WETH -> USDC) are aggregated into
 /// one value and all trades (USDC -> WETH) into another.
-type ScoreByDirection<C> = HashMap<DirectedTokenPair<C>, <C as ChainTypes>::Amount>;
+type ScoreByDirection<C> = HashMap<DirectedTokenPair<C>, <C as Scoring>::Amount>;
 
 /// Mapping from solution to `DirectionalScores` for all solutions
 /// of the auction.

--- a/crates/winner-selection/src/auction.rs
+++ b/crates/winner-selection/src/auction.rs
@@ -5,7 +5,7 @@
 //! and is the same for all solutions.
 
 use {
-    crate::{chain::ChainTypes, evm::Evm, primitives::FeePolicy},
+    crate::{chain::Scoring, evm::Evm, primitives::FeePolicy},
     std::collections::{HashMap, HashSet},
 };
 
@@ -14,7 +14,7 @@ use {
 /// This contains auction-level data that's needed to run the winner selection
 /// algorithm but isn't part of individual solutions. Both autopilot and driver
 /// build this from their respective auction representations.
-pub struct AuctionContext<C: ChainTypes = Evm> {
+pub struct AuctionContext<C: Scoring = Evm> {
     /// Fee policies for each order in the auction.
     ///
     /// Maps order UID to the list of fee policies that apply to that order.
@@ -35,7 +35,7 @@ pub struct AuctionContext<C: ChainTypes = Evm> {
 }
 
 // Manual impl because `derive(Default)` would wrongly require `C: Default`.
-impl<C: ChainTypes> Default for AuctionContext<C> {
+impl<C: Scoring> Default for AuctionContext<C> {
     fn default() -> Self {
         Self {
             fee_policies: HashMap::default(),
@@ -45,7 +45,7 @@ impl<C: ChainTypes> Default for AuctionContext<C> {
     }
 }
 
-impl<C: ChainTypes> AuctionContext<C> {
+impl<C: Scoring> AuctionContext<C> {
     /// Check if an order contributes to the solution's score.
     ///
     /// An order contributes to score if:

--- a/crates/winner-selection/src/lib.rs
+++ b/crates/winner-selection/src/lib.rs
@@ -5,8 +5,8 @@
 //! their full solution types to these minimal structs, which are then sent to
 //! the Pod Service for storage and later retrieval.
 //!
-//! The algorithm is generic over the chain's type vocabulary
-//! ([`chain::ChainTypes`]). Every generic type defaults its chain parameter
+//! The algorithm is generic over the chain's scoring vocabulary
+//! ([`chain::Scoring`]). Every generic type defaults its chain parameter
 //! to [`evm::Evm`], so bare type names mean the EVM instantiation, and
 //! Solana callers instantiate the same logic with [`solana::Solana`].
 
@@ -24,7 +24,7 @@ mod tests;
 pub use {
     arbitrator::{Arbitrator, Ranking},
     auction::AuctionContext,
-    chain_types::{Amount, ChainTypes},
+    chain_types::{Amount, Scoring},
     primitives::{Address, DirectedTokenPair, OrderUid, Side, U256},
     solution::{Order, RankType, Ranked, Scored, Solution, Unscored},
 };

--- a/crates/winner-selection/src/primitives.rs
+++ b/crates/winner-selection/src/primitives.rs
@@ -1,7 +1,7 @@
 //! Primitive types for winner selection, generic over the chain.
 
 pub use crate::evm::{Address, NATIVE_TOKEN, OrderUid, U256, as_erc20};
-use crate::{chain::ChainTypes, evm::Evm};
+use crate::{chain::Scoring, evm::Evm};
 
 /// A directed token pair for tracking uniform clearing prices.
 ///
@@ -9,7 +9,7 @@ use crate::{chain::ChainTypes, evm::Evm};
 /// selling token B to buy token A for the purpose of uniform directional
 /// clearing prices.
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
-pub struct DirectedTokenPair<C: ChainTypes = Evm> {
+pub struct DirectedTokenPair<C: Scoring = Evm> {
     pub sell: C::TokenId,
     pub buy: C::TokenId,
 }
@@ -23,7 +23,7 @@ pub enum Side {
 
 /// Protocol fee policy.
 #[derive(Debug, Clone, Copy, PartialEq)]
-pub enum FeePolicy<C: ChainTypes = Evm> {
+pub enum FeePolicy<C: Scoring = Evm> {
     /// Fee as a percentage of surplus over limit price.
     Surplus { factor: f64, max_volume_factor: f64 },
     /// Fee as a percentage of price improvement over quote.
@@ -38,7 +38,7 @@ pub enum FeePolicy<C: ChainTypes = Evm> {
 
 /// Quote data for price improvement fee calculation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct Quote<C: ChainTypes = Evm> {
+pub struct Quote<C: Scoring = Evm> {
     pub sell_amount: C::Amount,
     pub buy_amount: C::Amount,
     pub fee: C::Amount,

--- a/crates/winner-selection/src/solution.rs
+++ b/crates/winner-selection/src/solution.rs
@@ -6,7 +6,7 @@
 pub use state::{RankType, Unscored};
 
 use crate::{
-    chain::ChainTypes,
+    chain::Scoring,
     evm::{Evm, U256},
     primitives::Side,
     state,
@@ -19,7 +19,7 @@ pub type Ranked = state::Ranked<U256>;
 /// This contains only what's absolutely necessary to run the winner selection
 /// algorithm.
 #[derive(Debug, Clone)]
-pub struct Solution<State, C: ChainTypes = Evm> {
+pub struct Solution<State, C: Scoring = Evm> {
     /// Solution ID from solver (unique per solver).
     id: u64,
 
@@ -33,7 +33,7 @@ pub struct Solution<State, C: ChainTypes = Evm> {
     state: State,
 }
 
-impl<T, C: ChainTypes> Solution<T, C> {
+impl<T, C: Scoring> Solution<T, C> {
     /// Get the solution ID.
     pub fn id(&self) -> u64 {
         self.id
@@ -50,7 +50,7 @@ impl<T, C: ChainTypes> Solution<T, C> {
     }
 }
 
-impl<State, C: ChainTypes> state::HasState for Solution<State, C> {
+impl<State, C: Scoring> state::HasState for Solution<State, C> {
     type Next<NewState> = Solution<NewState, C>;
     type State = State;
 
@@ -68,7 +68,7 @@ impl<State, C: ChainTypes> state::HasState for Solution<State, C> {
     }
 }
 
-impl<C: ChainTypes> Solution<Unscored, C> {
+impl<C: Scoring> Solution<Unscored, C> {
     /// Create a new unscored solution.
     pub fn new(id: u64, solver: C::AccountId, orders: Vec<Order<C>>) -> Self {
         Self {
@@ -86,7 +86,7 @@ impl<C: ChainTypes> Solution<Unscored, C> {
 /// including limit amounts (from the original order) and executed amounts
 /// (what actually happened in this solution).
 #[derive(Debug, Clone)]
-pub struct Order<C: ChainTypes = Evm> {
+pub struct Order<C: Scoring = Evm> {
     /// Unique order identifier.
     pub uid: C::OrderUid,
 

--- a/crates/winner-selection/src/tests.rs
+++ b/crates/winner-selection/src/tests.rs
@@ -5,7 +5,7 @@ use {
     crate::{
         arbitrator::Arbitrator,
         auction::AuctionContext,
-        chain::ChainTypes,
+        chain::Scoring,
         evm::{Evm, OrderUid},
         primitives::{FeePolicy, Side},
         solana::{IntentHash, Pubkey, Solana},
@@ -33,7 +33,7 @@ const SOL_UNIT_PRICE: u64 = 1_000_000_000;
 
 /// A sell order executing at `executed_buy` against a `sell/buy` 100/90
 /// limit. Surplus over limit = executed_buy - 90.
-fn sell_order<C: ChainTypes>(
+fn sell_order<C: Scoring>(
     uid: C::OrderUid,
     sell_token: C::TokenId,
     buy_token: C::TokenId,


### PR DESCRIPTION
# Description
This PR lands the shared orchestration vocabulary and the generic auction loop, so the Solana demo loop and, later, the EVM loop build against one contract. The autopilot per-cycle flow (wake, cut the auction, solve, rank, dispatch, observe) becomes a generic `AuctionLoop` over six seam traits, with no chain-specific code in the loop. It lives in the existing `chain-types` crate rather than a new one, and the per-chain vocabulary is split into three layers so each consumer depends only on what it needs.

# Changes
- Split `ChainTypes` into a shared identity base (`OrderUid`, `AccountId`), plus `Scoring` (math half: `TokenId`, `Amount`, `canonical_token`, `uid_owner`, `value_in_native`) and `Cycle` (loop half: `Tip`, `Auction`, `Solution`, `Ranking`).
- Added the six seam traits (`CycleTrigger`, `AuctionProvider`, `SolverCompetition`, `WinnerSelection`, `SettlementExecutor`, `SettlementObserver`) and the generic `AuctionLoop` that owns the phase order and the auction dedupe.
- Rebound the winner-selection crate to `Scoring`, since it needs the math half, not the loop half.
- ADR trims: `AuctionId` is a concrete `i64`, `SubmissionDeadline` is a `u64`, leadership stays out of the loop as a chain-agnostic concern for the caller.

# How to test
New unit test. The phase-order test drives the loop over a mock chain and asserts the exact phase sequence, including the dedupe's one-cycle tip lag. The existing winner-selection tests pass unchanged against `Scoring`.

# Related issues
Resolves [BE-179](https://linear.app/cowswap/issue/BE-179/pr03-chain-loop-crate). Stacked on #4702.
