### PR TITLE
[trivial] add metrics for incoming requests

### DIFF
--- a/crates/orderbook/src/api.rs
+++ b/crates/orderbook/src/api.rs
@@ -124,6 +124,11 @@ async fn with_matched_path_metric(req: Request<axum::body::Body>, next: Next) ->
         .unwrap_or("unknown");
     let method_with_path = format!("{http_method} {matched_path}");
 
+    metrics
+        .requests_started
+        .with_label_values(&[method_with_path.as_str()])
+        .inc();
+
     let response = {
         let _timer = metrics
             .requests_duration_seconds
@@ -356,6 +361,10 @@ pub fn handle_all_routes(
 #[derive(prometheus_metric_storage::MetricStorage, Clone, Debug)]
 #[metric(subsystem = "api")]
 struct ApiMetrics {
+    /// Number of started API requests.
+    #[metric(labels("method"))]
+    requests_started: prometheus::IntCounterVec,
+
     /// Number of completed API requests.
     #[metric(labels("method", "status_code"))]
     requests_complete: prometheus::IntCounterVec,


### PR DESCRIPTION
# Description
Forgotten follow up to a post mortem.
During one incident our request spam alerts didn't kick in because we alert based on finished requests but the spammer cancelled requests before we processed them completely.

# Changes
introduce metric to track started requests in addition to finished requests.