### PR TITLE
[EASY] Add TokenAmount and ContractAddress composites

### DIFF
--- a/crates/chain-types/src/lib.rs
+++ b/crates/chain-types/src/lib.rs
@@ -3,7 +3,8 @@
 //! Chain-generic algorithms need identifiers they can hash and compare,
 //! amounts they can do checked arithmetic on, and a small set of
 //! chain-specific hooks. This crate defines that vocabulary ([`ChainTypes`],
-//! [`Amount`]) together with its EVM and Solana instantiations.
+//! [`Amount`]) plus common composite types ([`TokenAmount`],
+//! [`ContractAddress`]), together with its EVM and Solana instantiations.
 
 pub mod evm;
 pub mod solana;
@@ -86,4 +87,16 @@ pub enum MathError {
     DivisionByZero,
     #[error("negative")]
     Negative,
+}
+
+/// An account known to be a contract or program, as opposed to an arbitrary
+/// account. The newtype stops the two from being passed interchangeably.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct ContractAddress<C: ChainTypes>(pub C::AccountId);
+
+/// An amount together with the token it is denominated in.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct TokenAmount<C: ChainTypes> {
+    pub token: C::TokenId,
+    pub amount: C::Amount,
 }

--- a/crates/chain-types/src/lib.rs
+++ b/crates/chain-types/src/lib.rs
@@ -90,7 +90,7 @@ pub enum MathError {
 }
 
 /// An account known to be a contract or program, as opposed to an arbitrary
-/// account. The newtype stops the two from being passed interchangeably.
+/// account.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct ContractAddress<C: ChainTypes>(pub C::AccountId);
 


### PR DESCRIPTION
# Description
Adds two common composite vocabulary types to `chain-types` so identifiers and amounts carry their meaning in the type system: a contract or program address distinct from an arbitrary account, and an amount paired with the token it is denominated in. Both are generic over the chain vocabulary, so EVM, Solana, and winner-selection can use them. Open question for review: these are generic over the chain, an alternative is concrete per-chain newtypes.

# Changes
- `ContractAddress<C: ChainTypes>(C::AccountId)`, an account known to be a contract or program, kept distinct from an arbitrary account.
- `TokenAmount<C: ChainTypes> { token, amount }`, an amount together with the token it is denominated in.

# How to test
Existing tests.

# Related issues
Resolves [BE-206](https://linear.app/cowswap/issue/BE-206/chain-types-add-tokenamount-and-contractaddress-composites).
