### PR TITLE
generate and send new auction_id with fast path quotes

### DIFF
--- a/crates/autopilot/src/database/auction.rs
+++ b/crates/autopilot/src/database/auction.rs
@@ -61,14 +61,7 @@ impl QuoteStoring for Postgres {
     }
 
     async fn get_next_auction_id(&self) -> Result<i64> {
-        let _timer = super::Metrics::get()
-            .database_queries
-            .with_label_values(&["get_next_auction_id"])
-            .start_timer();
-        let mut ex = self.pool.acquire().await?;
-        database::auction::get_next_auction_id(&mut ex)
-            .await
-            .context("failed to fetch next auction_id")
+        self.get_next_auction_id().await
     }
 }
 

--- a/crates/autopilot/src/database/auction.rs
+++ b/crates/autopilot/src/database/auction.rs
@@ -61,7 +61,9 @@ impl QuoteStoring for Postgres {
     }
 
     async fn get_next_auction_id(&self) -> Result<i64> {
-        self.get_next_auction_id().await
+        // explicitly DON'T call the trait method to protect against
+        // endless recursion after a botched function rename
+        Postgres::get_next_auction_id(self).await
     }
 }
 

--- a/crates/autopilot/src/database/auction.rs
+++ b/crates/autopilot/src/database/auction.rs
@@ -59,6 +59,17 @@ impl QuoteStoring for Postgres {
             .map(|quote| Ok((quote.id, quote.try_into()?)))
             .transpose()
     }
+
+    async fn get_next_auction_id(&self) -> Result<i64> {
+        let _timer = super::Metrics::get()
+            .database_queries
+            .with_label_values(&["get_next_auction_id"])
+            .start_timer();
+        let mut ex = self.pool.acquire().await?;
+        database::auction::get_next_auction_id(&mut ex)
+            .await
+            .context("failed to fetch next auction_id")
+    }
 }
 
 impl Postgres {

--- a/crates/orderbook/src/database/quotes.rs
+++ b/crates/orderbook/src/database/quotes.rs
@@ -53,4 +53,15 @@ impl QuoteStoring for Postgres {
             .map(|quote| Ok((quote.id, quote.try_into()?)))
             .transpose()
     }
+
+    async fn get_next_auction_id(&self) -> Result<i64> {
+        let _timer = super::Metrics::get()
+            .database_queries
+            .with_label_values(&["get_next_auction_id"])
+            .start_timer();
+        let mut ex = self.pool.acquire().await?;
+        database::auction::get_next_auction_id(&mut ex)
+            .await
+            .context("failed to fetch next auction_id")
+    }
 }

--- a/crates/price-estimation/src/competition/mod.rs
+++ b/crates/price-estimation/src/competition/mod.rs
@@ -278,6 +278,7 @@ mod tests {
                 block_dependent: false,
                 fast_path: false,
                 timeout: HEALTHY_PRICE_ESTIMATION_TIME,
+                auction_id: None,
             }),
             Arc::new(Query {
                 verification: Default::default(),
@@ -288,6 +289,7 @@ mod tests {
                 block_dependent: false,
                 fast_path: false,
                 timeout: HEALTHY_PRICE_ESTIMATION_TIME,
+                auction_id: None,
             }),
             Arc::new(Query {
                 verification: Default::default(),
@@ -298,6 +300,7 @@ mod tests {
                 block_dependent: false,
                 fast_path: false,
                 timeout: HEALTHY_PRICE_ESTIMATION_TIME,
+                auction_id: None,
             }),
             Arc::new(Query {
                 verification: Default::default(),
@@ -308,6 +311,7 @@ mod tests {
                 block_dependent: false,
                 fast_path: false,
                 timeout: HEALTHY_PRICE_ESTIMATION_TIME,
+                auction_id: None,
             }),
             Arc::new(Query {
                 verification: Default::default(),
@@ -318,6 +322,7 @@ mod tests {
                 block_dependent: false,
                 fast_path: false,
                 timeout: HEALTHY_PRICE_ESTIMATION_TIME,
+                auction_id: None,
             }),
         ];
         let estimates = [
@@ -417,6 +422,7 @@ mod tests {
             block_dependent: false,
             fast_path: false,
             timeout: HEALTHY_PRICE_ESTIMATION_TIME,
+            auction_id: None,
         });
 
         fn estimate(amount: u64) -> Estimate {
@@ -480,6 +486,7 @@ mod tests {
             block_dependent: false,
             fast_path: false,
             timeout: HEALTHY_PRICE_ESTIMATION_TIME,
+            auction_id: None,
         });
 
         fn estimate(amount: u64) -> Estimate {
@@ -561,6 +568,7 @@ mod tests {
             block_dependent: false,
             fast_path: false,
             timeout: HEALTHY_PRICE_ESTIMATION_TIME,
+            auction_id: None,
         });
 
         fn estimate(amount: u64) -> Estimate {
@@ -631,6 +639,7 @@ mod tests {
             block_dependent: false,
             fast_path: false,
             timeout: HEALTHY_PRICE_ESTIMATION_TIME,
+            auction_id: None,
         })
     }
 

--- a/crates/price-estimation/src/instrumented.rs
+++ b/crates/price-estimation/src/instrumented.rs
@@ -153,6 +153,7 @@ mod tests {
             block_dependent: false,
             fast_path: false,
             timeout: HEALTHY_PRICE_ESTIMATION_TIME,
+            auction_id: None,
         });
 
         let mut estimator = MockPriceEstimating::new();

--- a/crates/price-estimation/src/lib.rs
+++ b/crates/price-estimation/src/lib.rs
@@ -163,6 +163,10 @@ pub struct Query {
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub fast_path: bool,
     pub timeout: Duration,
+    /// Only populated for fast path requests and used to later tell the
+    /// driver which solution to execute.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub auction_id: Option<i64>,
 }
 
 /// Conditions under which a given price estimate needs to work in order to be

--- a/crates/price-estimation/src/native/mod.rs
+++ b/crates/price-estimation/src/native/mod.rs
@@ -97,6 +97,7 @@ impl NativePriceEstimator {
             block_dependent: false,
             fast_path: false,
             timeout,
+            auction_id: None,
         }
     }
 }

--- a/crates/price-estimation/src/sanitized.rs
+++ b/crates/price-estimation/src/sanitized.rs
@@ -216,6 +216,7 @@ mod tests {
                     block_dependent: false,
                     fast_path: false,
                     timeout: HEALTHY_PRICE_ESTIMATION_TIME,
+                    auction_id: None,
                 },
                 Ok(Estimate {
                     out_amount: U256::ONE,
@@ -239,6 +240,7 @@ mod tests {
                     block_dependent: false,
                     fast_path: false,
                     timeout: HEALTHY_PRICE_ESTIMATION_TIME,
+                    auction_id: None,
                 },
                 Ok(Estimate {
                     out_amount: U256::ONE,
@@ -262,6 +264,7 @@ mod tests {
                     block_dependent: false,
                     fast_path: false,
                     timeout: HEALTHY_PRICE_ESTIMATION_TIME,
+                    auction_id: None,
                 },
                 Err(PriceEstimationError::ProtocolInternal(anyhow::anyhow!(
                     "cost of converting native asset would overflow gas price"
@@ -280,6 +283,7 @@ mod tests {
                     block_dependent: false,
                     fast_path: false,
                     timeout: HEALTHY_PRICE_ESTIMATION_TIME,
+                    auction_id: None,
                 },
                 Ok(Estimate {
                     out_amount: U256::ONE,
@@ -304,6 +308,7 @@ mod tests {
                     block_dependent: false,
                     fast_path: false,
                     timeout: HEALTHY_PRICE_ESTIMATION_TIME,
+                    auction_id: None,
                 },
                 Ok(Estimate {
                     out_amount: U256::ONE,
@@ -325,6 +330,7 @@ mod tests {
                     block_dependent: false,
                     fast_path: false,
                     timeout: HEALTHY_PRICE_ESTIMATION_TIME,
+                    auction_id: None,
                 },
                 Ok(Estimate {
                     out_amount: U256::ONE,
@@ -346,6 +352,7 @@ mod tests {
                     block_dependent: false,
                     fast_path: false,
                     timeout: HEALTHY_PRICE_ESTIMATION_TIME,
+                    auction_id: None,
                 },
                 Ok(Estimate {
                     out_amount: U256::ONE,
@@ -368,6 +375,7 @@ mod tests {
                     block_dependent: false,
                     fast_path: false,
                     timeout: HEALTHY_PRICE_ESTIMATION_TIME,
+                    auction_id: None,
                 },
                 Ok(Estimate {
                     out_amount: U256::ONE,
@@ -390,6 +398,7 @@ mod tests {
                     block_dependent: false,
                     fast_path: false,
                     timeout: HEALTHY_PRICE_ESTIMATION_TIME,
+                    auction_id: None,
                 },
                 Err(PriceEstimationError::UnsupportedToken {
                     token: BAD_TOKEN,
@@ -407,6 +416,7 @@ mod tests {
                     block_dependent: false,
                     fast_path: false,
                     timeout: HEALTHY_PRICE_ESTIMATION_TIME,
+                    auction_id: None,
                 },
                 Err(PriceEstimationError::UnsupportedToken {
                     token: BAD_TOKEN,
@@ -535,6 +545,7 @@ mod tests {
                     block_dependent: false,
                     fast_path: false,
                     timeout: HEALTHY_PRICE_ESTIMATION_TIME,
+                    auction_id: None,
                 },
                 Ok(Estimate {
                     out_amount: U256::ONE,
@@ -555,6 +566,7 @@ mod tests {
                     block_dependent: false,
                     fast_path: false,
                     timeout: HEALTHY_PRICE_ESTIMATION_TIME,
+                    auction_id: None,
                 },
                 Ok(Estimate {
                     out_amount: U256::ONE,

--- a/crates/price-estimation/src/trade_finding/external.rs
+++ b/crates/price-estimation/src/trade_finding/external.rs
@@ -73,6 +73,7 @@ impl ExternalTradeFinder {
                 kind: query.kind,
                 deadline: chrono::Utc::now() + query.timeout,
                 fast_path: query.fast_path,
+                auction_id: query.auction_id,
             };
             let block_dependent = query.block_dependent;
             let id = observe::tracing::distributed::request_id::from_current_span();
@@ -401,8 +402,10 @@ pub mod dto {
         pub amount: U256,
         pub kind: OrderKind,
         pub deadline: chrono::DateTime<chrono::Utc>,
-        #[serde(default)]
+        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
         pub fast_path: bool,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        pub auction_id: Option<i64>,
     }
 
     #[serde_as]

--- a/crates/shared/src/order_quoting.rs
+++ b/crates/shared/src/order_quoting.rs
@@ -52,7 +52,11 @@ impl QuoteParameters {
         &self,
         default_quote_timeout: std::time::Duration,
         max_quote_timeout: std::time::Duration,
+        auction_id: Option<i64>,
     ) -> price_estimation::Query {
+        // TODO: refactor interfaces to make them impossible to misuse.
+        debug_assert_eq!(auction_id.is_some(), self.fast_path);
+
         let (kind, in_amount) = self.side.kind_and_amount();
 
         let timeout = self
@@ -69,6 +73,7 @@ impl QuoteParameters {
             block_dependent: true,
             fast_path: self.fast_path,
             timeout,
+            auction_id,
         }
     }
 
@@ -371,6 +376,10 @@ pub trait QuoteStoring: Send + Sync {
         parameters: QuoteSearchParameters,
         expiration: DateTime<Utc>,
     ) -> Result<Option<(QuoteId, QuoteData)>>;
+
+    /// Generates a new unique auction id. This is used to associate a fast path
+    /// quote with auction competition data.
+    async fn get_next_auction_id(&self) -> Result<i64>;
 }
 
 #[cfg_attr(test, mockall::automock)]
@@ -462,6 +471,11 @@ impl OrderQuoter {
         &self,
         parameters: &QuoteParameters,
     ) -> Result<QuoteData, CalculateQuoteError> {
+        let auction_id = match parameters.fast_path {
+            true => Some(self.storage.get_next_auction_id().await?),
+            false => None,
+        };
+
         let expiration = match parameters.signing_scheme {
             QuoteSigningScheme::Eip1271 {
                 onchain_order: true,
@@ -473,8 +487,11 @@ impl OrderQuoter {
             _ => self.now.now() + self.validity.standard_quote,
         };
 
-        let trade_query =
-            Arc::new(parameters.to_price_query(self.default_quote_timeout, self.max_quote_timeout));
+        let trade_query = Arc::new(parameters.to_price_query(
+            self.default_quote_timeout,
+            self.max_quote_timeout,
+            auction_id,
+        ));
         let (effective_gas_price, trade_estimate, sell_token_price, _) = futures::try_join!(
             self.gas_estimator
                 .effective_gas_price()
@@ -634,9 +651,16 @@ impl StreamingQuoting for OrderQuoter {
         let estimator = self.streaming_price_estimator.clone().ok_or_else(|| {
             CalculateQuoteError::Other(anyhow::anyhow!("streaming estimator not configured"))
         })?;
+        let auction_id = match parameters.fast_path {
+            true => Some(self.storage.get_next_auction_id().await?),
+            false => None,
+        };
 
-        let trade_query =
-            Arc::new(parameters.to_price_query(self.default_quote_timeout, self.max_quote_timeout));
+        let trade_query = Arc::new(parameters.to_price_query(
+            self.default_quote_timeout,
+            self.max_quote_timeout,
+            auction_id,
+        ));
 
         let (effective_gas_price, sell_token_price, _buy_token_price) = futures::try_join!(
             self.gas_estimator
@@ -969,6 +993,7 @@ mod tests {
                     block_dependent: true,
                     fast_path: false,
                     timeout: HEALTHY_PRICE_ESTIMATION_TIME,
+                    auction_id: None,
                 }
             })
             .returning(|_| {
@@ -1117,6 +1142,7 @@ mod tests {
                     block_dependent: true,
                     fast_path: false,
                     timeout: HEALTHY_PRICE_ESTIMATION_TIME,
+                    auction_id: None,
                 }
             })
             .returning(|_| {
@@ -1260,6 +1286,7 @@ mod tests {
                     block_dependent: true,
                     fast_path: false,
                     timeout: HEALTHY_PRICE_ESTIMATION_TIME,
+                    auction_id: None,
                 }
             })
             .returning(|_| {


### PR DESCRIPTION
# Description
To reuse the existing driver /settle logic we need to send an auction id with fast path quotes. That way the driver can cache solutions and later settle solutions like it normally would when we send `/settle?auctionId=1234&solutionId=1`.

# Changes
* generate new unique auction id for every fast path quote
* send that auction id in the `/quote` request
* documented in openapi spec