### PR TITLE
refactor quoting interfaces to work with full competition

### DIFF
--- a/crates/autopilot/src/database/auction.rs
+++ b/crates/autopilot/src/database/auction.rs
@@ -10,22 +10,24 @@ use {
     shared::{
         db_order_conversions::full_order_into_model_order,
         event_storing_helpers::{create_db_search_parameters, create_quote_row},
-        order_quoting::{QuoteData, QuoteSearchParameters, QuoteStoring},
+        order_quoting::{QuoteCompetition, QuoteData, QuoteSearchParameters, QuoteStoring},
     },
     std::{collections::HashMap, ops::DerefMut, sync::Arc},
 };
 
 #[async_trait::async_trait]
 impl QuoteStoring for Postgres {
-    async fn save(&self, data: QuoteData) -> Result<QuoteId> {
+    async fn save(&self, data: QuoteCompetition) -> Result<QuoteId> {
         let _timer = super::Metrics::get()
             .database_queries
             .with_label_values(&["save_quote"])
             .start_timer();
 
         let mut ex = self.pool.acquire().await?;
-        let row = create_quote_row(data)?;
+        let row = create_quote_row(&data)?;
         let id = database::quotes::save(&mut ex, &row).await?;
+        // TODO populate `competition_auctions`, `proposed_solutions`,
+        // `proposed_trade_executions`
         Ok(id)
     }
 

--- a/crates/autopilot/src/database/auction.rs
+++ b/crates/autopilot/src/database/auction.rs
@@ -26,8 +26,6 @@ impl QuoteStoring for Postgres {
         let mut ex = self.pool.acquire().await?;
         let row = create_quote_row(&data)?;
         let id = database::quotes::save(&mut ex, &row).await?;
-        // TODO populate `competition_auctions`, `proposed_solutions`,
-        // `proposed_trade_executions`
         Ok(id)
     }
 

--- a/crates/autopilot/src/database/onchain_order_events/mod.rs
+++ b/crates/autopilot/src/database/onchain_order_events/mod.rs
@@ -500,8 +500,8 @@ where
                     buy_amount: u256_to_big_decimal(&quote.buy_amount),
                     solver: ByteArray(*quote.data.solver.0),
                     verified: quote.data.verified,
-                    metadata: quote.data.metadata.try_into()?,
-                    auction_id: None,
+                    metadata: quote.data.metadata.clone().try_into()?,
+                    auction_id: quote.data.auction_id,
                 }),
                 Err(err) => {
                     let err_label = err.to_metrics_label();
@@ -1315,8 +1315,8 @@ mod test {
             buy_amount: u256_to_big_decimal(&quote.buy_amount),
             solver: ByteArray(*quote.data.solver.0),
             verified: quote.data.verified,
-            metadata: quote.data.metadata.try_into().unwrap(),
-            auction_id: None,
+            metadata: quote.data.metadata.clone().try_into().unwrap(),
+            auction_id: quote.data.auction_id,
         };
         assert_eq!(result.1, vec![Some(expected_quote)]);
         assert_eq!(

--- a/crates/orderbook/src/database/quotes.rs
+++ b/crates/orderbook/src/database/quotes.rs
@@ -5,21 +5,23 @@ use {
     model::quote::QuoteId,
     shared::{
         event_storing_helpers::{create_db_search_parameters, create_quote_row},
-        order_quoting::{QuoteData, QuoteSearchParameters, QuoteStoring},
+        order_quoting::{QuoteCompetition, QuoteData, QuoteSearchParameters, QuoteStoring},
     },
 };
 
 #[async_trait::async_trait]
 impl QuoteStoring for Postgres {
-    async fn save(&self, data: QuoteData) -> Result<QuoteId> {
+    async fn save(&self, data: QuoteCompetition) -> Result<QuoteId> {
         let _timer = super::Metrics::get()
             .database_queries
             .with_label_values(&["save_quote"])
             .start_timer();
 
         let mut ex = self.pool.acquire().await?;
-        let row = create_quote_row(data)?;
+        let row = create_quote_row(&data)?;
         let id = database::quotes::save(&mut ex, &row).await?;
+        // TODO populate `competition_auctions`, `proposed_solutions`,
+        // `proposed_trade_executions`
         Ok(id)
     }
 

--- a/crates/orderbook/src/quoter.rs
+++ b/crates/orderbook/src/quoter.rs
@@ -132,7 +132,7 @@ impl QuoteHandler {
                     .store_quote(competition.clone())
                     .await
                     .map_err(CalculateQuoteError::Other)?;
-                let mut quote = competition.to_final_quote(&params)?;
+                let mut quote = competition.to_final_quote(&params);
                 quote.id = Some(id);
                 quote
             }
@@ -141,7 +141,7 @@ impl QuoteHandler {
                 // Fast quotes always have an expiry of zero because they're not
                 // very accurate and can be considered to expire immediately.
                 competition.metadata.expiration = Utc.timestamp_millis_opt(0).unwrap();
-                competition.to_final_quote(&params)?
+                competition.to_final_quote(&params)
             }
         };
 

--- a/crates/orderbook/src/quoter.rs
+++ b/crates/orderbook/src/quoter.rs
@@ -126,18 +126,22 @@ impl QuoteHandler {
 
         let quote = match request.price_quality {
             PriceQuality::Optimal | PriceQuality::Verified => {
-                let quote = self.optimal_quoter.calculate_quote(params).await?;
-                self.optimal_quoter
-                    .store_quote(quote)
+                let competition = self.optimal_quoter.calculate_quote(params.clone()).await?;
+                let id = self
+                    .optimal_quoter
+                    .store_quote(competition.clone())
                     .await
-                    .map_err(CalculateQuoteError::Other)?
+                    .map_err(CalculateQuoteError::Other)?;
+                let mut quote = competition.to_final_quote(&params)?;
+                quote.id = Some(id);
+                quote
             }
             PriceQuality::Fast => {
-                let mut quote = self.fast_quoter.calculate_quote(params).await?;
+                let mut competition = self.fast_quoter.calculate_quote(params.clone()).await?;
                 // Fast quotes always have an expiry of zero because they're not
                 // very accurate and can be considered to expire immediately.
-                quote.data.expiration = Utc.timestamp_millis_opt(0).unwrap();
-                quote
+                competition.metadata.expiration = Utc.timestamp_millis_opt(0).unwrap();
+                competition.to_final_quote(&params)?
             }
         };
 
@@ -536,6 +540,7 @@ mod tests {
                 verified: false,
                 supports_fast_path: false,
                 metadata: Default::default(),
+                auction_id: None,
             },
             sell_amount,
             buy_amount,

--- a/crates/price-estimation/src/lib.rs
+++ b/crates/price-estimation/src/lib.rs
@@ -256,16 +256,16 @@ impl RankedEstimates {
         Self { values }
     }
 
-    pub fn into_best(self) -> Estimate {
-        self.values
-            .into_iter()
-            .next()
-            .expect("non-empty by construction")
-    }
-
     /// Returns all estimates ordered best to worst.
+    #[cfg(test)]
     pub fn into_vec(self) -> Vec<Estimate> {
         self.values
+    }
+
+    pub fn into_best_and_rest(self) -> (Estimate, impl Iterator<Item = Estimate>) {
+        let mut iter = self.values.into_iter();
+        let best = iter.next().expect("non-empty by construction");
+        (best, iter)
     }
 }
 

--- a/crates/shared/src/event_storing_helpers.rs
+++ b/crates/shared/src/event_storing_helpers.rs
@@ -29,7 +29,7 @@ pub fn create_quote_row(competition: &QuoteCompetition) -> Result<DbQuote> {
         solver: ByteArray(*data.solver.0),
         verified: data.verified,
         metadata: data.metadata.try_into()?,
-        auction_id: competition.metadata.auction_id,
+        auction_id: None,
     })
 }
 

--- a/crates/shared/src/event_storing_helpers.rs
+++ b/crates/shared/src/event_storing_helpers.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         db_order_conversions::order_kind_into,
-        order_quoting::{QuoteData, QuoteSearchParameters, quote_kind_from_signing_scheme},
+        order_quoting::{QuoteCompetition, QuoteSearchParameters, quote_kind_from_signing_scheme},
     },
     anyhow::Result,
     chrono::{DateTime, Utc},
@@ -12,7 +12,8 @@ use {
     number::conversions::u256_to_big_decimal,
 };
 
-pub fn create_quote_row(data: QuoteData) -> Result<DbQuote> {
+pub fn create_quote_row(competition: &QuoteCompetition) -> Result<DbQuote> {
+    let data = competition.to_quote_data();
     Ok(DbQuote {
         id: Default::default(),
         sell_token: ByteArray(*data.sell_token.0),
@@ -28,7 +29,7 @@ pub fn create_quote_row(data: QuoteData) -> Result<DbQuote> {
         solver: ByteArray(*data.solver.0),
         verified: data.verified,
         metadata: data.metadata.try_into()?,
-        auction_id: None,
+        auction_id: competition.metadata.auction_id,
     })
 }
 

--- a/crates/shared/src/order_quoting.rs
+++ b/crates/shared/src/order_quoting.rs
@@ -265,7 +265,7 @@ pub struct QuoteResponse {
 
 impl QuoteCompetition {
     /// Constructor enforcing that there is at least 1 quote.
-    pub fn new(
+    pub(crate) fn new(
         request: QuoteRequest,
         best: QuoteResponse,
         rest: impl IntoIterator<Item = QuoteResponse>,
@@ -305,14 +305,9 @@ impl QuoteCompetition {
     }
 
     /// Produces the final `Quote` for this competition. Applies
-    /// additional-cost adjustments, and scales sell/buy amounts
-    /// when the caller asked for a `SellAmount::BeforeFee` sell
-    /// order. Returns [`CalculateQuoteError::SellAmountDoesNotCoverFee`]
-    /// when the fee exceeds the requested input.
-    pub fn to_final_quote(
-        &self,
-        parameters: &QuoteParameters,
-    ) -> Result<Quote, CalculateQuoteError> {
+    /// additional-cost adjustments, and scales sell/buy amounts when the
+    /// caller asked for a `SellAmount::BeforeFee` sell order.
+    pub fn to_final_quote(&self, parameters: &QuoteParameters) -> Quote {
         let mut quote = Quote::new(None, self.to_quote_data())
             .with_additional_cost(parameters.additional_cost());
 
@@ -326,15 +321,10 @@ impl QuoteCompetition {
             let sell_amount = sell_amount_before_fee
                 .get()
                 .saturating_sub(quote.fee_amount);
-            if sell_amount.is_zero() {
-                return Err(CalculateQuoteError::SellAmountDoesNotCoverFee {
-                    fee_amount: quote.fee_amount,
-                });
-            }
             quote = quote.with_scaled_sell_amount(sell_amount);
         }
 
-        Ok(quote)
+        quote
     }
 }
 
@@ -633,7 +623,7 @@ impl OrderQuoter {
                 .map_err(|err| (EstimatorKind::NativeBuy, err).into()),
         )?;
 
-        let quote = assemble_quote_data(
+        assemble_quote_data(
             parameters,
             trade_estimates,
             effective_gas_price,
@@ -641,9 +631,7 @@ impl OrderQuoter {
             buy_token_price,
             expiration,
             auction_id,
-        );
-
-        Ok(quote)
+        )
     }
 }
 
@@ -655,10 +643,6 @@ impl OrderQuoting for OrderQuoter {
         parameters: QuoteParameters,
     ) -> Result<QuoteCompetition, CalculateQuoteError> {
         let competition = self.compute_quote_data(&parameters).await?;
-        // Validate the fee doesn't exceed the requested input by deriving the
-        // final quote once. Callers can re-derive it later via
-        // `QuoteCompetition::to_final_quote`.
-        let _ = competition.to_final_quote(&parameters)?;
         tracing::debug!(?competition, "computed quote");
         Ok(competition)
     }
@@ -815,18 +799,18 @@ impl StreamingQuoting for OrderQuoter {
                 if new_best_quote.gas == 0 || new_best_quote.out_amount.is_zero() {
                     continue;
                 }
-                let competition = assemble_quote_data(
+                quotes.push(new_best_quote.clone());
+                let competition = match assemble_quote_data(
                     &parameters,
-                    RankedEstimates::new(new_best_quote.clone(), quotes.iter().rev().cloned()),
+                    // skip 1 item in reverse iter to not clone best quote twice
+                    RankedEstimates::new(new_best_quote, quotes.iter().rev().skip(1).cloned()),
                     effective_gas_price,
                     sell_token_price,
                     buy_token_price,
                     expiration,
                     auction_id,
-                );
-                quotes.push(new_best_quote);
-                let mut quote = match competition.to_final_quote(&parameters) {
-                    Ok(q) => q,
+                ) {
+                    Ok(c) => c,
                     Err(err @ CalculateQuoteError::SellAmountDoesNotCoverFee { .. }) => {
                         // A more actionable error than a generic inner one.
                         deferred_err = Some(err);
@@ -837,6 +821,7 @@ impl StreamingQuoting for OrderQuoter {
                         continue;
                     }
                 };
+                let mut quote = competition.to_final_quote(&parameters);
                 // Store latest state of the quote competition. (later iterations of
                 // the loop will update the DB state)
                 match storage.save(competition).await {
@@ -892,7 +877,11 @@ pub fn quote_kind_from_signing_scheme(scheme: &QuoteSigningScheme) -> QuoteKind 
 }
 
 /// Assembles a `QuoteCompetition` from every ranked estimate plus the
-/// competition-level context (native prices, gas price, expiration).
+/// competition-level context (native prices, gas price, expiration). Fails
+/// with [`CalculateQuoteError::SellAmountDoesNotCoverFee`] when the winner's
+/// fee would consume the entire requested `SellAmount::BeforeFee` amount, so
+/// the returned competition is guaranteed to produce a usable `Quote` via
+/// `QuoteCompetition::to_final_quote`.
 fn assemble_quote_data(
     parameters: &QuoteParameters,
     estimates: RankedEstimates,
@@ -901,7 +890,7 @@ fn assemble_quote_data(
     buy_token_price: f64,
     expiration: DateTime<Utc>,
     auction_id: Option<AuctionId>,
-) -> QuoteCompetition {
+) -> Result<QuoteCompetition, CalculateQuoteError> {
     let kind = match &parameters.side {
         OrderQuoteSide::Sell { .. } => OrderKind::Sell,
         OrderQuoteSide::Buy { .. } => OrderKind::Buy,
@@ -945,7 +934,7 @@ fn assemble_quote_data(
 
     let (best, rest) = estimates.into_best_and_rest();
 
-    QuoteCompetition::new(
+    let competition = QuoteCompetition::new(
         QuoteRequest {
             sell_token: parameters.sell_token,
             buy_token: parameters.buy_token,
@@ -962,7 +951,22 @@ fn assemble_quote_data(
             buy_token_price,
             sell_token_price,
         },
-    )
+    );
+
+    if let OrderQuoteSide::Sell {
+        sell_amount: SellAmount::BeforeFee { value: sell_amount },
+    } = &parameters.side
+    {
+        let fee_amount = competition
+            .to_quote_data()
+            .fee_parameters
+            .fee_with_additional_cost(parameters.additional_cost());
+        if sell_amount.get().saturating_sub(fee_amount).is_zero() {
+            return Err(CalculateQuoteError::SellAmountDoesNotCoverFee { fee_amount });
+        }
+    }
+
+    Ok(competition)
 }
 
 /// Used to store quote metadata in the database.
@@ -1198,7 +1202,7 @@ mod tests {
 
         let competition = quoter.calculate_quote(parameters.clone()).await.unwrap();
         let id = quoter.store_quote(competition.clone()).await.unwrap();
-        let mut quote = competition.to_final_quote(&parameters).unwrap();
+        let mut quote = competition.to_final_quote(&parameters);
         quote.id = Some(id);
 
         assert_eq!(
@@ -1358,7 +1362,7 @@ mod tests {
 
         let competition = quoter.calculate_quote(parameters.clone()).await.unwrap();
         let id = quoter.store_quote(competition.clone()).await.unwrap();
-        let mut quote = competition.to_final_quote(&parameters).unwrap();
+        let mut quote = competition.to_final_quote(&parameters);
         quote.id = Some(id);
 
         assert_eq!(
@@ -1513,7 +1517,7 @@ mod tests {
 
         let competition = quoter.calculate_quote(parameters.clone()).await.unwrap();
         let id = quoter.store_quote(competition.clone()).await.unwrap();
-        let mut quote = competition.to_final_quote(&parameters).unwrap();
+        let mut quote = competition.to_final_quote(&parameters);
         quote.id = Some(id);
 
         assert_eq!(
@@ -2157,7 +2161,8 @@ mod tests {
             0.5,
             expiration,
             None,
-        );
+        )
+        .unwrap();
         let data = competition.to_quote_data();
 
         assert_eq!(data.sell_token, Address::repeat_byte(1));
@@ -2214,7 +2219,8 @@ mod tests {
             0.5,
             expiration,
             None,
-        );
+        )
+        .unwrap();
         let data = competition.to_quote_data();
 
         assert_eq!(data.quoted_sell_amount, AlloyU256::from(42));

--- a/crates/shared/src/order_quoting.rs
+++ b/crates/shared/src/order_quoting.rs
@@ -23,6 +23,7 @@ use {
     price_estimation::{
         self,
         CompetitionPriceEstimating,
+        Estimate,
         PriceEstimationError,
         RankedEstimates,
         StreamingPriceEstimating,
@@ -223,12 +224,13 @@ pub struct QuoteData {
 }
 
 /// Collection of data that describes the full quote comptition (request,
-/// all quotes, native prices, gas price).
+/// all quotes, native prices, gas price). Guaranteed to contain at least
+/// one quote by construction.
 #[derive(Clone, Debug, PartialEq)]
 pub struct QuoteCompetition {
     pub request: QuoteRequest,
-    /// All quotes sorted from best to worst.
-    pub quotes: Vec<QuoteResponse>,
+    /// All quotes sorted from best to worst. Guaranteed to be non-empty.
+    quotes: Vec<QuoteResponse>,
     pub metadata: QuoteCompetitionMetadata,
 }
 
@@ -262,13 +264,25 @@ pub struct QuoteResponse {
 }
 
 impl QuoteCompetition {
+    /// Constructor enforcing that there is at least 1 quote.
+    pub fn new(
+        request: QuoteRequest,
+        best: QuoteResponse,
+        rest: impl IntoIterator<Item = QuoteResponse>,
+        metadata: QuoteCompetitionMetadata,
+    ) -> Self {
+        let quotes = std::iter::once(best).chain(rest).collect();
+        Self {
+            request,
+            quotes,
+            metadata,
+        }
+    }
+
     /// Flattens the winning quote and metadata from the competition in
     /// a `QuoteData`.
     pub fn to_quote_data(&self) -> QuoteData {
-        let winner = self
-            .quotes
-            .first()
-            .expect("only QuoteCompetitions with at least 1 quote should be created");
+        let winner = self.quotes.first().expect("non-empty by construction");
         QuoteData {
             sell_token: self.request.sell_token,
             buy_token: self.request.buy_token,
@@ -908,48 +922,47 @@ fn assemble_quote_data(
         } => buy_amount.get(),
     };
 
-    let quotes: Vec<QuoteResponse> = estimates
-        .into_vec()
-        .into_iter()
-        .map(|estimate| {
-            let (quoted_sell_amount, quoted_buy_amount) = match kind {
-                OrderKind::Sell => (input_amount, estimate.out_amount),
-                OrderKind::Buy => (estimate.out_amount, input_amount),
-            };
-            QuoteResponse {
-                solver: estimate.solver,
-                quoted_sell_amount,
-                quoted_buy_amount,
-                gas_amount: estimate.gas as f64,
-                verified: estimate.verified,
-                supports_fast_path: estimate.supports_fast_path,
-                metadata: QuoteMetadataV1 {
-                    interactions: estimate.execution.interactions,
-                    pre_interactions: estimate.execution.pre_interactions,
-                    jit_orders: estimate.execution.jit_orders,
-                }
-                .into(),
+    let into_quote_response = |estimate: Estimate| -> QuoteResponse {
+        let (quoted_sell_amount, quoted_buy_amount) = match kind {
+            OrderKind::Sell => (input_amount, estimate.out_amount),
+            OrderKind::Buy => (estimate.out_amount, input_amount),
+        };
+        QuoteResponse {
+            solver: estimate.solver,
+            quoted_sell_amount,
+            quoted_buy_amount,
+            gas_amount: estimate.gas as f64,
+            verified: estimate.verified,
+            supports_fast_path: estimate.supports_fast_path,
+            metadata: QuoteMetadataV1 {
+                interactions: estimate.execution.interactions,
+                pre_interactions: estimate.execution.pre_interactions,
+                jit_orders: estimate.execution.jit_orders,
             }
-        })
-        .collect();
+            .into(),
+        }
+    };
 
-    QuoteCompetition {
-        request: QuoteRequest {
+    let (best, rest) = estimates.into_best_and_rest();
+
+    QuoteCompetition::new(
+        QuoteRequest {
             sell_token: parameters.sell_token,
             buy_token: parameters.buy_token,
             input_amount,
             quote_kind: quote_kind_from_signing_scheme(&parameters.signing_scheme),
             kind,
         },
-        quotes,
-        metadata: QuoteCompetitionMetadata {
+        into_quote_response(best),
+        rest.map(into_quote_response),
+        QuoteCompetitionMetadata {
             auction_id,
             expiration,
             gas_price: effective_gas_price as f64,
             buy_token_price,
             sell_token_price,
         },
-    }
+    )
 }
 
 /// Used to store quote metadata in the database.
@@ -1143,15 +1156,15 @@ mod tests {
         let mut storage = MockQuoteStoring::new();
         storage
             .expect_save()
-            .with(eq(QuoteCompetition {
-                request: QuoteRequest {
+            .with(eq(QuoteCompetition::new(
+                QuoteRequest {
                     sell_token: Address::repeat_byte(1),
                     buy_token: Address::repeat_byte(2),
                     input_amount: U256::from(100),
                     quote_kind: QuoteKind::Standard,
                     kind: OrderKind::Sell,
                 },
-                quotes: vec![QuoteResponse {
+                QuoteResponse {
                     solver: Address::repeat_byte(1),
                     quoted_sell_amount: U256::from(100),
                     quoted_buy_amount: U256::from(42),
@@ -1159,15 +1172,16 @@ mod tests {
                     verified: false,
                     supports_fast_path: false,
                     metadata: Default::default(),
-                }],
-                metadata: QuoteCompetitionMetadata {
+                },
+                [],
+                QuoteCompetitionMetadata {
                     auction_id: None,
                     expiration: now + Duration::seconds(60i64),
                     gas_price: 2.,
                     buy_token_price: 0.2,
                     sell_token_price: 0.2,
                 },
-            }))
+            )))
             .returning(|_| Ok(1337));
 
         let quoter = OrderQuoter {
@@ -1302,15 +1316,15 @@ mod tests {
         let mut storage = MockQuoteStoring::new();
         storage
             .expect_save()
-            .with(eq(QuoteCompetition {
-                request: QuoteRequest {
+            .with(eq(QuoteCompetition::new(
+                QuoteRequest {
                     sell_token: Address::repeat_byte(1),
                     buy_token: Address::repeat_byte(2),
                     input_amount: U256::from(100),
                     quote_kind: QuoteKind::Standard,
                     kind: OrderKind::Sell,
                 },
-                quotes: vec![QuoteResponse {
+                QuoteResponse {
                     solver: Address::repeat_byte(1),
                     quoted_sell_amount: U256::from(100),
                     quoted_buy_amount: U256::from(42),
@@ -1318,15 +1332,16 @@ mod tests {
                     verified: false,
                     supports_fast_path: false,
                     metadata: Default::default(),
-                }],
-                metadata: QuoteCompetitionMetadata {
+                },
+                [],
+                QuoteCompetitionMetadata {
                     auction_id: None,
                     expiration: now + chrono::Duration::seconds(60i64),
                     gas_price: 2.,
                     buy_token_price: 0.2,
                     sell_token_price: 0.2,
                 },
-            }))
+            )))
             .returning(|_| Ok(1337));
 
         let quoter = OrderQuoter {
@@ -1456,15 +1471,15 @@ mod tests {
         let mut storage = MockQuoteStoring::new();
         storage
             .expect_save()
-            .with(eq(QuoteCompetition {
-                request: QuoteRequest {
+            .with(eq(QuoteCompetition::new(
+                QuoteRequest {
                     sell_token: Address::repeat_byte(1),
                     buy_token: Address::repeat_byte(2),
                     input_amount: U256::from(42),
                     quote_kind: QuoteKind::Standard,
                     kind: OrderKind::Buy,
                 },
-                quotes: vec![QuoteResponse {
+                QuoteResponse {
                     solver: Address::repeat_byte(1),
                     quoted_sell_amount: U256::from(100),
                     quoted_buy_amount: U256::from(42),
@@ -1472,15 +1487,16 @@ mod tests {
                     verified: false,
                     supports_fast_path: false,
                     metadata: Default::default(),
-                }],
-                metadata: QuoteCompetitionMetadata {
+                },
+                [],
+                QuoteCompetitionMetadata {
                     auction_id: None,
                     expiration: now + chrono::Duration::seconds(60i64),
                     gas_price: 2.,
                     buy_token_price: 0.2,
                     sell_token_price: 0.2,
                 },
-            }))
+            )))
             .returning(|_| Ok(1337));
 
         let quoter = OrderQuoter {

--- a/crates/shared/src/order_quoting.rs
+++ b/crates/shared/src/order_quoting.rs
@@ -232,19 +232,6 @@ pub struct QuoteCompetition {
     pub metadata: QuoteCompetitionMetadata,
 }
 
-impl Default for QuoteCompetition {
-    fn default() -> Self {
-        // `winning_quote()` requires a non-empty vec; keep the invariant true
-        // for `Default::default()` so test helpers that lean on it don't
-        // silently produce an unusable competition.
-        Self {
-            request: Default::default(),
-            quotes: vec![QuoteResponse::default()],
-            metadata: Default::default(),
-        }
-    }
-}
-
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct QuoteRequest {
     pub sell_token: Address,

--- a/crates/shared/src/order_quoting.rs
+++ b/crates/shared/src/order_quoting.rs
@@ -7,7 +7,10 @@ use {
     alloy::primitives::{Address, U256, U512, ruint::UintTryFrom},
     anyhow::{Context, Result},
     chrono::{DateTime, Duration, Utc},
-    database::quotes::{Quote as QuoteRow, QuoteKind},
+    database::{
+        auction::AuctionId,
+        quotes::{Quote as QuoteRow, QuoteKind},
+    },
     futures::{StreamExt, TryFutureExt},
     gas_price_estimation::GasPriceEstimating,
     model::{
@@ -178,7 +181,7 @@ impl Quote {
     }
 }
 
-/// Detailed data for a computed order quote.
+/// Detailed data for the final computed quote.
 #[derive(Clone, Debug, Default, PartialEq)]
 pub struct QuoteData {
     pub sell_token: Address,
@@ -214,6 +217,124 @@ pub struct QuoteData {
     pub supports_fast_path: bool,
     /// Additional data associated with the quote.
     pub metadata: QuoteMetadata,
+    /// Auction id linking this quote to `competition_auctions`. Only populated
+    /// for fast-path quotes.
+    pub auction_id: Option<AuctionId>,
+}
+
+/// Collection of data that describes the full quote comptition (request,
+/// all quotes, native prices, gas price).
+#[derive(Clone, Debug, PartialEq)]
+pub struct QuoteCompetition {
+    pub request: QuoteRequest,
+    /// All quotes sorted from best to worst.
+    pub quotes: Vec<QuoteResponse>,
+    pub metadata: QuoteCompetitionMetadata,
+}
+
+impl Default for QuoteCompetition {
+    fn default() -> Self {
+        // `winning_quote()` requires a non-empty vec; keep the invariant true
+        // for `Default::default()` so test helpers that lean on it don't
+        // silently produce an unusable competition.
+        Self {
+            request: Default::default(),
+            quotes: vec![QuoteResponse::default()],
+            metadata: Default::default(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct QuoteRequest {
+    pub sell_token: Address,
+    pub buy_token: Address,
+    pub input_amount: U256,
+    pub quote_kind: QuoteKind,
+    pub kind: OrderKind,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct QuoteCompetitionMetadata {
+    pub auction_id: Option<AuctionId>,
+    pub expiration: DateTime<Utc>,
+    pub gas_price: f64,
+    pub buy_token_price: f64,
+    pub sell_token_price: f64,
+}
+
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct QuoteResponse {
+    pub solver: Address,
+    pub quoted_sell_amount: U256,
+    pub quoted_buy_amount: U256,
+    pub gas_amount: f64,
+    pub verified: bool,
+    pub supports_fast_path: bool,
+    pub metadata: QuoteMetadata,
+}
+
+impl QuoteCompetition {
+    /// Flattens the winning quote and metadata from the competition in
+    /// a `QuoteData`.
+    pub fn to_quote_data(&self) -> QuoteData {
+        let winner = self
+            .quotes
+            .first()
+            .expect("only QuoteCompetitions with at least 1 quote should be created");
+        QuoteData {
+            sell_token: self.request.sell_token,
+            buy_token: self.request.buy_token,
+            quoted_sell_amount: winner.quoted_sell_amount,
+            quoted_buy_amount: winner.quoted_buy_amount,
+            fee_parameters: FeeParameters {
+                gas_amount: winner.gas_amount,
+                gas_price: self.metadata.gas_price,
+                sell_token_price: self.metadata.sell_token_price,
+            },
+            kind: self.request.kind,
+            expiration: self.metadata.expiration,
+            quote_kind: self.request.quote_kind.clone(),
+            solver: winner.solver,
+            verified: winner.verified,
+            supports_fast_path: winner.supports_fast_path,
+            metadata: winner.metadata.clone(),
+            auction_id: self.metadata.auction_id,
+        }
+    }
+
+    /// Produces the final `Quote` for this competition. Applies
+    /// additional-cost adjustments, and scales sell/buy amounts
+    /// when the caller asked for a `SellAmount::BeforeFee` sell
+    /// order. Returns [`CalculateQuoteError::SellAmountDoesNotCoverFee`]
+    /// when the fee exceeds the requested input.
+    pub fn to_final_quote(
+        &self,
+        parameters: &QuoteParameters,
+    ) -> Result<Quote, CalculateQuoteError> {
+        let mut quote = Quote::new(None, self.to_quote_data())
+            .with_additional_cost(parameters.additional_cost());
+
+        if let OrderQuoteSide::Sell {
+            sell_amount:
+                SellAmount::BeforeFee {
+                    value: sell_amount_before_fee,
+                },
+        } = &parameters.side
+        {
+            let sell_amount = sell_amount_before_fee
+                .get()
+                .saturating_sub(quote.fee_amount);
+            if sell_amount.is_zero() {
+                return Err(CalculateQuoteError::SellAmountDoesNotCoverFee {
+                    fee_amount: quote.fee_amount,
+                });
+            }
+            quote = quote.with_scaled_sell_amount(sell_amount);
+        }
+
+        Ok(quote)
+    }
 }
 
 impl TryFrom<QuoteRow> for QuoteData {
@@ -240,6 +361,7 @@ impl TryFrom<QuoteRow> for QuoteData {
             // Not stored in the DB yet; defaults to false until persisted.
             supports_fast_path: false,
             metadata: row.metadata.try_into()?,
+            auction_id: row.auction_id,
         })
     }
 }
@@ -252,10 +374,10 @@ pub trait OrderQuoting: Send + Sync {
     async fn calculate_quote(
         &self,
         parameters: QuoteParameters,
-    ) -> Result<Quote, CalculateQuoteError>;
+    ) -> Result<QuoteCompetition, CalculateQuoteError>;
 
     /// Stores a quote.
-    async fn store_quote(&self, quote: Quote) -> Result<Quote>;
+    async fn store_quote(&self, competition: QuoteCompetition) -> Result<QuoteId>;
 
     /// Finds an existing quote.
     async fn find_quote(
@@ -365,7 +487,7 @@ pub trait QuoteStoring: Send + Sync {
     ///
     /// This storage implementation should return `None` to indicate that it
     /// will not store the quote.
-    async fn save(&self, data: QuoteData) -> Result<QuoteId>;
+    async fn save(&self, data: QuoteCompetition) -> Result<QuoteId>;
 
     /// Retrieves an existing quote by ID.
     async fn get(&self, id: QuoteId) -> Result<Option<QuoteData>>;
@@ -470,7 +592,7 @@ impl OrderQuoter {
     async fn compute_quote_data(
         &self,
         parameters: &QuoteParameters,
-    ) -> Result<QuoteData, CalculateQuoteError> {
+    ) -> Result<QuoteCompetition, CalculateQuoteError> {
         let auction_id = match parameters.fast_path {
             true => Some(self.storage.get_next_auction_id().await?),
             false => None,
@@ -492,7 +614,7 @@ impl OrderQuoter {
             self.max_quote_timeout,
             auction_id,
         ));
-        let (effective_gas_price, trade_estimate, sell_token_price, _) = futures::try_join!(
+        let (effective_gas_price, trade_estimates, sell_token_price, buy_token_price) = futures::try_join!(
             self.gas_estimator
                 .effective_gas_price()
                 .map_err(|err| CalculateQuoteError::from((
@@ -501,14 +623,10 @@ impl OrderQuoter {
                 ))),
             self.price_estimator
                 .estimates(trade_query.clone())
-                .map_ok(RankedEstimates::into_best)
                 .map_err(|err| CalculateQuoteError::from((EstimatorKind::Regular, err))),
             self.native_price_estimator
                 .estimate_native_price(parameters.sell_token, trade_query.timeout)
                 .map_err(|err| (EstimatorKind::NativeSell, err).into()),
-            // We don't care about the native price of the buy_token for the quote but we need it
-            // when we build the auction. To prevent creating orders which we can't settle later on
-            // we make the native buy_token price a requirement here as well.
             self.native_price_estimator
                 .estimate_native_price(parameters.buy_token, trade_query.timeout)
                 .map_err(|err| (EstimatorKind::NativeBuy, err).into()),
@@ -516,10 +634,12 @@ impl OrderQuoter {
 
         let quote = assemble_quote_data(
             parameters,
-            trade_estimate,
+            trade_estimates,
             effective_gas_price,
             sell_token_price,
+            buy_token_price,
             expiration,
+            auction_id,
         );
 
         Ok(quote)
@@ -532,44 +652,19 @@ impl OrderQuoting for OrderQuoter {
     async fn calculate_quote(
         &self,
         parameters: QuoteParameters,
-    ) -> Result<Quote, CalculateQuoteError> {
-        let data = self.compute_quote_data(&parameters).await?;
-        let mut quote =
-            Quote::new(Default::default(), data).with_additional_cost(parameters.additional_cost());
-
-        // Make sure to scale the sell and buy amounts for quotes for sell
-        // amounts before fees.
-        if let OrderQuoteSide::Sell {
-            sell_amount:
-                SellAmount::BeforeFee {
-                    value: sell_amount_before_fee,
-                },
-        } = &parameters.side
-        {
-            let sell_amount = sell_amount_before_fee
-                .get()
-                .saturating_sub(quote.fee_amount);
-            if sell_amount.is_zero() {
-                // We want a sell_amount of at least 1!
-                return Err(CalculateQuoteError::SellAmountDoesNotCoverFee {
-                    fee_amount: quote.fee_amount,
-                });
-            }
-
-            quote = quote.with_scaled_sell_amount(sell_amount);
-        }
-
-        tracing::debug!(?quote, "computed quote");
-        Ok(quote)
+    ) -> Result<QuoteCompetition, CalculateQuoteError> {
+        let competition = self.compute_quote_data(&parameters).await?;
+        // Validate the fee doesn't exceed the requested input by deriving the
+        // final quote once. Callers can re-derive it later via
+        // `QuoteCompetition::to_final_quote`.
+        let _ = competition.to_final_quote(&parameters)?;
+        tracing::debug!(?competition, "computed quote");
+        Ok(competition)
     }
 
     #[instrument(skip_all)]
-    async fn store_quote(&self, quote: Quote) -> Result<Quote> {
-        let id = self.storage.save(quote.data.clone()).await?;
-        Ok(Quote {
-            id: Some(id),
-            ..quote
-        })
+    async fn store_quote(&self, competition: QuoteCompetition) -> Result<QuoteId> {
+        self.storage.save(competition).await
     }
 
     #[instrument(skip_all)]
@@ -662,7 +757,7 @@ impl StreamingQuoting for OrderQuoter {
             auction_id,
         ));
 
-        let (effective_gas_price, sell_token_price, _buy_token_price) = futures::try_join!(
+        let (effective_gas_price, sell_token_price, buy_token_price) = futures::try_join!(
             self.gas_estimator
                 .effective_gas_price()
                 .map_err(|err| CalculateQuoteError::from((
@@ -691,7 +786,6 @@ impl StreamingQuoting for OrderQuoter {
             _ => self.now.now() + self.validity.standard_quote,
         };
 
-        let additional_cost = parameters.additional_cost();
         let storage = self.storage.clone();
 
         let stream = async_stream::stream! {
@@ -701,8 +795,14 @@ impl StreamingQuoting for OrderQuoter {
             // Errors are only surfaced at the end if no quote ever succeeds.
             let mut deferred_err: Option<CalculateQuoteError> = None;
             let mut any_ok = false;
+            // All usable quotes seen so far, in arrival order. The inner
+            // stream guarantees each new item ranks strictly better than
+            // the previous best, so the *last* item is always the current
+            // winner. When we build `RankedEstimates` we iterate in
+            // reverse so the best sits at index 0.
+            let mut quotes: Vec<price_estimation::Estimate> = Vec::new();
             while let Some(result) = inner.next().await {
-                let estimate = match result {
+                let new_best_quote = match result {
                     Ok(e) => e,
                     // An inner error is terminal but less specific than SellAmountDoesNotCoverFee, so it should not mask the latter.
                     Err(err) => {
@@ -711,37 +811,34 @@ impl StreamingQuoting for OrderQuoter {
                     }
                 };
                 // Drop estimates with zero gas or zero output to avoid emitting garbage quotes.
-                if estimate.gas == 0 || estimate.out_amount.is_zero() {
+                if new_best_quote.gas == 0 || new_best_quote.out_amount.is_zero() {
                     continue;
                 }
-                let data = assemble_quote_data(
+                let competition = assemble_quote_data(
                     &parameters,
-                    estimate,
+                    RankedEstimates::new(new_best_quote.clone(), quotes.iter().rev().cloned()),
                     effective_gas_price,
                     sell_token_price,
+                    buy_token_price,
                     expiration,
+                    auction_id,
                 );
-                let mut quote =
-                    Quote::new(Default::default(), data).with_additional_cost(additional_cost);
-                if let OrderQuoteSide::Sell {
-                    sell_amount: SellAmount::BeforeFee { value },
-                } = &parameters.side
-                {
-                    let sell_amount = value.get().saturating_sub(quote.fee_amount);
-                    if sell_amount.is_zero() {
-                        // SellAmountDoesNotCoverFee is a more actionable error than a generic inner one
-                        deferred_err = Some(CalculateQuoteError::SellAmountDoesNotCoverFee {
-                            fee_amount: quote.fee_amount,
-                        });
+                quotes.push(new_best_quote);
+                let mut quote = match competition.to_final_quote(&parameters) {
+                    Ok(q) => q,
+                    Err(err @ CalculateQuoteError::SellAmountDoesNotCoverFee { .. }) => {
+                        // A more actionable error than a generic inner one.
+                        deferred_err = Some(err);
                         continue;
                     }
-                    quote = quote.with_scaled_sell_amount(sell_amount);
-                }
-                // Persist the quote so it can be referenced by id when the
-                // order is later placed, mirroring the one-shot endpoint. A
-                // failed write must not turn an otherwise good quote into an
-                // error event.
-                match storage.save(quote.data.clone()).await {
+                    Err(err) => {
+                        deferred_err = deferred_err.or(Some(err));
+                        continue;
+                    }
+                };
+                // Store latest state of the quote competition. (later iterations of
+                // the loop will update the DB state)
+                match storage.save(competition).await {
                     Ok(id) => quote.id = Some(id),
                     Err(err) => tracing::error!(?err, "failed to persist streamed quote"),
                 }
@@ -793,53 +890,78 @@ pub fn quote_kind_from_signing_scheme(scheme: &QuoteSigningScheme) -> QuoteKind 
     }
 }
 
-/// Assembles a `QuoteData` from a completed price estimate and its inputs.
-///
-/// `expiration` must be computed by the caller (it depends on `&self` state in
-/// `OrderQuoter`).
+/// Assembles a `QuoteCompetition` from every ranked estimate plus the
+/// competition-level context (native prices, gas price, expiration).
 fn assemble_quote_data(
     parameters: &QuoteParameters,
-    estimate: price_estimation::Estimate,
+    estimates: RankedEstimates,
     effective_gas_price: u128,
     sell_token_price: f64,
+    buy_token_price: f64,
     expiration: DateTime<Utc>,
-) -> QuoteData {
-    let (quoted_sell_amount, quoted_buy_amount, kind) = match &parameters.side {
+    auction_id: Option<AuctionId>,
+) -> QuoteCompetition {
+    let kind = match &parameters.side {
+        OrderQuoteSide::Sell { .. } => OrderKind::Sell,
+        OrderQuoteSide::Buy { .. } => OrderKind::Buy,
+    };
+    // For sell orders the request amount is fixed on the sell side; for buy
+    // orders it's fixed on the buy side. In either case that value is what we
+    // record on the `QuoteRequest` while the per-quote amounts live on each
+    // `QuoteResponse`.
+    let input_amount = match &parameters.side {
         OrderQuoteSide::Sell {
             sell_amount: SellAmount::BeforeFee { value: sell_amount },
         }
         | OrderQuoteSide::Sell {
             sell_amount: SellAmount::AfterFee { value: sell_amount },
-        } => (sell_amount.get(), estimate.out_amount, OrderKind::Sell),
+        } => sell_amount.get(),
         OrderQuoteSide::Buy {
             buy_amount_after_fee: buy_amount,
-        } => (estimate.out_amount, buy_amount.get(), OrderKind::Buy),
+        } => buy_amount.get(),
     };
 
-    let fee_parameters = FeeParameters {
-        gas_amount: estimate.gas as f64,
-        gas_price: effective_gas_price as f64,
-        sell_token_price,
-    };
+    let quotes: Vec<QuoteResponse> = estimates
+        .into_vec()
+        .into_iter()
+        .map(|estimate| {
+            let (quoted_sell_amount, quoted_buy_amount) = match kind {
+                OrderKind::Sell => (input_amount, estimate.out_amount),
+                OrderKind::Buy => (estimate.out_amount, input_amount),
+            };
+            QuoteResponse {
+                solver: estimate.solver,
+                quoted_sell_amount,
+                quoted_buy_amount,
+                gas_amount: estimate.gas as f64,
+                verified: estimate.verified,
+                supports_fast_path: estimate.supports_fast_path,
+                metadata: QuoteMetadataV1 {
+                    interactions: estimate.execution.interactions,
+                    pre_interactions: estimate.execution.pre_interactions,
+                    jit_orders: estimate.execution.jit_orders,
+                }
+                .into(),
+            }
+        })
+        .collect();
 
-    QuoteData {
-        sell_token: parameters.sell_token,
-        buy_token: parameters.buy_token,
-        quoted_sell_amount,
-        quoted_buy_amount,
-        fee_parameters,
-        kind,
-        expiration,
-        quote_kind: quote_kind_from_signing_scheme(&parameters.signing_scheme),
-        solver: estimate.solver,
-        verified: estimate.verified,
-        supports_fast_path: estimate.supports_fast_path,
-        metadata: QuoteMetadataV1 {
-            interactions: estimate.execution.interactions,
-            pre_interactions: estimate.execution.pre_interactions,
-            jit_orders: estimate.execution.jit_orders,
-        }
-        .into(),
+    QuoteCompetition {
+        request: QuoteRequest {
+            sell_token: parameters.sell_token,
+            buy_token: parameters.buy_token,
+            input_amount,
+            quote_kind: quote_kind_from_signing_scheme(&parameters.signing_scheme),
+            kind,
+        },
+        quotes,
+        metadata: QuoteCompetitionMetadata {
+            auction_id,
+            expiration,
+            gas_price: effective_gas_price as f64,
+            buy_token_price,
+            sell_token_price,
+        },
     }
 }
 
@@ -1034,23 +1156,30 @@ mod tests {
         let mut storage = MockQuoteStoring::new();
         storage
             .expect_save()
-            .with(eq(QuoteData {
-                sell_token: Address::repeat_byte(1),
-                buy_token: Address::repeat_byte(2),
-                quoted_sell_amount: U256::from(100),
-                quoted_buy_amount: U256::from(42),
-                fee_parameters: FeeParameters {
+            .with(eq(QuoteCompetition {
+                request: QuoteRequest {
+                    sell_token: Address::repeat_byte(1),
+                    buy_token: Address::repeat_byte(2),
+                    input_amount: U256::from(100),
+                    quote_kind: QuoteKind::Standard,
+                    kind: OrderKind::Sell,
+                },
+                quotes: vec![QuoteResponse {
+                    solver: Address::repeat_byte(1),
+                    quoted_sell_amount: U256::from(100),
+                    quoted_buy_amount: U256::from(42),
                     gas_amount: 3.,
+                    verified: false,
+                    supports_fast_path: false,
+                    metadata: Default::default(),
+                }],
+                metadata: QuoteCompetitionMetadata {
+                    auction_id: None,
+                    expiration: now + Duration::seconds(60i64),
                     gas_price: 2.,
+                    buy_token_price: 0.2,
                     sell_token_price: 0.2,
                 },
-                kind: OrderKind::Sell,
-                expiration: now + Duration::seconds(60i64),
-                quote_kind: QuoteKind::Standard,
-                solver: Address::repeat_byte(1),
-                verified: false,
-                supports_fast_path: false,
-                metadata: Default::default(),
             }))
             .returning(|_| Ok(1337));
 
@@ -1066,8 +1195,10 @@ mod tests {
             streaming_price_estimator: None,
         };
 
-        let quote = quoter.calculate_quote(parameters).await.unwrap();
-        let quote = quoter.store_quote(quote).await.unwrap();
+        let competition = quoter.calculate_quote(parameters.clone()).await.unwrap();
+        let id = quoter.store_quote(competition.clone()).await.unwrap();
+        let mut quote = competition.to_final_quote(&parameters).unwrap();
+        quote.id = Some(id);
 
         assert_eq!(
             quote,
@@ -1090,6 +1221,7 @@ mod tests {
                     verified: false,
                     supports_fast_path: false,
                     metadata: Default::default(),
+                    auction_id: None,
                 },
                 sell_amount: U256::from(70),
                 buy_amount: U256::from(29),
@@ -1183,23 +1315,30 @@ mod tests {
         let mut storage = MockQuoteStoring::new();
         storage
             .expect_save()
-            .with(eq(QuoteData {
-                sell_token: Address::repeat_byte(1),
-                buy_token: Address::repeat_byte(2),
-                quoted_sell_amount: U256::from(100),
-                quoted_buy_amount: U256::from(42),
-                fee_parameters: FeeParameters {
+            .with(eq(QuoteCompetition {
+                request: QuoteRequest {
+                    sell_token: Address::repeat_byte(1),
+                    buy_token: Address::repeat_byte(2),
+                    input_amount: U256::from(100),
+                    quote_kind: QuoteKind::Standard,
+                    kind: OrderKind::Sell,
+                },
+                quotes: vec![QuoteResponse {
+                    solver: Address::repeat_byte(1),
+                    quoted_sell_amount: U256::from(100),
+                    quoted_buy_amount: U256::from(42),
                     gas_amount: 3.,
+                    verified: false,
+                    supports_fast_path: false,
+                    metadata: Default::default(),
+                }],
+                metadata: QuoteCompetitionMetadata {
+                    auction_id: None,
+                    expiration: now + chrono::Duration::seconds(60i64),
                     gas_price: 2.,
+                    buy_token_price: 0.2,
                     sell_token_price: 0.2,
                 },
-                kind: OrderKind::Sell,
-                expiration: now + chrono::Duration::seconds(60i64),
-                quote_kind: QuoteKind::Standard,
-                solver: Address::repeat_byte(1),
-                verified: false,
-                supports_fast_path: false,
-                metadata: Default::default(),
             }))
             .returning(|_| Ok(1337));
 
@@ -1215,8 +1354,10 @@ mod tests {
             streaming_price_estimator: None,
         };
 
-        let quote = quoter.calculate_quote(parameters).await.unwrap();
-        let quote = quoter.store_quote(quote).await.unwrap();
+        let competition = quoter.calculate_quote(parameters.clone()).await.unwrap();
+        let id = quoter.store_quote(competition.clone()).await.unwrap();
+        let mut quote = competition.to_final_quote(&parameters).unwrap();
+        quote.id = Some(id);
 
         assert_eq!(
             quote,
@@ -1239,6 +1380,7 @@ mod tests {
                     verified: false,
                     supports_fast_path: false,
                     metadata: Default::default(),
+                    auction_id: None,
                 },
                 sell_amount: U256::from(100),
                 buy_amount: U256::from(42),
@@ -1327,23 +1469,30 @@ mod tests {
         let mut storage = MockQuoteStoring::new();
         storage
             .expect_save()
-            .with(eq(QuoteData {
-                sell_token: Address::repeat_byte(1),
-                buy_token: Address::repeat_byte(2),
-                quoted_sell_amount: U256::from(100),
-                quoted_buy_amount: U256::from(42),
-                fee_parameters: FeeParameters {
+            .with(eq(QuoteCompetition {
+                request: QuoteRequest {
+                    sell_token: Address::repeat_byte(1),
+                    buy_token: Address::repeat_byte(2),
+                    input_amount: U256::from(42),
+                    quote_kind: QuoteKind::Standard,
+                    kind: OrderKind::Buy,
+                },
+                quotes: vec![QuoteResponse {
+                    solver: Address::repeat_byte(1),
+                    quoted_sell_amount: U256::from(100),
+                    quoted_buy_amount: U256::from(42),
                     gas_amount: 3.,
+                    verified: false,
+                    supports_fast_path: false,
+                    metadata: Default::default(),
+                }],
+                metadata: QuoteCompetitionMetadata {
+                    auction_id: None,
+                    expiration: now + chrono::Duration::seconds(60i64),
                     gas_price: 2.,
+                    buy_token_price: 0.2,
                     sell_token_price: 0.2,
                 },
-                kind: OrderKind::Buy,
-                expiration: now + chrono::Duration::seconds(60i64),
-                quote_kind: QuoteKind::Standard,
-                solver: Address::repeat_byte(1),
-                verified: false,
-                supports_fast_path: false,
-                metadata: Default::default(),
             }))
             .returning(|_| Ok(1337));
 
@@ -1359,8 +1508,10 @@ mod tests {
             streaming_price_estimator: None,
         };
 
-        let quote = quoter.calculate_quote(parameters).await.unwrap();
-        let quote = quoter.store_quote(quote).await.unwrap();
+        let competition = quoter.calculate_quote(parameters.clone()).await.unwrap();
+        let id = quoter.store_quote(competition.clone()).await.unwrap();
+        let mut quote = competition.to_final_quote(&parameters).unwrap();
+        quote.id = Some(id);
 
         assert_eq!(
             quote,
@@ -1383,6 +1534,7 @@ mod tests {
                     verified: false,
                     supports_fast_path: false,
                     metadata: Default::default(),
+                    auction_id: None,
                 },
                 sell_amount: U256::from(100),
                 buy_amount: U256::from(42),
@@ -1569,27 +1721,33 @@ mod tests {
             },
         };
 
+        let stored = QuoteData {
+            sell_token: Address::repeat_byte(1),
+            buy_token: Address::repeat_byte(2),
+            quoted_sell_amount: U256::from(100),
+            quoted_buy_amount: U256::from(42),
+            fee_parameters: FeeParameters {
+                gas_amount: 3.,
+                gas_price: 2.,
+                sell_token_price: 0.2,
+            },
+            kind: OrderKind::Sell,
+            expiration: now + chrono::Duration::seconds(10),
+            quote_kind: QuoteKind::Standard,
+            solver: Address::repeat_byte(1),
+            verified: false,
+            supports_fast_path: false,
+            metadata: Default::default(),
+            auction_id: None,
+        };
         let mut storage = MockQuoteStoring::new();
-        storage.expect_get().with(eq(42)).returning(move |_| {
-            Ok(Some(QuoteData {
-                sell_token: Address::repeat_byte(1),
-                buy_token: Address::repeat_byte(2),
-                quoted_sell_amount: U256::from(100),
-                quoted_buy_amount: U256::from(42),
-                fee_parameters: FeeParameters {
-                    gas_amount: 3.,
-                    gas_price: 2.,
-                    sell_token_price: 0.2,
-                },
-                kind: OrderKind::Sell,
-                expiration: now + chrono::Duration::seconds(10),
-                quote_kind: QuoteKind::Standard,
-                solver: Address::repeat_byte(1),
-                verified: false,
-                supports_fast_path: false,
-                metadata: Default::default(),
-            }))
-        });
+        {
+            let stored = stored.clone();
+            storage
+                .expect_get()
+                .with(eq(42))
+                .returning(move |_| Ok(Some(stored.clone())));
+        }
 
         let quoter = OrderQuoter {
             price_estimator: Arc::new(MockCompetitionPriceEstimating::new()),
@@ -1607,24 +1765,7 @@ mod tests {
             quoter.find_quote(Some(quote_id), parameters).await.unwrap(),
             Quote {
                 id: Some(42),
-                data: QuoteData {
-                    sell_token: Address::repeat_byte(1),
-                    buy_token: Address::repeat_byte(2),
-                    quoted_sell_amount: U256::from(100),
-                    quoted_buy_amount: U256::from(42),
-                    fee_parameters: FeeParameters {
-                        gas_amount: 3.,
-                        gas_price: 2.,
-                        sell_token_price: 0.2,
-                    },
-                    kind: OrderKind::Sell,
-                    expiration: now + chrono::Duration::seconds(10),
-                    quote_kind: QuoteKind::Standard,
-                    solver: Address::repeat_byte(1),
-                    verified: false,
-                    supports_fast_path: false,
-                    metadata: Default::default(),
-                },
+                data: stored,
                 sell_amount: U256::from(85),
                 // Allows for "out-of-price" buy amounts. This means that order
                 // be used for providing liquidity at a premium over current
@@ -1654,27 +1795,33 @@ mod tests {
             },
         };
 
+        let stored = QuoteData {
+            sell_token: Address::repeat_byte(1),
+            buy_token: Address::repeat_byte(2),
+            quoted_sell_amount: U256::from(100),
+            quoted_buy_amount: U256::from(42),
+            fee_parameters: FeeParameters {
+                gas_amount: 3.,
+                gas_price: 2.,
+                sell_token_price: 0.2,
+            },
+            kind: OrderKind::Sell,
+            expiration: now + chrono::Duration::seconds(10),
+            quote_kind: QuoteKind::Standard,
+            solver: Address::repeat_byte(1),
+            verified: false,
+            supports_fast_path: false,
+            metadata: Default::default(),
+            auction_id: None,
+        };
         let mut storage = MockQuoteStoring::new();
-        storage.expect_get().with(eq(42)).returning(move |_| {
-            Ok(Some(QuoteData {
-                sell_token: Address::repeat_byte(1),
-                buy_token: Address::repeat_byte(2),
-                quoted_sell_amount: U256::from(100),
-                quoted_buy_amount: U256::from(42),
-                fee_parameters: FeeParameters {
-                    gas_amount: 3.,
-                    gas_price: 2.,
-                    sell_token_price: 0.2,
-                },
-                kind: OrderKind::Sell,
-                expiration: now + chrono::Duration::seconds(10),
-                quote_kind: QuoteKind::Standard,
-                solver: Address::repeat_byte(1),
-                verified: false,
-                supports_fast_path: false,
-                metadata: Default::default(),
-            }))
-        });
+        {
+            let stored = stored.clone();
+            storage
+                .expect_get()
+                .with(eq(42))
+                .returning(move |_| Ok(Some(stored.clone())));
+        }
 
         let quoter = OrderQuoter {
             price_estimator: Arc::new(MockCompetitionPriceEstimating::new()),
@@ -1692,24 +1839,7 @@ mod tests {
             quoter.find_quote(Some(quote_id), parameters).await.unwrap(),
             Quote {
                 id: Some(42),
-                data: QuoteData {
-                    sell_token: Address::repeat_byte(1),
-                    buy_token: Address::repeat_byte(2),
-                    quoted_sell_amount: U256::from(100),
-                    quoted_buy_amount: U256::from(42),
-                    fee_parameters: FeeParameters {
-                        gas_amount: 3.,
-                        gas_price: 2.,
-                        sell_token_price: 0.2,
-                    },
-                    kind: OrderKind::Sell,
-                    expiration: now + chrono::Duration::seconds(10),
-                    quote_kind: QuoteKind::Standard,
-                    solver: Address::repeat_byte(1),
-                    verified: false,
-                    supports_fast_path: false,
-                    metadata: Default::default(),
-                },
+                data: stored,
                 sell_amount: U256::from(100),
                 buy_amount: U256::from(42),
                 fee_amount: U256::from(30),
@@ -1735,33 +1865,33 @@ mod tests {
             },
         };
 
+        let stored = QuoteData {
+            sell_token: Address::repeat_byte(1),
+            buy_token: Address::repeat_byte(2),
+            quoted_sell_amount: U256::from(100),
+            quoted_buy_amount: U256::from(42),
+            fee_parameters: FeeParameters {
+                gas_amount: 3.,
+                gas_price: 2.,
+                sell_token_price: 0.2,
+            },
+            kind: OrderKind::Buy,
+            expiration: now + chrono::Duration::seconds(10),
+            quote_kind: QuoteKind::Standard,
+            solver: Address::repeat_byte(1),
+            verified: false,
+            supports_fast_path: false,
+            metadata: Default::default(),
+            auction_id: None,
+        };
         let mut storage = MockQuoteStoring::new();
-        storage
-            .expect_find()
-            .with(eq(parameters.clone()), eq(now))
-            .returning(move |_, _| {
-                Ok(Some((
-                    42,
-                    QuoteData {
-                        sell_token: Address::repeat_byte(1),
-                        buy_token: Address::repeat_byte(2),
-                        quoted_sell_amount: U256::from(100),
-                        quoted_buy_amount: U256::from(42),
-                        fee_parameters: FeeParameters {
-                            gas_amount: 3.,
-                            gas_price: 2.,
-                            sell_token_price: 0.2,
-                        },
-                        kind: OrderKind::Buy,
-                        expiration: now + chrono::Duration::seconds(10),
-                        quote_kind: QuoteKind::Standard,
-                        solver: Address::repeat_byte(1),
-                        verified: false,
-                        supports_fast_path: false,
-                        metadata: Default::default(),
-                    },
-                )))
-            });
+        {
+            let stored = stored.clone();
+            storage
+                .expect_find()
+                .with(eq(parameters.clone()), eq(now))
+                .returning(move |_, _| Ok(Some((42, stored.clone()))));
+        }
 
         let quoter = OrderQuoter {
             price_estimator: Arc::new(MockCompetitionPriceEstimating::new()),
@@ -1779,24 +1909,7 @@ mod tests {
             quoter.find_quote(None, parameters).await.unwrap(),
             Quote {
                 id: Some(42),
-                data: QuoteData {
-                    sell_token: Address::repeat_byte(1),
-                    buy_token: Address::repeat_byte(2),
-                    quoted_sell_amount: U256::from(100),
-                    quoted_buy_amount: U256::from(42),
-                    fee_parameters: FeeParameters {
-                        gas_amount: 3.,
-                        gas_price: 2.,
-                        sell_token_price: 0.2,
-                    },
-                    kind: OrderKind::Buy,
-                    expiration: now + chrono::Duration::seconds(10),
-                    quote_kind: QuoteKind::Standard,
-                    solver: Address::repeat_byte(1),
-                    verified: false,
-                    supports_fast_path: false,
-                    metadata: Default::default(),
-                },
+                data: stored,
                 sell_amount: U256::from(100),
                 buy_amount: U256::from(42),
                 fee_amount: U256::from(30),
@@ -2033,7 +2146,16 @@ mod tests {
             execution: Default::default(),
         };
 
-        let data = assemble_quote_data(&parameters, estimate, 2, 0.5, expiration);
+        let competition = assemble_quote_data(
+            &parameters,
+            RankedEstimates::new(estimate, std::iter::empty()),
+            2,
+            0.5,
+            0.5,
+            expiration,
+            None,
+        );
+        let data = competition.to_quote_data();
 
         assert_eq!(data.sell_token, Address::repeat_byte(1));
         assert_eq!(data.buy_token, Address::repeat_byte(2));
@@ -2081,7 +2203,16 @@ mod tests {
             execution: Default::default(),
         };
 
-        let data = assemble_quote_data(&parameters, estimate, 2, 0.5, expiration);
+        let competition = assemble_quote_data(
+            &parameters,
+            RankedEstimates::new(estimate, std::iter::empty()),
+            2,
+            0.5,
+            0.5,
+            expiration,
+            None,
+        );
+        let data = competition.to_quote_data();
 
         assert_eq!(data.quoted_sell_amount, AlloyU256::from(42));
         assert_eq!(data.quoted_buy_amount, AlloyU256::from(100));

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -1177,11 +1177,13 @@ async fn get_or_create_quote(
                 timeout: None, // let &dyn OrderQuoting chose default
             };
 
-            let quote = quoter.calculate_quote(parameters).await?;
-            let quote = quoter
-                .store_quote(quote)
+            let competition = quoter.calculate_quote(parameters.clone()).await?;
+            let id = quoter
+                .store_quote(competition.clone())
                 .await
                 .map_err(ValidationError::Other)?;
+            let mut quote = competition.to_final_quote(&parameters)?;
+            quote.id = Some(id);
 
             tracing::debug!(
                 original_quote_id = ?quote_id,
@@ -1267,7 +1269,14 @@ mod tests {
         super::*,
         crate::{
             order_creation_simulation::MockOrderSimulating,
-            order_quoting::{FindQuoteError, MockOrderQuoting},
+            order_quoting::{
+                FindQuoteError,
+                MockOrderQuoting,
+                QuoteCompetition,
+                QuoteCompetitionMetadata,
+                QuoteRequest,
+                QuoteResponse,
+            },
         },
         account_balances::MockBalanceFetching,
         alloy::{
@@ -2889,9 +2898,23 @@ mod tests {
             verification: verification.clone(),
             ..Default::default()
         };
-        let quote_data = Quote {
-            fee_amount: alloy::primitives::U256::from(6),
-            ..Default::default()
+        // Craft a QuoteCompetition whose winner + metadata produce
+        // fee_amount = 6 via `FeeParameters::fee()`
+        // (gas_amount * gas_price / sell_token_price = 6 * 1 / 1).
+        let competition = QuoteCompetition {
+            request: QuoteRequest {
+                kind: OrderKind::Sell,
+                ..Default::default()
+            },
+            quotes: vec![QuoteResponse {
+                gas_amount: 6.,
+                ..Default::default()
+            }],
+            metadata: QuoteCompetitionMetadata {
+                gas_price: 1.,
+                sell_token_price: 1.,
+                ..Default::default()
+            },
         };
         let fee_amount = U256::ZERO;
         order_quoter
@@ -2911,18 +2934,13 @@ mod tests {
                 timeout: None,
             }))
             .returning({
-                let quote_data = quote_data.clone();
-                move |_| Ok(quote_data.clone())
+                let competition = competition.clone();
+                move |_| Ok(competition.clone())
             });
         order_quoter
             .expect_store_quote()
-            .with(eq(quote_data.clone()))
-            .returning(|quote| {
-                Ok(Quote {
-                    id: Some(42),
-                    ..quote
-                })
-            });
+            .with(eq(competition.clone()))
+            .returning(|_| Ok(42));
 
         let quote = get_quote_and_check_fee(
             &order_quoter,
@@ -2937,6 +2955,7 @@ mod tests {
             quote,
             Quote {
                 id: Some(42),
+                data: competition.to_quote_data(),
                 fee_amount: alloy::primitives::U256::from(6),
                 ..Default::default()
             }

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -2901,21 +2901,22 @@ mod tests {
         // Craft a QuoteCompetition whose winner + metadata produce
         // fee_amount = 6 via `FeeParameters::fee()`
         // (gas_amount * gas_price / sell_token_price = 6 * 1 / 1).
-        let competition = QuoteCompetition {
-            request: QuoteRequest {
+        let competition = QuoteCompetition::new(
+            QuoteRequest {
                 kind: OrderKind::Sell,
                 ..Default::default()
             },
-            quotes: vec![QuoteResponse {
+            QuoteResponse {
                 gas_amount: 6.,
                 ..Default::default()
-            }],
-            metadata: QuoteCompetitionMetadata {
+            },
+            [],
+            QuoteCompetitionMetadata {
                 gas_price: 1.,
                 sell_token_price: 1.,
                 ..Default::default()
             },
-        };
+        );
         let fee_amount = U256::ZERO;
         order_quoter
             .expect_calculate_quote()

--- a/crates/shared/src/order_validation.rs
+++ b/crates/shared/src/order_validation.rs
@@ -1182,7 +1182,7 @@ async fn get_or_create_quote(
                 .store_quote(competition.clone())
                 .await
                 .map_err(ValidationError::Other)?;
-            let mut quote = competition.to_final_quote(&parameters)?;
+            let mut quote = competition.to_final_quote(&parameters);
             quote.id = Some(id);
 
             tracing::debug!(


### PR DESCRIPTION
# Description
In order to actually store a full quote competition in the DB as if it were a regular auction we need to update the quoting related types and interfaces. Actually writing the competition data to the DB will happen in a follow up PR.

# Changes
* storing function now takes `QuoteCompetition` which contains all quotes and only returns the new quote id. If a full quote + id is needed the caller can assemble it themselves
* adjusted quote stream to continuously update the same `QuoteCompetition` - will become relevant in the follow up PR
* updates unit tests to new interface

## How to test
only an interface change - all tests should still pass

## Related Issues
[BE-56](https://linear.app/cowswap/issue/BE-56/orderbook-persists-quote-competition-in-db)