### PR TITLE
Cap effective_eth_out to U256::MAX

### DIFF
--- a/crates/price-estimation/src/competition/quote.rs
+++ b/crates/price-estimation/src/competition/quote.rs
@@ -290,7 +290,8 @@ impl RankingContext {
             // Note on truncation: previously we used primitive_types::U256::from_f64_lossy which
             // truncated the floating point, while alloy is slightly more faithful to the original
             // value and rounds to closest integer: [0, 0.5) => 0, [0.5, 1] => 1
-            v => U256::from(v.trunc()),
+            // Source: https://github.com/paritytech/parity-common/blob/2b887751f2bd3aafe7d6b33197f5a4a35ae61d34/primitive-types/src/fp_conversion.rs#L4-L13
+            v => U256::saturating_from(v.trunc()),
         }
     }
 }


### PR DESCRIPTION
# Description
BNB API entered a [crashloop](https://nomevlabs.slack.com/archives/C036ZGSCJNP/p1786335864506279) because the `f64->U256` conversion panics on overflow; the old implementation, using [`primitive_types::U256::from_f64_lossy` capped to `U256::MAX` on overflow](https://github.com/paritytech/parity-common/blob/2b887751f2bd3aafe7d6b33197f5a4a35ae61d34/primitive-types/src/fp_conversion.rs#L4-L13), this PR rectifies that.

# Changes

* Replace the panicking `U256::from` with `U256::saturating_from`
* Added a comment pointing to the source implementation to simplify finding it (since it's a bit hard to find the docs for it)

