### PR TITLE
Add more auction time metrics

### DIFF
--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -174,8 +174,9 @@ impl RunLoop {
             // order, new block). We only update the cache afterwards to update
             // to the most recent state.
             self_arc.wake_notify.notified().await;
-            let start_block = self_arc
-                .update_caches(&mut last_block, leader_lock_tracker.is_leader())
+            let start_block = self_arc.wait_until_auction_start(&mut last_block).await;
+            self_arc
+                .update_caches(start_block, leader_lock_tracker.is_leader())
                 .await;
 
             // caches are warmed up, we're ready to do leader work
@@ -195,7 +196,7 @@ impl RunLoop {
             {
                 let auction_id = auction.id;
                 self_arc
-                    .single_run(auction)
+                    .single_run(auction, start_block)
                     .instrument(tracing::info_span!("auction", auction_id))
                     .await
             }
@@ -230,10 +231,10 @@ impl RunLoop {
     }
 
     #[instrument(skip_all)]
-    async fn update_caches(&self, prev_block: &mut Option<B256>, is_leader: bool) -> BlockInfo {
+    async fn wait_until_auction_start(&self, prev_block: &mut Option<B256>) -> BlockInfo {
         let current_block = *self.eth.current_block().borrow();
         let time_since_last_block = current_block.observed_at.elapsed();
-        let auction_block = if time_since_last_block > self.config.max_run_loop_delay {
+        if time_since_last_block > self.config.max_run_loop_delay {
             if prev_block.is_some_and(|prev_block| prev_block != current_block.hash) {
                 // don't emit warning if we finished prev run loop within the same block
                 tracing::warn!(
@@ -244,8 +245,11 @@ impl RunLoop {
             ethrpc::block_stream::next_block(self.eth.current_block()).await
         } else {
             current_block
-        };
+        }
+    }
 
+    #[instrument(skip_all)]
+    async fn update_caches(&self, auction_block: BlockInfo, is_leader: bool) {
         {
             let _timer = Metrics::get().service_maintenance_time.start_timer();
             self.maintenance
@@ -267,7 +271,6 @@ impl RunLoop {
                 tracing::warn!(?err, "failed to update auction");
             }
         }
-        auction_block
     }
 
     /// Sleeps until the next auction is supposed to start, builds it and
@@ -329,8 +332,7 @@ impl RunLoop {
     }
 
     #[instrument(skip_all)]
-    async fn single_run(self: &Arc<Self>, auction: domain::Auction) {
-        let single_run_start = Instant::now();
+    async fn single_run(self: &Arc<Self>, auction: domain::Auction, start_block: BlockInfo) {
         tracing::info!(auction_id = ?auction.id, "solving");
 
         // Mark all auction orders as `Ready` for competition
@@ -389,6 +391,7 @@ impl RunLoop {
             OrderEventLabel::Considered,
         );
         tracing::trace!(auction_id = ?auction.id, "orders marked as considered");
+        Metrics::winner_declared(start_block.observed_at.elapsed());
 
         for (solution_uid, winner) in ranking.enumerated().filter(|(_, bid)| bid.is_winner()) {
             let (driver, solution) = (winner.driver(), winner.solution());
@@ -396,7 +399,7 @@ impl RunLoop {
 
             self.start_settlement_execution(
                 auction.id,
-                single_run_start,
+                start_block.observed_at,
                 driver,
                 solution,
                 solution_uid,
@@ -1025,6 +1028,13 @@ struct Metrics {
     #[metric(buckets(0.01, 0.05, 0.1, 0.2, 0.5, 1, 1.5, 2, 2.5, 5))]
     service_maintenance_time: prometheus::Histogram,
 
+    /// Total time between seeing the start block of the auction and declaring
+    /// a winning driver.
+    #[metric(buckets(
+        0, 1, 2, 3, 4, 5, 6, 7, 7.5, 8, 8.25, 8.5, 8.75, 9, 9.25, 9.5, 9.75, 10
+    ))]
+    winner_declared: prometheus::Histogram,
+
     /// Total time spent in a single run of the run loop.
     #[metric(buckets(0, 3, 6, 9, 12, 15, 18, 21, 24, 27, 30, 33, 36, 39, 42, 45, 48))]
     single_run_time: prometheus::Histogram,
@@ -1114,6 +1124,10 @@ impl Metrics {
 
     fn single_run_completed(elapsed: Duration) {
         Self::get().single_run_time.observe(elapsed.as_secs_f64());
+    }
+
+    fn winner_declared(elapsed: Duration) {
+        Self::get().winner_declared.observe(elapsed.as_secs_f64());
     }
 
     fn auction_ready(init_block_timestamp: Instant) {

--- a/crates/ethrpc/src/block_stream.rs
+++ b/crates/ethrpc/src/block_stream.rs
@@ -325,10 +325,16 @@ pub struct Metrics {
     last_block_number: prometheus::core::GenericGauge<prometheus::core::AtomicU64>,
 
     /// Measures how much time passes between 2 blocks
+    // buckets were chosen to have high resolution around target block times of various
+    // chains (250ms, 500ms, 1s, 2s, 5s, 12s)
     #[metric(buckets(
-        0., 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1., 1.25, 1.5, 1.75, 2., 2.25, 2.5, 3., 4., 5., 10.,
+        0., 0.1, 0.2, 0.25, 0.3, // 250ms
+        0.4, 0.5, // 500ms
+        0.75, 1., 1.25, // 1s
+        1.5, 1.75, 2., 2.25, 2.5, // 2s
+        4.25, 4.5, 5., 5.25, 5.5, // 5s
         10.25, 10.5, 10.75, 11., 11.25, 11.5, 11.75, 12., 12.25, 12.5, 12.75, 13., 13.25, 13.5,
-        13.75, 14.
+        13.75, 14. // 12s
     ))]
     time_since_last_block: prometheus::Histogram,
 }

--- a/crates/ethrpc/src/block_stream.rs
+++ b/crates/ethrpc/src/block_stream.rs
@@ -233,20 +233,19 @@ fn handle_new_block(
     new_block: BlockInfo,
     sender: &watch::Sender<BlockInfo>,
 ) {
-    update_current_block_metrics(new_block.number);
-
     // If the block is exactly the same as the previous one, ignore it.
     if previous_block.hash == new_block.hash {
         return;
     }
 
     tracing::debug!(number=%new_block.number, hash=?new_block.hash, "observed new block");
-    update_block_metrics(previous_block.number, new_block.number);
 
     // Only update the stream if the number has increased.
     if new_block.number <= previous_block.number {
         return;
     }
+
+    update_block_metrics(previous_block, &new_block);
 
     tracing::info!(number=%new_block.number, hash=?new_block.hash, "noticed a new block");
     if let Err(err) = sender.send(new_block) {
@@ -324,30 +323,36 @@ pub struct Metrics {
 
     /// Records newly observed block number.
     last_block_number: prometheus::core::GenericGauge<prometheus::core::AtomicU64>,
+
+    /// Measures how much time passes between 2 blocks
+    #[metric(buckets(
+        0., 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1., 1.25, 1.5, 1.75, 2., 2.25, 2.5, 3., 4., 5., 10.,
+        10.25, 10.5, 10.75, 11., 11.25, 11.5, 11.75, 12., 12.25, 12.5, 12.75, 13., 13.25, 13.5,
+        13.75, 14.
+    ))]
+    time_since_last_block: prometheus::Histogram,
 }
 
-/// Updates metrics about the difference of the new block number compared to the
-/// current block.
-fn update_block_metrics(current_block: u64, new_block: u64) {
-    let metric = &Metrics::instance(observe::metrics::get_storage_registry())
-        .unwrap()
-        .block_stream_update_delta;
+fn update_block_metrics(previous_block: &BlockInfo, new_block: &BlockInfo) {
+    let metrics = Metrics::instance(observe::metrics::get_storage_registry()).unwrap();
 
-    let delta = (i128::from(new_block) - i128::from(current_block)) as f64;
+    let delta = (i128::from(new_block.number) - i128::from(previous_block.number)) as f64;
     if delta <= 0. {
-        metric.with_label_values(&["negative"]).observe(delta.abs());
+        metrics
+            .block_stream_update_delta
+            .with_label_values(&["negative"])
+            .observe(delta.abs());
     } else {
-        metric.with_label_values(&["positive"]).observe(delta.abs());
+        metrics
+            .block_stream_update_delta
+            .with_label_values(&["positive"])
+            .observe(delta.abs());
     }
-}
 
-/// Records newly observed block number in the metrics.
-fn update_current_block_metrics(block_number: u64) {
-    let metric = &Metrics::instance(observe::metrics::get_storage_registry())
-        .unwrap()
-        .last_block_number;
-
-    metric.set(block_number);
+    metrics.last_block_number.set(new_block.number);
+    metrics
+        .time_since_last_block
+        .observe(previous_block.observed_at.elapsed().as_secs_f64());
 }
 
 /// Awaits and returns the next block that will be pushed into the stream.


### PR DESCRIPTION
# Description
Adds or adjusts a few metrics to get more insights about auction timings.

# Changes
* factor `wait_until_auction_start` our of `update_caches` so that the tempo data for those spans is purely compute (instead of waiting + compute like today)
* measure full auction run loop time against when we first saw the block the auction was built against
* add metrics for time until we declare a winner (measured against observation of auction start block)
* added metrics to measure how regularly we see new block (this fluctuates in practice and currently we don't really know how much)