### PR TITLE
Do not append empty indexable events

### DIFF
--- a/crates/event-indexing/src/event_handler.rs
+++ b/crates/event-indexing/src/event_handler.rs
@@ -493,8 +493,12 @@ where
         // update storage regardless if it's a full update or partial update
         let range = RangeInclusive::try_new(blocks.first().unwrap().0, blocks.last().unwrap().0)?;
         if is_reorg {
+            // must also run with no events to delete reorged ones in the range
             self.store.replace_events(events, range.clone()).await?;
-        } else {
+        } else if !events.is_empty() {
+            // most blocks contain no events for the indexed contract; skipping
+            // the append then saves an empty write transaction per block for
+            // DB backed stores
             self.store.append_events(events).await?;
         }
         self.update_last_handled_blocks(&blocks);


### PR DESCRIPTION
# Description
On fast chains we see quite a bit of blocks that don't have indexable events, in those cases there's no point in trying to append an empty list, this PR avoids that.

# Changes

* Do not `BEGIN`/`COMMIT` on blocks with no indexable events

## How to test
Tested in staging and prod, using arbitrum; queries dropped from ~686k to ~1k
<img width="2177" height="400" alt="image" src="https://github.com/user-attachments/assets/1e03d336-6fdb-4e79-96c6-1f38ce6809bd" />

```
sum by (network) (rate(gp_v2_autopilot_autopilot_database_queries_count{type=~"append_events|append_onchain_order_events"}[5m])) * 86400
```