### PR TITLE
feat: introduce solana-driver crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9794,6 +9794,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-driver"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "futures",
+ "mimalloc",
+ "observe",
+ "tikv-jemallocator",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "solana-epoch-info"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9799,7 +9799,6 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "futures",
- "mimalloc",
  "observe",
  "tikv-jemallocator",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,6 +124,7 @@ shared = { path = "crates/shared" }
 signature-validator = { path = "crates/signature-validator" }
 simulator = { path = "crates/simulator" }
 solana-client = "4"
+solana-driver = { path = "crates/solana-driver" }
 solana-indexer = { path = "crates/solana-indexer" }
 solana-sdk = "4"
 solver = { path = "crates/solver" }

--- a/crates/solana-driver/Cargo.toml
+++ b/crates/solana-driver/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "solana-driver"
+version = "0.1.0"
+authors = ["Cow Protocol Developers <dev@cow.fi>"]
+edition = "2024"
+license = "GPL-3.0-or-later"
+description = "Solana settlement driver for CoW Protocol"
+repository = "https://github.com/cowprotocol/services"
+
+[lib]
+name = "solana_driver"
+path = "src/lib.rs"
+
+[[bin]]
+name = "solana-driver"
+path = "src/main.rs"
+
+[dependencies]
+clap = { workspace = true }
+futures = { workspace = true }
+mimalloc = { workspace = true, optional = true }
+observe = { workspace = true }
+tikv-jemallocator = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal"] }
+tracing = { workspace = true }
+
+[features]
+default = []
+mimalloc-allocator = ["dep:mimalloc"]
+
+[lints]
+workspace = true

--- a/crates/solana-driver/Cargo.toml
+++ b/crates/solana-driver/Cargo.toml
@@ -18,7 +18,6 @@ path = "src/main.rs"
 [dependencies]
 clap = { workspace = true }
 futures = { workspace = true }
-mimalloc = { workspace = true, optional = true }
 observe = { workspace = true }
 tikv-jemallocator = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal"] }
@@ -26,7 +25,6 @@ tracing = { workspace = true }
 
 [features]
 default = []
-mimalloc-allocator = ["dep:mimalloc"]
 
 [lints]
 workspace = true

--- a/crates/solana-driver/src/infra/mod.rs
+++ b/crates/solana-driver/src/infra/mod.rs
@@ -1,0 +1,4 @@
+//! Infrastructure layer: concrete implementations of the driver's external
+//! dependencies (configuration, RPC, HTTP API, observability).
+
+pub mod observe;

--- a/crates/solana-driver/src/infra/observe/mod.rs
+++ b/crates/solana-driver/src/infra/observe/mod.rs
@@ -1,0 +1,8 @@
+//! Observability for the Solana driver, built on the shared `observe` crate.
+
+/// Set up the observability. The `obs_config` argument configures the tokio
+/// tracing framework.
+pub fn init(obs_config: observe::Config) {
+    observe::panic_hook::install();
+    observe::tracing::init::initialize_reentrant(&obs_config);
+}

--- a/crates/solana-driver/src/lib.rs
+++ b/crates/solana-driver/src/lib.rs
@@ -1,0 +1,8 @@
+//! The Solana driver.
+
+#![forbid(unsafe_code)]
+
+pub mod infra;
+mod run;
+
+pub use self::run::{run, start};

--- a/crates/solana-driver/src/main.rs
+++ b/crates/solana-driver/src/main.rs
@@ -1,8 +1,3 @@
-#[cfg(feature = "mimalloc-allocator")]
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
-
-#[cfg(not(feature = "mimalloc-allocator"))]
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 

--- a/crates/solana-driver/src/main.rs
+++ b/crates/solana-driver/src/main.rs
@@ -1,0 +1,12 @@
+#[cfg(feature = "mimalloc-allocator")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+#[cfg(not(feature = "mimalloc-allocator"))]
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
+#[tokio::main]
+async fn main() {
+    solana_driver::start(std::env::args()).await;
+}

--- a/crates/solana-driver/src/run.rs
+++ b/crates/solana-driver/src/run.rs
@@ -1,0 +1,59 @@
+//! Driver entry-point logic.
+
+use {crate::infra::observe as infra_observe, clap::Parser};
+
+/// The Solana driver command line arguments.
+#[derive(Debug, Parser)]
+#[command(author, version, about)]
+pub struct Args {
+    /// Log filter for the tracing framework.
+    #[arg(long, env = "RUST_LOG", default_value = "info,warn,solana_driver=debug")]
+    log: String,
+}
+
+/// The driver entry-point. Parses command-line arguments and runs the driver.
+pub async fn start(args: impl Iterator<Item = String>) {
+    let args = Args::parse_from(args);
+    run(args).await;
+}
+
+/// Runs the driver, blocking until the shutdown signal is received.
+pub async fn run(args: Args) {
+    infra_observe::init(observe::Config::default().with_env_filter(&args.log));
+
+    let version = observe::version::git_version();
+    tracing::info!(%version, "running solana driver");
+
+    tracing::info!("awaiting shutdown signal");
+    shutdown_signal().await;
+    tracing::info!("shutting down");
+}
+
+/// Wait for the shutdown signal.
+#[cfg(unix)]
+async fn shutdown_signal() {
+    // Intercept signals for graceful shutdown. Kubernetes sends sigterm, Ctrl-C
+    // sends sigint.
+    let sigterm = async {
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("failed to install SIGTERM handler")
+            .recv()
+            .await;
+    };
+    let sigint = async {
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt())
+            .expect("failed to install SIGINT handler")
+            .recv()
+            .await;
+    };
+    futures::pin_mut!(sigint);
+    futures::pin_mut!(sigterm);
+    futures::future::select(sigterm, sigint).await;
+}
+
+/// Wait for the shutdown signal.
+#[cfg(windows)]
+async fn shutdown_signal() {
+    // No support for signal handling on Windows.
+    std::future::pending().await
+}

--- a/crates/solana-driver/src/run.rs
+++ b/crates/solana-driver/src/run.rs
@@ -25,35 +25,6 @@ pub async fn run(args: Args) {
     tracing::info!(%version, "running solana driver");
 
     tracing::info!("awaiting shutdown signal");
-    shutdown_signal().await;
+    observe::shutdown::shutdown_signal().await;
     tracing::info!("shutting down");
-}
-
-/// Wait for the shutdown signal.
-#[cfg(unix)]
-async fn shutdown_signal() {
-    // Intercept signals for graceful shutdown. Kubernetes sends sigterm, Ctrl-C
-    // sends sigint.
-    let sigterm = async {
-        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
-            .expect("failed to install SIGTERM handler")
-            .recv()
-            .await;
-    };
-    let sigint = async {
-        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::interrupt())
-            .expect("failed to install SIGINT handler")
-            .recv()
-            .await;
-    };
-    futures::pin_mut!(sigint);
-    futures::pin_mut!(sigterm);
-    futures::future::select(sigterm, sigint).await;
-}
-
-/// Wait for the shutdown signal.
-#[cfg(windows)]
-async fn shutdown_signal() {
-    // No support for signal handling on Windows.
-    std::future::pending().await
 }

--- a/crates/solana-driver/src/run.rs
+++ b/crates/solana-driver/src/run.rs
@@ -7,11 +7,7 @@ use {crate::infra::observe as infra_observe, clap::Parser};
 #[command(author, version, about)]
 pub struct Args {
     /// Log filter for the tracing framework.
-    #[arg(
-        long,
-        env = "RUST_LOG",
-        default_value = "info,warn,solana_driver=debug"
-    )]
+    #[arg(long, env, default_value = "info,solana_driver=debug")]
     log: String,
 }
 

--- a/crates/solana-driver/src/run.rs
+++ b/crates/solana-driver/src/run.rs
@@ -7,7 +7,11 @@ use {crate::infra::observe as infra_observe, clap::Parser};
 #[command(author, version, about)]
 pub struct Args {
     /// Log filter for the tracing framework.
-    #[arg(long, env = "RUST_LOG", default_value = "info,warn,solana_driver=debug")]
+    #[arg(
+        long,
+        env = "RUST_LOG",
+        default_value = "info,warn,solana_driver=debug"
+    )]
     log: String,
 }
 


### PR DESCRIPTION
# Description
Introduces the `solana-driver` crate to the `services` workspace.

# Changes
- New workspace crate `solana-driver`, with bare minimum wiring for running and exiting on a termination signal.
- By "minimum wiring" I mean: argparsing, tracing, panic handling, etc. I tried to mirror other existing crates in this repository.
- This is supposed to follow our [Solana Driver PR plan](https://app.notion.com/p/cownation/Solana-Driver-Detailed-PR-Scopes-3ae8da5f04ca80729a85f492d8d05d3c), the reference is in the branch's suffix (01) in this case. I deviated a bit by avoiding stub implementations, which will be incorporated along future PRs.

## How to test

Run `cargo run -p solana-driver`.

BE-150