### PR TITLE
Remove mimalloc

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -10,7 +10,6 @@ on:
         type: choice
         options:
           - 'None'
-          - 'mimalloc-allocator'
           - 'tokio-console'
         default: 'None'
         required: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,7 +129,7 @@ configs/        # Configuration files
 - Tokio-console support: **Only available in playground environment** (set `TOKIO_CONSOLE=true` to activate when running in playground)
 - Production builds do **not** include tokio-console overhead
 - Runtime log filter changes via UNIX socket at `/tmp/log_filter_override_<program_name>_<pid>.sock`
-- Memory allocator: Uses jemalloc by default with built-in heap profiling support (enable at runtime via MALLOC_CONF environment variable). Can optionally use mimalloc via `--features mimalloc-allocator`
+- Memory allocator: Uses jemalloc with built-in heap profiling support (enable at runtime via MALLOC_CONF environment variable)
 
 ## Playground Environment
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1522,7 +1522,6 @@ dependencies = [
  "indexmap 2.14.0",
  "itertools 0.14.0",
  "maplit",
- "mimalloc",
  "mockall",
  "model",
  "num 0.4.3",
@@ -4491,7 +4490,6 @@ dependencies = [
  "itertools 0.14.0",
  "liquidity-sources",
  "maplit",
- "mimalloc",
  "model",
  "moka",
  "num 0.4.3",
@@ -6227,16 +6225,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
-name = "libmimalloc-sys"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "libredox"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6443,15 +6431,6 @@ dependencies = [
  "keccak",
  "rand_core 0.6.4",
  "zeroize",
-]
-
-[[package]]
-name = "mimalloc"
-version = "0.1.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
-dependencies = [
- "libmimalloc-sys",
 ]
 
 [[package]]
@@ -7133,7 +7112,6 @@ dependencies = [
  "http-client",
  "humantime",
  "humantime-serde",
- "mimalloc",
  "mockall",
  "model",
  "multibase",
@@ -7414,7 +7392,6 @@ dependencies = [
  "ethrpc",
  "futures",
  "itertools 0.14.0",
- "mimalloc",
  "num 0.4.3",
  "number",
  "observe",
@@ -8232,7 +8209,6 @@ dependencies = [
  "gas-price-estimation",
  "http-client",
  "humantime",
- "mimalloc",
  "mockall",
  "number",
  "observe",
@@ -11367,7 +11343,6 @@ dependencies = [
  "itertools 0.14.0",
  "liquidity-sources",
  "maplit",
- "mimalloc",
  "model",
  "moka",
  "num 0.4.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,7 +79,6 @@ jemalloc_pprof = { version = "0.8", features = ["symbolize"] }
 jsonrpc-core = "18.0.0"
 liquidity-sources = { path = "crates/liquidity-sources" }
 maplit = "1.0.2"
-mimalloc = "0.1.43"
 mockall = "0.12.1"
 model = { path = "crates/model" }
 moka = "0.12.10"

--- a/README.md
+++ b/README.md
@@ -116,8 +116,6 @@ tokio-console
 
 All binaries use jemalloc as the default memory allocator with built-in heap profiling support. Profiling is enabled at runtime via the `MALLOC_CONF` environment variable, allowing you to analyze memory usage in production environments without recompiling or restarting services.
 
-**Note:** You can optionally use mimalloc instead of jemalloc by building with `--features mimalloc-allocator`, but this disables heap profiling capability.
-
 ### Enabling Heap Profiling
 
 To enable heap profiling, run services with the `MALLOC_CONF` environment variable set:

--- a/crates/autopilot/Cargo.toml
+++ b/crates/autopilot/Cargo.toml
@@ -46,7 +46,6 @@ humantime = { workspace = true }
 humantime-serde = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
-mimalloc = { workspace = true, optional = true }
 model = { workspace = true }
 num = { workspace = true }
 number = { workspace = true }
@@ -89,7 +88,6 @@ tempfile = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 
 [features]
-mimalloc-allocator = ["dep:mimalloc"]
 test-util = ["configs/test-util", "dep:tempfile", "price-estimation/test-util"]
 tokio-console = ["observe/tokio-console"]
 

--- a/crates/autopilot/src/main.rs
+++ b/crates/autopilot/src/main.rs
@@ -1,8 +1,3 @@
-#[cfg(feature = "mimalloc-allocator")]
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
-
-#[cfg(not(feature = "mimalloc-allocator"))]
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 

--- a/crates/driver/Cargo.toml
+++ b/crates/driver/Cargo.toml
@@ -46,7 +46,6 @@ humantime-serde = { workspace = true }
 indexmap = { workspace = true }
 itertools = { workspace = true }
 liquidity-sources = { workspace = true }
-mimalloc = { workspace = true, optional = true }
 moka = { workspace = true, features = ["future"] }
 num = { workspace = true }
 number = { workspace = true }
@@ -99,7 +98,6 @@ tempfile = { workspace = true }
 tokio = { workspace = true, features = ["process", "test-util"] }
 
 [features]
-mimalloc-allocator = ["dep:mimalloc"]
 tokio-console = ["observe/tokio-console"]
 
 [lints]

--- a/crates/driver/src/main.rs
+++ b/crates/driver/src/main.rs
@@ -1,8 +1,3 @@
-#[cfg(feature = "mimalloc-allocator")]
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
-
-#[cfg(not(feature = "mimalloc-allocator"))]
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 

--- a/crates/orderbook/Cargo.toml
+++ b/crates/orderbook/Cargo.toml
@@ -42,7 +42,6 @@ hex-literal = { workspace = true }
 http-client = { workspace = true }
 humantime = { workspace = true }
 humantime-serde = { workspace = true }
-mimalloc = { workspace = true, optional = true }
 model = { workspace = true }
 multibase = { workspace = true }
 num = { workspace = true }
@@ -81,7 +80,6 @@ tokio = { workspace = true, features = ["test-util"] }
 
 [features]
 e2e = []
-mimalloc-allocator = ["dep:mimalloc"]
 test-util = ["dep:tempfile", "shared/test-util"]
 tokio-console = ["observe/tokio-console"]
 

--- a/crates/orderbook/src/main.rs
+++ b/crates/orderbook/src/main.rs
@@ -1,8 +1,3 @@
-#[cfg(feature = "mimalloc-allocator")]
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
-
-#[cfg(not(feature = "mimalloc-allocator"))]
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 

--- a/crates/pool-indexer/Cargo.toml
+++ b/crates/pool-indexer/Cargo.toml
@@ -31,7 +31,6 @@ contracts = { workspace = true }
 ethrpc = { workspace = true }
 futures = { workspace = true }
 itertools = { workspace = true }
-mimalloc = { workspace = true, optional = true }
 num = { workspace = true }
 number = { workspace = true }
 observe = { workspace = true }
@@ -52,7 +51,6 @@ tracing = { workspace = true }
 url = { workspace = true }
 
 [features]
-mimalloc-allocator = ["dep:mimalloc"]
 tokio-console = ["observe/tokio-console"]
 
 [lints]

--- a/crates/pool-indexer/src/main.rs
+++ b/crates/pool-indexer/src/main.rs
@@ -1,8 +1,3 @@
-#[cfg(feature = "mimalloc-allocator")]
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
-
-#[cfg(not(feature = "mimalloc-allocator"))]
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 

--- a/crates/refunder/Cargo.toml
+++ b/crates/refunder/Cargo.toml
@@ -18,7 +18,6 @@ futures = { workspace = true }
 gas-price-estimation = { workspace = true }
 http-client = { workspace = true }
 humantime = { workspace = true }
-mimalloc = { workspace = true, optional = true }
 number = { workspace = true }
 observe = { workspace = true }
 prometheus = { workspace = true }
@@ -36,7 +35,6 @@ rand = { workspace = true }
 rstest = { workspace = true }
 
 [features]
-mimalloc-allocator = ["dep:mimalloc"]
 tokio-console = ["observe/tokio-console"]
 
 [lints]

--- a/crates/refunder/src/main.rs
+++ b/crates/refunder/src/main.rs
@@ -1,8 +1,3 @@
-#[cfg(feature = "mimalloc-allocator")]
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
-
-#[cfg(not(feature = "mimalloc-allocator"))]
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 

--- a/crates/solvers/Cargo.toml
+++ b/crates/solvers/Cargo.toml
@@ -30,7 +30,6 @@ hmac = { workspace = true }
 humantime-serde = { workspace = true }
 itertools = { workspace = true }
 liquidity-sources = { workspace = true }
-mimalloc = { workspace = true, optional = true }
 moka = { workspace = true, features = ["future"] }
 num = { workspace = true }
 number = { workspace = true }
@@ -69,7 +68,6 @@ tempfile = { workspace = true }
 testlib = { workspace = true }
 
 [features]
-mimalloc-allocator = ["dep:mimalloc"]
 tokio-console = ["observe/tokio-console"]
 
 [lints]

--- a/crates/solvers/src/main.rs
+++ b/crates/solvers/src/main.rs
@@ -1,8 +1,3 @@
-#[cfg(feature = "mimalloc-allocator")]
-#[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
-
-#[cfg(not(feature = "mimalloc-allocator"))]
 #[global_allocator]
 static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 


### PR DESCRIPTION
# Description
We haven't been using mimalloc; it was previously used, it had a smaller footprint but led to memory leaks and didn't have the tooling jemalloc does). In the meantime, we've even added some jemalloc specific functionality like the memory dump and status, so the mimalloc code is effectively dead code