### PR TITLE
solana-driver: http api skeleton

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9774,16 +9774,22 @@ dependencies = [
 name = "solana-driver"
 version = "0.1.0"
 dependencies = [
+ "axum 0.8.8",
  "clap",
  "configs",
+ "futures",
  "humantime-serde",
  "observe",
+ "reqwest 0.13.4",
  "serde",
  "serde-ext",
  "solana-sdk",
  "tikv-jemallocator",
  "tokio",
+ "tokio-util",
  "toml",
+ "tower 0.5.3",
+ "tower-http",
  "tracing",
  "url",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,6 +147,7 @@ token-info = { path = "crates/token-info" }
 tokio = { version = "1.38.0", features = ["tracing"] }
 tokio-stream = { version = "0.1.15", features = ["sync"] }
 tokio-tungstenite = { version = "0.28", default-features = false }
+tokio-util = "0.7"
 toml = "0.8.14"
 tower = "0.5"
 tower-http = "0.6"

--- a/crates/solana-driver/Cargo.toml
+++ b/crates/solana-driver/Cargo.toml
@@ -16,8 +16,10 @@ name = "solana-driver"
 path = "src/main.rs"
 
 [dependencies]
+axum = { workspace = true }
 clap = { workspace = true }
 configs = { workspace = true }
+futures = { workspace = true }
 humantime-serde = { workspace = true }
 observe = { workspace = true }
 serde = { workspace = true }
@@ -25,12 +27,18 @@ serde-ext = { workspace = true }
 solana-sdk = { workspace = true }
 tikv-jemallocator = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal"] }
+tokio-util = { workspace = true }
 toml = { workspace = true }
+tower = { workspace = true }
+tower-http = { workspace = true, features = ["decompression-br", "trace"] }
 tracing = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 
 [features]
 default = []
+
+[dev-dependencies]
+reqwest = { workspace = true, features = ["json"] }
 
 [lints]
 workspace = true

--- a/crates/solana-driver/Cargo.toml
+++ b/crates/solana-driver/Cargo.toml
@@ -22,6 +22,7 @@ configs = { workspace = true }
 futures = { workspace = true }
 humantime-serde = { workspace = true }
 observe = { workspace = true }
+reqwest = { workspace = true, features = ["json"] }
 serde = { workspace = true }
 serde-ext = { workspace = true }
 solana-sdk = { workspace = true }
@@ -36,9 +37,6 @@ url = { workspace = true, features = ["serde"] }
 
 [features]
 default = []
-
-[dev-dependencies]
-reqwest = { workspace = true, features = ["json"] }
 
 [lints]
 workspace = true

--- a/crates/solana-driver/src/infra/api/mod.rs
+++ b/crates/solana-driver/src/infra/api/mod.rs
@@ -1,0 +1,77 @@
+//! HTTP API server.
+
+use {
+    axum::{
+        Router,
+        extract::DefaultBodyLimit,
+        routing::{get, post},
+    },
+    observe::tracing::distributed::axum::{make_span, record_trace_id},
+    std::{net::SocketAddr, sync::Arc},
+    tokio_util::sync::CancellationToken,
+    tower::ServiceBuilder,
+    tower_http::{decompression::RequestDecompressionLayer, trace::TraceLayer},
+};
+
+pub mod routes;
+
+/// The Solana driver HTTP API server.
+pub struct Api {
+    /// Address the server binds to and listens on.
+    pub addr: SocketAddr,
+}
+
+impl Api {
+    /// Bind to the configured address, returning the listener and the actual
+    /// bound address (which differs from `addr` when binding to port 0).
+    pub async fn bind(self) -> Result<(tokio::net::TcpListener, SocketAddr), std::io::Error> {
+        let listener = tokio::net::TcpListener::bind(self.addr).await?;
+        let local_addr = listener.local_addr()?;
+        tracing::info!(port = local_addr.port(), "serving solana driver");
+        Ok((listener, local_addr))
+    }
+
+    /// Serve the API on the given listener until `shutdown` resolves, then
+    /// drain in-flight requests before returning.
+    pub async fn serve(
+        listener: tokio::net::TcpListener,
+        shutdown: CancellationToken,
+    ) -> Result<(), std::io::Error> {
+        // Propagate the OpenTelemetry trace context from incoming request headers and
+        // record the trace id on the request span, so logs can be correlated across
+        // services. `make_span` sets the parent context and an empty `trace_id` field;
+        // `record_trace_id` then fills it in.
+        let tracing_layer = ServiceBuilder::new()
+            .layer(TraceLayer::new_for_http().make_span_with(make_span))
+            .map_request(record_trace_id);
+
+        let app = Router::new()
+            .route("/healthz", get(routes::healthz))
+            .route("/solve", post(routes::solve))
+            .route("/settle", post(routes::settle))
+            // Disable the request body limit: solver payloads (auctions and solutions)
+            // can exceed axum's 2MB default.
+            .layer(DefaultBodyLimit::disable())
+            .layer(RequestDecompressionLayer::new())
+            .layer(tracing_layer)
+            .with_state(State(Arc::new(Inner {})));
+
+        axum::serve(listener, app)
+            .with_graceful_shutdown(shutdown.cancelled_owned())
+            .await
+    }
+}
+
+/// Shared state available to all route handlers.
+///
+/// The inner field is not yet read by any handler (the `/solve` and `/settle`
+/// handlers are stubs), so `#[expect(dead_code)]` suppresses the unused-field
+/// warning until shared state is added.
+#[derive(Clone)]
+#[expect(dead_code)]
+pub struct State(Arc<Inner>);
+
+struct Inner {
+    // Shared state fields will be added as the driver gains functionality
+    // (e.g. validated solutions for `/settle` to resolve).
+}

--- a/crates/solana-driver/src/infra/api/routes/healthz.rs
+++ b/crates/solana-driver/src/infra/api/routes/healthz.rs
@@ -1,0 +1,3 @@
+pub async fn healthz() -> axum::http::StatusCode {
+    axum::http::StatusCode::OK
+}

--- a/crates/solana-driver/src/infra/api/routes/mod.rs
+++ b/crates/solana-driver/src/infra/api/routes/mod.rs
@@ -1,0 +1,5 @@
+mod healthz;
+mod settle;
+mod solve;
+
+pub use {healthz::healthz, settle::settle, solve::solve};

--- a/crates/solana-driver/src/infra/api/routes/settle/mod.rs
+++ b/crates/solana-driver/src/infra/api/routes/settle/mod.rs
@@ -1,0 +1,6 @@
+use crate::infra::api::State;
+
+/// Stub handler.
+pub async fn settle(_state: axum::extract::State<State>) -> axum::http::StatusCode {
+    axum::http::StatusCode::NOT_IMPLEMENTED
+}

--- a/crates/solana-driver/src/infra/api/routes/settle/mod.rs
+++ b/crates/solana-driver/src/infra/api/routes/settle/mod.rs
@@ -1,6 +1,5 @@
 use crate::infra::api::State;
 
-/// Stub handler.
 pub async fn settle(_state: axum::extract::State<State>) -> axum::http::StatusCode {
     axum::http::StatusCode::NOT_IMPLEMENTED
 }

--- a/crates/solana-driver/src/infra/api/routes/solve/mod.rs
+++ b/crates/solana-driver/src/infra/api/routes/solve/mod.rs
@@ -1,0 +1,6 @@
+use crate::infra::api::State;
+
+/// Stub handler.
+pub async fn solve(_state: axum::extract::State<State>) -> axum::http::StatusCode {
+    axum::http::StatusCode::NOT_IMPLEMENTED
+}

--- a/crates/solana-driver/src/infra/api/routes/solve/mod.rs
+++ b/crates/solana-driver/src/infra/api/routes/solve/mod.rs
@@ -1,6 +1,5 @@
 use crate::infra::api::State;
 
-/// Stub handler.
 pub async fn solve(_state: axum::extract::State<State>) -> axum::http::StatusCode {
     axum::http::StatusCode::NOT_IMPLEMENTED
 }

--- a/crates/solana-driver/src/infra/mod.rs
+++ b/crates/solana-driver/src/infra/mod.rs
@@ -1,5 +1,8 @@
 //! Infrastructure layer: concrete implementations of the driver's external
 //! dependencies (configuration, RPC, HTTP API, observability).
 
+pub mod api;
 pub mod config;
 pub mod observe;
+
+pub use self::api::Api;

--- a/crates/solana-driver/src/run.rs
+++ b/crates/solana-driver/src/run.rs
@@ -1,9 +1,9 @@
 //! Driver entry-point logic.
 
 use {
-    crate::infra::{config, observe as infra_observe},
+    crate::infra::{Api, config, observe as infra_observe},
     clap::Parser,
-    std::path::PathBuf,
+    std::{path::PathBuf, time::Duration},
 };
 
 /// The Solana driver command line arguments.
@@ -33,7 +33,24 @@ pub async fn run(args: Args) {
         tracing::info!(?config, "loaded config");
     }
 
-    tracing::info!("awaiting shutdown signal");
-    observe::shutdown::shutdown_signal().await;
-    tracing::info!("shutting down");
+    let shutdown_token = tokio_util::sync::CancellationToken::new();
+    let api = Api {
+        addr: config.http.bind_address,
+    };
+    let (listener, _addr) = api.bind().await.expect("failed to bind HTTP server");
+    let serve = Api::serve(listener, shutdown_token.clone());
+
+    futures::pin_mut!(serve);
+    tokio::select! {
+        result = &mut serve => panic!("serve task exited: {result:?}"),
+        _ = observe::shutdown::shutdown_signal() => {
+            tracing::info!("Gracefully shutting down API");
+            shutdown_token.cancel();
+            // Shutdown timeout needs to be larger than the auction deadline
+            match tokio::time::timeout(Duration::from_secs(20), serve).await {
+                Ok(inner) => inner.expect("API failed during shutdown"),
+                Err(_) => panic!("API shutdown exceeded timeout"),
+            }
+        }
+    }
 }

--- a/crates/solana-driver/tests/api.rs
+++ b/crates/solana-driver/tests/api.rs
@@ -1,0 +1,49 @@
+//! Integration tests for the HTTP API server.
+
+use {solana_driver::infra::api::Api, std::net::SocketAddr, tokio_util::sync::CancellationToken};
+
+/// Spawn the API server on an ephemeral port and return its bound address.
+async fn spawn_server() -> SocketAddr {
+    let api = Api {
+        addr: "0.0.0.0:0".parse().unwrap(),
+    };
+    let (listener, addr) = api.bind().await.unwrap();
+    // A token that is never cancelled keeps the server alive for the test.
+    let shutdown = CancellationToken::new();
+    tokio::spawn(async move { Api::serve(listener, shutdown).await.unwrap() });
+    addr
+}
+
+#[tokio::test]
+async fn healthz_returns_200() {
+    let addr = spawn_server().await;
+    let response = reqwest::Client::new()
+        .get(format!("http://{addr}/healthz"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+}
+
+#[tokio::test]
+async fn shuts_down_cleanly_on_signal() {
+    let api = Api {
+        addr: "0.0.0.0:0".parse().unwrap(),
+    };
+    let (listener, addr) = api.bind().await.unwrap();
+    let shutdown_token = CancellationToken::new();
+    let serve = Api::serve(listener, shutdown_token.clone());
+    let handle = tokio::spawn(async move { serve.await.unwrap() });
+
+    // The server is up and serving requests.
+    let response = reqwest::Client::new()
+        .get(format!("http://{addr}/healthz"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+    // Trigger graceful shutdown and assert the serve future completes cleanly.
+    shutdown_token.cancel();
+    handle.await.unwrap();
+}


### PR DESCRIPTION
# Description
Sets up the HTTP api skeleton for the `solana-driver`.

# Changes
<!-- List of detailed changes (how the change is accomplished) -->
- introduces the new `infra/api` module, with working health endpoint and two stubs for `/settle` and `/solve`.
* contains the axum setup code, mirroring the EVM driver.

## How to test
- run with `cargo run`, interact w/ the `/healtz` endpoint. which should return a `200` status code.
- `cargo test -p solana-driver`
