### PR TITLE
Add (inert) delta auction configurations to the autopilot 

### DIFF
--- a/crates/configs/src/autopilot/run_loop.rs
+++ b/crates/configs/src/autopilot/run_loop.rs
@@ -1,9 +1,6 @@
 use {
     serde::Deserialize,
-    std::{
-        num::{NonZeroU64, NonZeroUsize},
-        time::Duration,
-    },
+    std::{num::NonZeroUsize, time::Duration},
 };
 
 const fn default_max_delay() -> Duration {
@@ -30,8 +27,8 @@ const fn default_min_solve_time() -> Duration {
     Duration::from_secs(10)
 }
 
-const fn default_auction_delta_checkpoint_interval() -> NonZeroU64 {
-    NonZeroU64::new(10).unwrap()
+const fn default_auction_delta_checkpoint_interval() -> Duration {
+    Duration::from_mins(2)
 }
 
 /// Configuration for the autopilot run loop timing.
@@ -63,11 +60,15 @@ pub struct RunLoopConfig {
     pub compress_solve_request: bool,
 
     /// How often a full auction (checkpoint) is sent to drivers that opted
-    /// into incremental auctions (`supports-auction-deltas`). Such drivers
-    /// receive a full auction every this many auctions and deltas relative
-    /// to the previously sent auction in between.
-    #[serde(default = "default_auction_delta_checkpoint_interval")]
-    pub auction_delta_checkpoint_interval: NonZeroU64,
+    /// into incremental auctions (`supports-auction-deltas`). The first
+    /// auction that starts after this much time passed since the last
+    /// checkpoint is sent in full; the auctions in between are sent as
+    /// deltas relative to the previously sent auction.
+    #[serde(
+        with = "humantime_serde",
+        default = "default_auction_delta_checkpoint_interval"
+    )]
+    pub auction_delta_checkpoint_interval: Duration,
 
     /// The maximum number of blocks to wait for a settlement to appear on
     /// chain.
@@ -150,7 +151,7 @@ mod tests {
         assert_eq!(config.max_delay, Duration::from_secs(2));
         assert_eq!(
             config.auction_delta_checkpoint_interval,
-            NonZeroU64::new(10).unwrap()
+            Duration::from_mins(2)
         );
     }
 
@@ -158,12 +159,17 @@ mod tests {
     fn deserialize_full() {
         let toml = r#"
         max-delay = "5s"
+        auction-delta-checkpoint-interval = "30s"
         [sync-solve-deadline-to-blockchain]
             slot-length = "12s"
             tx-propagation-latency = "2s"
         "#;
         let config: RunLoopConfig = toml::from_str(toml).unwrap();
         assert_eq!(config.max_delay, Duration::from_secs(5));
+        assert_eq!(
+            config.auction_delta_checkpoint_interval,
+            Duration::from_secs(30)
+        );
         assert_eq!(
             config
                 .sync_solve_deadline_to_blockchain

--- a/crates/configs/src/autopilot/run_loop.rs
+++ b/crates/configs/src/autopilot/run_loop.rs
@@ -1,6 +1,9 @@
 use {
     serde::Deserialize,
-    std::{num::NonZeroUsize, time::Duration},
+    std::{
+        num::{NonZeroU64, NonZeroUsize},
+        time::Duration,
+    },
 };
 
 const fn default_max_delay() -> Duration {
@@ -25,6 +28,10 @@ const fn default_max_settlement_transaction_wait() -> Duration {
 
 const fn default_min_solve_time() -> Duration {
     Duration::from_secs(10)
+}
+
+const fn default_auction_delta_checkpoint_interval() -> NonZeroU64 {
+    NonZeroU64::new(10).unwrap()
 }
 
 /// Configuration for the autopilot run loop timing.
@@ -54,6 +61,13 @@ pub struct RunLoopConfig {
     /// Enable brotli compression of `/solve` request bodies sent to drivers.
     #[serde(default)]
     pub compress_solve_request: bool,
+
+    /// How often a full auction (checkpoint) is sent to drivers that opted
+    /// into incremental auctions (`supports-auction-deltas`). Such drivers
+    /// receive a full auction every this many auctions and deltas relative
+    /// to the previously sent auction in between.
+    #[serde(default = "default_auction_delta_checkpoint_interval")]
+    pub auction_delta_checkpoint_interval: NonZeroU64,
 
     /// The maximum number of blocks to wait for a settlement to appear on
     /// chain.
@@ -107,6 +121,7 @@ impl Default for RunLoopConfig {
             max_solutions_per_solver: default_max_solutions_per_solver(),
             enable_leader_lock: false,
             compress_solve_request: false,
+            auction_delta_checkpoint_interval: default_auction_delta_checkpoint_interval(),
             submission_deadline: default_submission_deadline(),
             max_settlement_transaction_wait: default_max_settlement_transaction_wait(),
             min_solve_time: default_min_solve_time(),
@@ -133,6 +148,10 @@ mod tests {
     fn deserialize_defaults() {
         let config: RunLoopConfig = toml::from_str("").unwrap();
         assert_eq!(config.max_delay, Duration::from_secs(2));
+        assert_eq!(
+            config.auction_delta_checkpoint_interval,
+            NonZeroU64::new(10).unwrap()
+        );
     }
 
     #[test]

--- a/crates/configs/src/autopilot/solver.rs
+++ b/crates/configs/src/autopilot/solver.rs
@@ -17,6 +17,12 @@ pub struct Solver {
     /// Account used to submit settlement transactions on-chain.
     #[serde(flatten)]
     pub submission_account: Account,
+    /// Whether the driver understands incremental auctions: `/solve` request
+    /// bodies that only contain the difference to the previously sent
+    /// auction, with a full auction every
+    /// `auction-delta-checkpoint-interval` auctions.
+    #[serde(default)]
+    pub supports_auction_deltas: bool,
 }
 
 impl Solver {
@@ -25,6 +31,7 @@ impl Solver {
             name,
             url,
             submission_account: account,
+            supports_auction_deltas: false,
         }
     }
 }
@@ -72,6 +79,7 @@ impl Solver {
             name: name.to_string(),
             url: format!("http://localhost:11088/{name}").parse().unwrap(),
             submission_account: Account::Address(address),
+            supports_auction_deltas: false,
         }
     }
 }
@@ -112,6 +120,21 @@ mod test {
             Account::Kms(Arn("arn:aws:kms:supersecretstuff".into())),
         );
         assert_eq!(driver, expected);
+    }
+
+    #[test]
+    fn auction_deltas_are_opt_in() {
+        let toml = r#"
+        name = "name1"
+        url = "http://localhost:8080"
+        address = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
+        "#;
+        let driver = toml::from_str::<Solver>(toml).unwrap();
+        assert!(!driver.supports_auction_deltas);
+
+        let toml = format!("{toml}\nsupports-auction-deltas = true");
+        let driver = toml::from_str::<Solver>(&toml).unwrap();
+        assert!(driver.supports_auction_deltas);
     }
 
     #[test]

--- a/crates/configs/src/autopilot/solver.rs
+++ b/crates/configs/src/autopilot/solver.rs
@@ -19,8 +19,8 @@ pub struct Solver {
     pub submission_account: Account,
     /// Whether the driver understands incremental auctions: `/solve` request
     /// bodies that only contain the difference to the previously sent
-    /// auction, with a full auction every
-    /// `auction-delta-checkpoint-interval` auctions.
+    /// auction, with a full auction sent every
+    /// `auction-delta-checkpoint-interval`.
     #[serde(default)]
     pub supports_auction_deltas: bool,
 }


### PR DESCRIPTION
# Description
To minimize the diff noise, I'm starting with the configuration — currently inert.

Adds the autopilot configuration for the autopilot deltas.

# Changes

* `[[solver]] supports-auction-deltas` marks a driver as able to handle `/solve` bodies that only carry the difference to the previously sent auction.
* `[run-loop] auction-delta-checkpoint-interval` sets how often such a driver is sent a full auction instead of a delta.

## How to test
Added deserialization tests