### PR TITLE
Implement auction delta generation

### DIFF
--- a/crates/autopilot/src/domain/competition/winner_selection.rs
+++ b/crates/autopilot/src/domain/competition/winner_selection.rs
@@ -1252,6 +1252,7 @@ mod tests {
             url::Url::parse("http://localhost").unwrap(),
             solver_address.to_string(),
             Account::Address(solver_address),
+            false,
         )
         .await
         .unwrap();

--- a/crates/autopilot/src/infra/solvers/dto/solve.rs
+++ b/crates/autopilot/src/infra/solvers/dto/solve.rs
@@ -46,7 +46,7 @@ impl Request {
         deadline: chrono::DateTime<chrono::Utc>,
         compress: bool,
     ) -> Self {
-        let helper = RequestHelper {
+        let helper = FullRequestHelper {
             id: auction.id,
             orders: auction.orders.iter().map(dto::order::from_domain).collect(),
             tokens: tokens(auction, trusted_tokens),
@@ -64,7 +64,7 @@ impl Request {
         deadline: chrono::DateTime<chrono::Utc>,
         compress: bool,
     ) -> Self {
-        let helper = DeltaHelper {
+        let helper = DeltaRequestHelper {
             id: current.id,
             tokens: tokens(current, trusted_tokens),
             orders: OrderDelta::compute(&previous.orders, &current.orders),
@@ -145,22 +145,22 @@ impl Request {
 #[derive(Clone, Debug, Serialize)]
 #[serde(tag = "kind", rename_all = "camelCase")]
 enum RequestBody {
-    Full(RequestHelper),
-    Delta(DeltaHelper),
+    Full(FullRequestHelper),
+    Delta(DeltaRequestHelper),
 }
 
 impl RequestBody {
     fn id(&self) -> i64 {
         match self {
-            RequestBody::Full(RequestHelper { id, .. }) => *id,
-            RequestBody::Delta(DeltaHelper { id, .. }) => *id,
+            RequestBody::Full(FullRequestHelper { id, .. }) => *id,
+            RequestBody::Delta(DeltaRequestHelper { id, .. }) => *id,
         }
     }
 
     fn deadline(&self) -> DateTime<Utc> {
         match self {
-            RequestBody::Full(RequestHelper { deadline, .. }) => *deadline,
-            RequestBody::Delta(DeltaHelper { deadline, .. }) => *deadline,
+            RequestBody::Full(FullRequestHelper { deadline, .. }) => *deadline,
+            RequestBody::Delta(DeltaRequestHelper { deadline, .. }) => *deadline,
         }
     }
 }
@@ -235,7 +235,7 @@ impl Response {
 #[serde_as]
 #[derive(Clone, Debug, Default, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct RequestHelper {
+struct FullRequestHelper {
     #[serde_as(as = "DisplayFromStr")]
     pub id: i64,
     pub tokens: Vec<Token>,
@@ -250,7 +250,7 @@ struct RequestHelper {
 #[serde_as]
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct DeltaHelper {
+pub struct DeltaRequestHelper {
     #[serde_as(as = "DisplayFromStr")]
     id: i64,
     tokens: Vec<Token>,

--- a/crates/autopilot/src/infra/solvers/dto/solve.rs
+++ b/crates/autopilot/src/infra/solvers/dto/solve.rs
@@ -294,9 +294,8 @@ impl OrderDelta {
 
         // `HashMap` iteration order is unspecified, so sort to keep the
         // payload a pure function of the two auctions.
-        let mut removed_orders: Vec<boundary::OrderUid> =
+        let removed_orders: Vec<boundary::OrderUid> =
             unmatched.into_keys().map(Into::into).collect();
-        removed_orders.sort_unstable();
 
         Self {
             updated_orders,

--- a/crates/autopilot/src/infra/solvers/dto/solve.rs
+++ b/crates/autopilot/src/infra/solvers/dto/solve.rs
@@ -46,33 +46,42 @@ impl Request {
         deadline: chrono::DateTime<chrono::Utc>,
         compress: bool,
     ) -> Self {
-        let _timer =
-            observe::metrics::metrics().on_auction_overhead_start("autopilot", "serialize_request");
         let helper = RequestHelper {
             id: auction.id,
             orders: auction.orders.iter().map(dto::order::from_domain).collect(),
-            tokens: auction
-                .prices
-                .iter()
-                .map(|(address, price)| Token {
-                    address: *address.to_owned(),
-                    price: Some(price.get().0),
-                    trusted: trusted_tokens.contains(&Address::from(*address)),
-                })
-                .chain(trusted_tokens.iter().map(|&address| Token {
-                    address,
-                    price: None,
-                    trusted: true,
-                }))
-                .unique_by(|token| token.address)
-                .collect(),
+            tokens: tokens(auction, trusted_tokens),
             deadline,
             surplus_capturing_jit_order_owners: auction.surplus_capturing_jit_order_owners.to_vec(),
         };
-        let auction_id = auction.id;
+        Self::from_body(RequestBody::Full(helper), compress).await
+    }
+
+    /// Builds a request containing the delta to the previously sent auction.
+    pub async fn new_delta(
+        previous: &domain::Auction,
+        current: &domain::Auction,
+        trusted_tokens: &HashSet<Address>,
+        deadline: chrono::DateTime<chrono::Utc>,
+        compress: bool,
+    ) -> Self {
+        let helper = DeltaHelper {
+            id: current.id,
+            tokens: tokens(current, trusted_tokens),
+            orders: OrderDelta::compute(&previous.orders, &current.orders),
+            deadline,
+            surplus_capturing_jit_order_owners: current.surplus_capturing_jit_order_owners.to_vec(),
+        };
+
+        Self::from_body(RequestBody::Delta(helper), compress).await
+    }
+
+    async fn from_body(body: RequestBody, compress: bool) -> Self {
+        let _timer =
+            observe::metrics::metrics().on_auction_overhead_start("autopilot", "serialize_request");
+        let (auction_id, deadline) = (body.id(), body.deadline());
 
         let (body, content_encoding) = tokio::task::spawn_blocking(move || {
-            let serialized = serde_json::to_vec(&helper).expect("type should be JSON serializable");
+            let serialized = serde_json::to_vec(&body).expect("auction is JSON serializable");
 
             if !compress {
                 return (Bytes::from(serialized), None);
@@ -125,6 +134,55 @@ impl Request {
             .to_std()
             .unwrap_or(Duration::ZERO)
     }
+}
+
+/// The two kinds of `/solve` request bodies, distinguished by an internal
+/// `kind` tag: the full auction or - for drivers that opted in - only the
+/// difference to a previously sent auction.
+///
+/// The tag is also set on full auctions. That is a purely additive change for
+/// drivers that predate delta requests: they ignore the unknown field.
+#[derive(Clone, Debug, Serialize)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+enum RequestBody {
+    Full(RequestHelper),
+    Delta(DeltaHelper),
+}
+
+impl RequestBody {
+    fn id(&self) -> i64 {
+        match self {
+            RequestBody::Full(RequestHelper { id, .. }) => *id,
+            RequestBody::Delta(DeltaHelper { id, .. }) => *id,
+        }
+    }
+
+    fn deadline(&self) -> DateTime<Utc> {
+        match self {
+            RequestBody::Full(RequestHelper { deadline, .. }) => *deadline,
+            RequestBody::Delta(DeltaHelper { deadline, .. }) => *deadline,
+        }
+    }
+}
+
+/// Builds the token list of an auction: all tokens with a known price plus
+/// all trusted tokens.
+fn tokens(auction: &domain::Auction, trusted_tokens: &HashSet<Address>) -> Vec<Token> {
+    auction
+        .prices
+        .iter()
+        .map(|(address, price)| Token {
+            address: *address.to_owned(),
+            price: Some(price.get().0),
+            trusted: trusted_tokens.contains(&Address::from(*address)),
+        })
+        .chain(trusted_tokens.iter().map(|&address| Token {
+            address,
+            price: None,
+            trusted: true,
+        }))
+        .unique_by(|token| token.address)
+        .collect()
 }
 
 impl InjectIntoHttpRequest for Request {
@@ -184,6 +242,68 @@ struct RequestHelper {
     pub orders: Vec<Order>,
     pub deadline: DateTime<Utc>,
     pub surplus_capturing_jit_order_owners: Vec<Address>,
+}
+
+/// Difference of an auction relative to the auction `previous_id`, which is
+/// the auction the receiving driver got immediately before this one. Only
+/// orders are diffed; tokens and all scalar fields are sent whole.
+#[serde_as]
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeltaHelper {
+    #[serde_as(as = "DisplayFromStr")]
+    id: i64,
+    tokens: Vec<Token>,
+    #[serde(flatten)]
+    orders: OrderDelta,
+    deadline: DateTime<Utc>,
+    surplus_capturing_jit_order_owners: Vec<Address>,
+}
+
+/// The orders of an auction expressed as the difference to a previous auction.
+/// Flattened into [`DeltaHelper`], so the two fields sit next to `tokens` and
+/// friends on the wire.
+#[derive(Clone, Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct OrderDelta {
+    /// Orders that were added or modified since the base auction.
+    updated_orders: Vec<Order>,
+    /// Uids of orders that were removed since the base auction.
+    removed_orders: Vec<boundary::OrderUid>,
+}
+
+impl OrderDelta {
+    /// Diffs the orders of two auctions, matching them by uid. An order counts
+    /// as updated when it is new or when any of its fields changed.
+    fn compute(previous: &[domain::Order], current: &[domain::Order]) -> Self {
+        // Matched orders are taken out of the map, so whatever is left at the
+        // end is exactly the set of removed orders. That saves both a second
+        // hash set holding the uids of `current` and a second pass over
+        // `previous`.
+        let mut unmatched: HashMap<_, _> =
+            previous.iter().map(|order| (order.uid, order)).collect();
+
+        let mut updated_orders = Vec::new();
+        for order in current {
+            let unchanged = unmatched
+                .remove(&order.uid)
+                .is_some_and(|previous| previous == order);
+            if !unchanged {
+                updated_orders.push(dto::order::from_domain(order));
+            }
+        }
+
+        // `HashMap` iteration order is unspecified, so sort to keep the
+        // payload a pure function of the two auctions.
+        let mut removed_orders: Vec<boundary::OrderUid> =
+            unmatched.into_keys().map(Into::into).collect();
+        removed_orders.sort_unstable();
+
+        Self {
+            updated_orders,
+            removed_orders,
+        }
+    }
 }
 
 #[serde_as]
@@ -362,5 +482,153 @@ mod tests {
 
         assert_eq!(request.content_encoding, None);
         assert_eq!(request.body.as_ref(), json.as_slice());
+    }
+
+    /// Uid with all 56 bytes set to `uid_byte`.
+    fn uid(uid_byte: u8) -> boundary::OrderUid {
+        boundary::OrderUid([uid_byte; 56])
+    }
+
+    fn uid_json(uid_byte: u8) -> String {
+        format!("0x{}", format!("{uid_byte:02x}").repeat(56))
+    }
+
+    /// JSON of a minimal order as serialized by [`RequestHelper`], with all
+    /// bytes of the uid set to `uid_byte`.
+    fn order_json(uid_byte: u8, executed: u64) -> serde_json::Value {
+        serde_json::json!({
+            "uid": uid_json(uid_byte),
+            "sellToken": "0x2222222222222222222222222222222222222222",
+            "buyToken": "0x3333333333333333333333333333333333333333",
+            "sellAmount": "1000",
+            "buyAmount": "2000",
+            "protocolFees": [],
+            "created": 1,
+            "validTo": 2,
+            "kind": "sell",
+            "receiver": null,
+            "owner": "0x4444444444444444444444444444444444444444",
+            "partiallyFillable": true,
+            "executed": executed.to_string(),
+            "preInteractions": [],
+            "postInteractions": [],
+            "sellTokenBalance": "erc20",
+            "buyTokenBalance": "erc20",
+            "class": "limit",
+            "appData": format!("0x{}", "00".repeat(32)),
+            "signingScheme": "eip712",
+            "signature": format!("0x{}1c", "01".repeat(64)),
+            "quote": null,
+        })
+    }
+
+    fn test_order(uid_byte: u8, executed: u64) -> domain::Order {
+        dto::order::to_domain(serde_json::from_value(order_json(uid_byte, executed)).unwrap())
+    }
+
+    fn test_auction(id: i64, orders: Vec<domain::Order>) -> domain::Auction {
+        domain::Auction {
+            id,
+            block: 1,
+            orders,
+            prices: Default::default(),
+            surplus_capturing_jit_order_owners: vec![],
+        }
+    }
+
+    fn test_deadline() -> DateTime<Utc> {
+        DateTime::from_timestamp(1_700_000_000, 0).unwrap()
+    }
+
+    #[tokio::test]
+    async fn full_request_is_tagged() {
+        let auction = test_auction(1, vec![test_order(0x11, 0)]);
+        let request = Request::new(&auction, &HashSet::new(), test_deadline(), false).await;
+        let body: serde_json::Value = serde_json::from_str(&request.body_to_string()).unwrap();
+
+        // The `kind` tag is the only addition compared to the body drivers
+        // received before delta requests existed; every other field keeps its
+        // name and place, so drivers that ignore unknown fields are unaffected.
+        assert_eq!(body.get("kind"), Some(&serde_json::json!("full")));
+        assert_eq!(body.get("id"), Some(&serde_json::json!("1")));
+        assert_eq!(
+            body.get("orders"),
+            Some(&serde_json::json!([order_json(0x11, 0)]))
+        );
+    }
+
+    /// The wire shape of a delta body, mirrored in the driver's tests
+    /// (crates/driver/src/infra/api/routes/solve/dto/solve_request.rs) to
+    /// pin the format both sides agree on. Note that the two [`OrderDelta`]
+    /// fields are flattened into the body instead of nested.
+    #[tokio::test]
+    async fn delta_request_wire_format() {
+        let previous = test_auction(1, vec![test_order(0x33, 0)]);
+        let current = test_auction(2, vec![test_order(0x44, 0)]);
+        let request =
+            Request::new_delta(&previous, &current, &HashSet::new(), test_deadline(), false).await;
+
+        let actual: serde_json::Value = serde_json::from_str(&request.body_to_string()).unwrap();
+        let expected = serde_json::json!({
+            "kind": "delta",
+            "id": "2",
+            "tokens": [],
+            "updatedOrders": [order_json(0x44, 0)],
+            "removedOrders": [uid_json(0x33)],
+            "deadline": "2023-11-14T22:13:20Z",
+            "surplusCapturingJitOrderOwners": [],
+        });
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn order_delta_splits_updated_from_removed() {
+        let unchanged = test_order(0x11, 0);
+        let previous = [unchanged.clone(), test_order(0x22, 0), test_order(0x33, 0)];
+        let current = [
+            unchanged,
+            // same uid, but partially filled by now
+            test_order(0x22, 100),
+            // brand new order
+            test_order(0x44, 0),
+        ];
+
+        let delta = OrderDelta::compute(&previous, &current);
+
+        let updated: Vec<_> = delta
+            .updated_orders
+            .iter()
+            .map(|order| (order.uid, order.executed))
+            .collect();
+        assert_eq!(
+            updated,
+            [(uid(0x22), U256::from(100)), (uid(0x44), U256::ZERO)]
+        );
+        assert_eq!(delta.removed_orders, [uid(0x33)]);
+    }
+
+    #[test]
+    fn order_delta_is_empty_for_identical_orders() {
+        let orders = [test_order(0x11, 0), test_order(0x22, 0)];
+
+        let delta = OrderDelta::compute(&orders, &orders);
+
+        assert!(delta.updated_orders.is_empty());
+        assert!(delta.removed_orders.is_empty());
+    }
+
+    #[test]
+    fn removed_orders_are_sorted() {
+        let previous = [
+            test_order(0x33, 0),
+            test_order(0x11, 0),
+            test_order(0x22, 0),
+        ];
+
+        let delta = OrderDelta::compute(&previous, &[]);
+
+        // The uids come out of a `HashMap`, so without sorting their order
+        // would differ between runs.
+        assert_eq!(delta.removed_orders, [uid(0x11), uid(0x22), uid(0x33)]);
     }
 }

--- a/crates/autopilot/src/infra/solvers/dto/solve.rs
+++ b/crates/autopilot/src/infra/solvers/dto/solve.rs
@@ -292,8 +292,6 @@ impl OrderDelta {
             }
         }
 
-        // `HashMap` iteration order is unspecified, so sort to keep the
-        // payload a pure function of the two auctions.
         let removed_orders: Vec<boundary::OrderUid> =
             unmatched.into_keys().map(Into::into).collect();
 

--- a/crates/autopilot/src/infra/solvers/dto/solve.rs
+++ b/crates/autopilot/src/infra/solvers/dto/solve.rs
@@ -284,10 +284,10 @@ impl OrderDelta {
 
         let mut updated_orders = Vec::new();
         for order in current {
-            let unchanged = unmatched
+            let changed = unmatched
                 .remove(&order.uid)
-                .is_some_and(|previous| previous == order);
-            if !unchanged {
+                .is_none_or(|previous| previous != order);
+            if changed {
                 updated_orders.push(dto::order::from_domain(order));
             }
         }

--- a/crates/autopilot/src/infra/solvers/dto/solve.rs
+++ b/crates/autopilot/src/infra/solvers/dto/solve.rs
@@ -244,9 +244,8 @@ struct FullRequestHelper {
     pub surplus_capturing_jit_order_owners: Vec<Address>,
 }
 
-/// Difference of an auction relative to the auction `previous_id`, which is
-/// the auction the receiving driver got immediately before this one. Only
-/// orders are diffed; tokens and all scalar fields are sent whole.
+/// Difference of an auction relative to the previous (i.e. `id - 1`).
+/// Only orders are diffed; tokens and all scalar fields are sent whole.
 #[serde_as]
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/crates/autopilot/src/infra/solvers/dto/solve.rs
+++ b/crates/autopilot/src/infra/solvers/dto/solve.rs
@@ -614,19 +614,4 @@ mod tests {
         assert!(delta.updated_orders.is_empty());
         assert!(delta.removed_orders.is_empty());
     }
-
-    #[test]
-    fn removed_orders_are_sorted() {
-        let previous = [
-            test_order(0x33, 0),
-            test_order(0x11, 0),
-            test_order(0x22, 0),
-        ];
-
-        let delta = OrderDelta::compute(&previous, &[]);
-
-        // The uids come out of a `HashMap`, so without sorting their order
-        // would differ between runs.
-        assert_eq!(delta.removed_orders, [uid(0x11), uid(0x22), uid(0x33)]);
-    }
 }

--- a/crates/autopilot/src/infra/solvers/mod.rs
+++ b/crates/autopilot/src/infra/solvers/mod.rs
@@ -22,6 +22,7 @@ pub struct Driver {
     pub name: String,
     pub url: Url,
     pub submission_address: eth::Address,
+    pub supports_auction_deltas: bool,
     client: Client,
 }
 
@@ -39,6 +40,7 @@ impl Driver {
         url: Url,
         name: String,
         submission_account: Account,
+        supports_auction_deltas: bool,
     ) -> Result<Self, Error> {
         let submission_address = match submission_account {
             Account::Kms(key_id) => {
@@ -54,7 +56,13 @@ impl Driver {
             }
             Account::Address(address) => address,
         };
-        tracing::info!(?name, ?url, ?submission_address, "Creating solver");
+        tracing::info!(
+            ?name,
+            ?url,
+            ?submission_address,
+            supports_auction_deltas,
+            "creating solver"
+        );
 
         Ok(Self {
             name,
@@ -65,6 +73,7 @@ impl Driver {
                 .build()
                 .map_err(Error::FailedToBuildClient)?,
             submission_address,
+            supports_auction_deltas,
         })
     }
 
@@ -141,7 +150,7 @@ impl Driver {
         let text = String::from_utf8_lossy(&body);
         tracing::trace!(%status, body=%text, "solver response");
         let context = || format!("url {url}, body {text:?}");
-        if status != 200 {
+        if status != StatusCode::OK.as_u16() {
             return Err(anyhow!("bad status {status}, {}", context()));
         }
         serde_json::from_slice(&body).with_context(|| format!("bad json {}", context()))

--- a/crates/autopilot/src/run.rs
+++ b/crates/autopilot/src/run.rs
@@ -610,10 +610,15 @@ pub async fn run(config: Configuration, shutdown_controller: ShutdownController)
         .drivers
         .into_iter()
         .map(|driver| async move {
-            infra::Driver::try_new(driver.url, driver.name.clone(), driver.submission_account)
-                .await
-                .map(Arc::new)
-                .expect("failed to load solver configuration")
+            infra::Driver::try_new(
+                driver.url,
+                driver.name.clone(),
+                driver.submission_account,
+                driver.supports_auction_deltas,
+            )
+            .await
+            .map(Arc::new)
+            .expect("failed to load solver configuration")
         })
         .collect::<Vec<_>>();
 
@@ -670,6 +675,8 @@ async fn shadow_mode(config: Configuration) -> ! {
                 // this address for anything important so we
                 // can simply generate random addresses here.
                 Account::Address(Address::random()),
+                // the shadow autopilot always sends full auctions
+                false,
             )
             .await
             .map(Arc::new)

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -672,11 +672,11 @@ impl RunLoop {
                     .await
             },
         );
-        Metrics::solve_request_body_size(request.body_size());
+        Metrics::solve_request_body_size("full", request.body_size());
 
         // On checkpoint auctions the delta drivers receive the full body.
         let delta_request = delta_request.unwrap_or_else(|| request.clone());
-        Metrics::solve_request_delta_body_size(delta_request.body_size());
+        Metrics::solve_request_body_size("delta", delta_request.body_size());
 
         (request, delta_request)
     }
@@ -1171,19 +1171,18 @@ struct Metrics {
     #[metric(buckets(0, 0.25, 0.5, 0.75, 1, 1.5, 2, 2.5, 3, 4, 5, 6))]
     current_block_delay: prometheus::Histogram,
 
-    /// Tracks the size of the `/solve` request body in bytes.
-    #[metric(buckets(
-        1_000, 5_000, 10_000, 50_000, 100_000, 500_000, 1_000_000, 2_000_000, 3_000_000, 4_000_000
-    ))]
-    solve_request_body_size: prometheus::Histogram,
-
-    /// Tracks the size in bytes of the `/solve` body built for drivers that
-    /// opted into incremental auctions. Matches `solve_request_body_size` on
-    /// checkpoint auctions, and on every auction while no driver has opted in.
-    #[metric(buckets(
-        1_000, 5_000, 10_000, 50_000, 100_000, 500_000, 1_000_000, 2_000_000, 3_000_000, 4_000_000
-    ))]
-    solve_request_delta_body_size: prometheus::Histogram,
+    /// Tracks the size of the `/solve` request body in bytes. The `kind` label
+    /// tells the two bodies apart: `full` is sent to regular drivers, `delta`
+    /// to the drivers that opted into incremental auctions. Both are equal on
+    /// checkpoint auctions and while no driver has opted in.
+    #[metric(
+        labels("kind"),
+        buckets(
+            1_000, 5_000, 10_000, 25_000, 50_000, 100_000, 250_000, 500_000, 1_000_000, 2_000_000,
+            3_000_000, 4_000_000
+        )
+    )]
+    solve_request_body_size: prometheus::HistogramVec,
 }
 
 impl Metrics {
@@ -1271,13 +1270,10 @@ impl Metrics {
             .observe(init_block_timestamp.elapsed().as_secs_f64())
     }
 
-    fn solve_request_body_size(size: usize) {
-        Self::get().solve_request_body_size.observe(size as f64)
-    }
-
-    fn solve_request_delta_body_size(size: usize) {
+    fn solve_request_body_size(kind: &str, size: usize) {
         Self::get()
-            .solve_request_delta_body_size
+            .solve_request_body_size
+            .with_label_values(&[kind])
             .observe(size as f64)
     }
 }

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -194,9 +194,10 @@ impl RunLoop {
 
         Self::spawn_block_listener(eth.current_block().clone(), wake_runloop.clone());
 
-        let interval = config.auction_delta_checkpoint_interval;
-
         Self {
+            delta_state: std::sync::Mutex::new(DeltaState::new(
+                config.auction_delta_checkpoint_interval,
+            )),
             config,
             eth,
             persistence,
@@ -206,7 +207,6 @@ impl RunLoop {
             maintenance,
             winner_selection: winner_selection::Arbitrator::new(max_winners, weth),
             wake_notify: wake_runloop,
-            delta_state: std::sync::Mutex::new(DeltaState::new(interval)),
             drivers,
         }
     }

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -123,7 +123,7 @@ impl DeltaState {
 
     /// Resets `previous_auction` and `last_checkpoint` to their default values.
     fn reset(&mut self) {
-        self.last_checkpoint = Default::default();
+        self.previous_auction = Default::default();
         self.last_checkpoint = Default::default();
     }
 

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -107,13 +107,27 @@ pub struct Probes {
 
 /// The auction sent to the delta drivers in the previous run, and when the
 /// last full auction (checkpoint) was sent to them.
-#[derive(Default)]
 struct DeltaState {
     previous_auction: Option<Arc<domain::Auction>>,
     last_checkpoint: Option<Instant>,
+    interval: Duration,
 }
 
 impl DeltaState {
+    fn new(interval: Duration) -> Self {
+        Self {
+            previous_auction: Default::default(),
+            last_checkpoint: Default::default(),
+            interval,
+        }
+    }
+
+    /// Resets `previous_auction` and `last_checkpoint` to their default values.
+    fn reset(&mut self) {
+        self.last_checkpoint = Default::default();
+        self.last_checkpoint = Default::default();
+    }
+
     /// Returns the auction to diff `auction` against, and stores `auction`
     /// to be diffed against in the next cycle. A delta is always relative to
     /// the auction sent immediately before it.
@@ -123,13 +137,14 @@ impl DeltaState {
     /// passed since the last checkpoint.
     fn advance(
         &mut self,
-        interval: Duration,
         now: Instant,
         auction: &Arc<domain::Auction>,
     ) -> Option<Arc<domain::Auction>> {
         let previous = self.previous_auction.replace(auction.clone());
         match (previous, self.last_checkpoint) {
-            (Some(previous), Some(checkpoint)) if now.duration_since(checkpoint) < interval => {
+            (Some(previous), Some(checkpoint))
+                if now.duration_since(checkpoint) < self.interval =>
+            {
                 Some(previous)
             }
             _ => {
@@ -186,6 +201,8 @@ impl RunLoop {
             .into_iter()
             .partition(|driver| driver.supports_auction_deltas);
 
+        let interval = config.auction_delta_checkpoint_interval.clone();
+
         Self {
             config,
             eth,
@@ -196,7 +213,7 @@ impl RunLoop {
             maintenance,
             winner_selection: winner_selection::Arbitrator::new(max_winners, weth),
             wake_notify: wake_runloop,
-            delta_state: Default::default(),
+            delta_state: std::sync::Mutex::new(DeltaState::new(interval)),
             drivers,
             delta_drivers,
         }
@@ -241,7 +258,7 @@ impl RunLoop {
                 // the previous auction this instance recorded is not the one
                 // the drivers received; ensure we start from a checkpoint when
                 // leadership is (re)gained.
-                *self_arc.delta_state.lock().unwrap() = Default::default();
+                self_arc.delta_state.lock().unwrap().reset();
                 // only the leader is supposed to run the auctions
                 tokio::time::sleep(Duration::from_millis(200)).await;
                 continue;
@@ -736,11 +753,11 @@ impl RunLoop {
         trusted_tokens: &HashSet<Address>,
         deadline: chrono::DateTime<chrono::Utc>,
     ) -> Option<solve::Request> {
-        let previous = self.delta_state.lock().unwrap().advance(
-            self.config.auction_delta_checkpoint_interval,
-            Instant::now(),
-            auction,
-        )?;
+        let previous = self
+            .delta_state
+            .lock()
+            .unwrap()
+            .advance(Instant::now(), auction)?;
         Some(
             solve::Request::new_delta(
                 &previous,
@@ -1433,7 +1450,7 @@ mod tests {
             surplus_capturing_jit_order_owners: vec![],
         };
         let interval = Duration::from_secs(30);
-        let mut state = DeltaState::default();
+        let mut state = DeltaState::new(interval);
         let start = Instant::now();
 
         // With a 30s interval the very first auction is sent in full (no
@@ -1444,11 +1461,7 @@ mod tests {
         for (id, offset) in (0..).zip([0, 10, 20, 30, 40, 50, 60, 70]) {
             diffed_against.push(
                 state
-                    .advance(
-                        interval,
-                        start + Duration::from_secs(offset),
-                        &Arc::new(auction(id)),
-                    )
+                    .advance(start + Duration::from_secs(offset), &Arc::new(auction(id)))
                     .map(|prev| prev.id),
             );
         }

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -44,6 +44,7 @@ use {
     shared::token_list::AutoUpdatingTokenList,
     std::{
         collections::{HashMap, HashSet},
+        iter::chain,
         num::NonZeroUsize,
         sync::{
             Arc,
@@ -67,6 +68,7 @@ pub struct Config {
     pub max_solutions_per_solver: NonZeroUsize,
     pub enable_leader_lock: bool,
     pub compress_solve_request: bool,
+    pub auction_delta_checkpoint_interval: Duration,
 }
 
 impl From<configs::autopilot::run_loop::RunLoopConfig> for Config {
@@ -80,6 +82,7 @@ impl From<configs::autopilot::run_loop::RunLoopConfig> for Config {
             max_solutions_per_solver: value.max_solutions_per_solver,
             enable_leader_lock: value.enable_leader_lock,
             compress_solve_request: value.compress_solve_request,
+            auction_delta_checkpoint_interval: value.auction_delta_checkpoint_interval,
             sync_solve_deadline_to_blockchain: value.sync_solve_deadline_to_blockchain.map(|cfg| {
                 SlotConfig {
                     slot_length: cfg.slot_length,
@@ -102,11 +105,45 @@ pub struct Probes {
     pub startup: Arc<Option<AtomicBool>>,
 }
 
+/// The auction sent to the delta drivers in the previous run, and when the
+/// last full auction (checkpoint) was sent to them.
+#[derive(Default)]
+struct DeltaState {
+    previous_auction: Option<Arc<domain::Auction>>,
+    last_checkpoint: Option<Instant>,
+}
+
+impl DeltaState {
+    /// Returns the auction to diff `auction` against, and stores `auction`
+    /// to be diffed against in the next cycle. A delta is always relative to
+    /// the auction sent immediately before it.
+    ///
+    /// Returns `None` when a full auction (checkpoint) is due instead: on the
+    /// very first auction and on the first auction that starts once `interval`
+    /// passed since the last checkpoint.
+    fn advance(
+        &mut self,
+        interval: Duration,
+        now: Instant,
+        auction: &Arc<domain::Auction>,
+    ) -> Option<Arc<domain::Auction>> {
+        let previous = self.previous_auction.replace(auction.clone());
+        match (previous, self.last_checkpoint) {
+            (Some(previous), Some(checkpoint)) if now.duration_since(checkpoint) < interval => {
+                Some(previous)
+            }
+            _ => {
+                self.last_checkpoint = Some(now);
+                None
+            }
+        }
+    }
+}
+
 pub struct RunLoop {
     config: Config,
     eth: infra::Ethereum,
     persistence: infra::Persistence,
-    drivers: Vec<Arc<infra::Driver>>,
     solvable_orders_cache: Arc<SolvableOrdersCache>,
     trusted_tokens: AutoUpdatingTokenList,
     probes: Probes,
@@ -116,6 +153,15 @@ pub struct RunLoop {
     winner_selection: winner_selection::Arbitrator,
     /// Notifier that wakes the main loop on new blocks or orders
     wake_notify: Arc<tokio::sync::Notify>,
+
+    /// State for building delta requests for drivers that opted into
+    /// incremental auctions.
+    delta_state: std::sync::Mutex<DeltaState>,
+
+    /// Drivers that do NOT support delta auctions
+    drivers: Vec<Arc<infra::Driver>>,
+    /// Drivers that do support delta auctions
+    delta_drivers: Vec<Arc<infra::Driver>>,
 }
 
 impl RunLoop {
@@ -136,17 +182,23 @@ impl RunLoop {
 
         Self::spawn_block_listener(eth.current_block().clone(), wake_runloop.clone());
 
+        let (delta_drivers, drivers) = drivers
+            .into_iter()
+            .partition(|driver| driver.supports_auction_deltas);
+
         Self {
             config,
             eth,
             persistence,
-            drivers,
             solvable_orders_cache,
             trusted_tokens,
             probes,
             maintenance,
             winner_selection: winner_selection::Arbitrator::new(max_winners, weth),
             wake_notify: wake_runloop,
+            delta_state: Default::default(),
+            drivers,
+            delta_drivers,
         }
     }
 
@@ -185,6 +237,11 @@ impl RunLoop {
             }
 
             if !leader_lock_tracker.is_leader() {
+                // While not leading another instance sends the auctions, so
+                // the previous auction this instance recorded is not the one
+                // the drivers received; ensure we start from a checkpoint when
+                // leadership is (re)gained.
+                *self_arc.delta_state.lock().unwrap() = Default::default();
                 // only the leader is supposed to run the auctions
                 tokio::time::sleep(Duration::from_millis(200)).await;
                 continue;
@@ -196,7 +253,7 @@ impl RunLoop {
             {
                 let auction_id = auction.id;
                 self_arc
-                    .single_run(auction, start_block)
+                    .single_run(&auction, start_block)
                     .instrument(tracing::info_span!("auction", auction_id))
                     .await
             }
@@ -279,9 +336,9 @@ impl RunLoop {
     async fn next_auction(
         &self,
         start_block: BlockInfo,
-        prev_auction: &mut Option<domain::Auction>,
+        prev_auction: &mut Option<Arc<domain::Auction>>,
         prev_block: &mut Option<B256>,
-    ) -> Option<domain::Auction> {
+    ) -> Option<Arc<domain::Auction>> {
         // wait for appropriate time to start building the auction
         let auction = self.cut_auction().await?;
         tracing::trace!(auction_id = ?auction.id, "auction cut");
@@ -294,13 +351,13 @@ impl RunLoop {
             return None;
         }
 
-        observe::log_auction_delta(&previous, &auction, &start_block);
+        observe::log_auction_delta(previous.as_deref(), &auction, &start_block);
         self.probes.liveness.auction();
         Metrics::auction_ready(start_block.observed_at);
         Some(auction)
     }
 
-    async fn cut_auction(&self) -> Option<domain::Auction> {
+    async fn cut_auction(&self) -> Option<Arc<domain::Auction>> {
         let Some(auction) = self.solvable_orders_cache.current_auction().await else {
             tracing::debug!("no current auction");
             return None;
@@ -322,17 +379,17 @@ impl RunLoop {
             tracing::debug!("skipping empty auction");
             return None;
         }
-        Some(domain::Auction {
+        Some(Arc::new(domain::Auction {
             id,
             block: auction.block,
             orders: auction.orders,
             prices: auction.prices,
             surplus_capturing_jit_order_owners: auction.surplus_capturing_jit_order_owners,
-        })
+        }))
     }
 
     #[instrument(skip_all)]
-    async fn single_run(self: &Arc<Self>, auction: domain::Auction, start_block: BlockInfo) {
+    async fn single_run(self: &Arc<Self>, auction: &Arc<domain::Auction>, start_block: BlockInfo) {
         tracing::info!(auction_id = ?auction.id, "solving");
 
         // Mark all auction orders as `Ready` for competition
@@ -341,13 +398,13 @@ impl RunLoop {
         tracing::trace!(auction_id = ?auction.id, "orders marked as ready");
 
         // Collect valid solutions from all drivers
-        let solutions = self.fetch_solutions(&auction).await;
+        let solutions = self.fetch_solutions(auction).await;
         observe::bids(&solutions);
         if solutions.is_empty() {
             return;
         }
 
-        let ranking = self.winner_selection.arbitrate(solutions, &auction);
+        let ranking = self.winner_selection.arbitrate(solutions, auction);
 
         // Count and record the number of winners
         let num_winners = ranking.winners().count();
@@ -362,7 +419,7 @@ impl RunLoop {
         // of storing all the competition/auction-related data to the DB.
         if let Err(err) = self
             .post_processing(
-                &auction,
+                auction,
                 competition_simulation_block,
                 &ranking,
                 block_deadline,
@@ -407,7 +464,7 @@ impl RunLoop {
             );
         }
         tracing::trace!(auction_id = ?auction.id, "settlement execution started");
-        observe::unsettled(&ranking, &auction);
+        observe::unsettled(&ranking, auction);
     }
 
     /// Starts settlement execution in a background task. The function is async
@@ -584,26 +641,59 @@ impl RunLoop {
         Ok(())
     }
 
+    /// Builds the auction requests, if no drivers have opted-in to
+    /// delta-auctions or if a checkpoint is due, the second request will
+    /// effectively be a copy of the first.
+    async fn build_auction_requests(
+        &self,
+        auction: &Arc<domain::Auction>,
+    ) -> (solve::Request, solve::Request) {
+        let deadline = self.pick_solve_deadline();
+        let trusted_tokens = self.trusted_tokens.all();
+
+        let (request, delta_request) = tokio::join!(
+            solve::Request::new(
+                auction,
+                &trusted_tokens,
+                deadline,
+                self.config.compress_solve_request,
+            ),
+            async {
+                if self.delta_drivers.is_empty() {
+                    return None;
+                }
+                self.build_delta_request(auction, &trusted_tokens, deadline)
+                    .await
+            },
+        );
+        Metrics::solve_request_body_size(request.body_size());
+
+        // On checkpoint auctions the delta drivers receive the full body.
+        let delta_request = delta_request.unwrap_or_else(|| request.clone());
+        Metrics::solve_request_delta_body_size(delta_request.body_size());
+
+        (request, delta_request)
+    }
+
     /// Runs the solver competition, making all configured drivers participate.
     /// Returns all fair solutions sorted by their score (best to worst).
     #[instrument(skip_all)]
-    async fn fetch_solutions(&self, auction: &domain::Auction) -> Vec<competition::Bid<Unscored>> {
-        let deadline = self.pick_solve_deadline();
+    async fn fetch_solutions(
+        &self,
+        auction: &Arc<domain::Auction>,
+    ) -> Vec<competition::Bid<Unscored>> {
+        let (request, delta_request) = self.build_auction_requests(auction).await;
 
-        let request = solve::Request::new(
-            auction,
-            &self.trusted_tokens.all(),
-            deadline,
-            self.config.compress_solve_request,
-        )
-        .await;
-        Metrics::solve_request_body_size(request.body_size());
-
-        let mut bids = futures::future::join_all(
+        let mut bids = futures::future::join_all(chain(
             self.drivers
                 .iter()
-                .map(|driver| self.solve(driver.clone(), request.clone())),
-        )
+                .cloned()
+                .map(|driver| self.solve(driver, request.clone())),
+            self.delta_drivers
+                .iter()
+                .cloned()
+                .map(|driver| self.solve(driver, delta_request.clone())),
+        ))
         .await
         .into_iter()
         .flatten()
@@ -635,6 +725,32 @@ impl RunLoop {
         // Shuffle so that sorting randomly splits ties.
         bids.shuffle(&mut rand::rng());
         bids
+    }
+
+    /// Builds the delta request for this auction, shared by all drivers that
+    /// opted into incremental auctions. Returns `None` when a full auction
+    /// (checkpoint) is due instead.
+    async fn build_delta_request(
+        &self,
+        auction: &Arc<domain::Auction>,
+        trusted_tokens: &HashSet<Address>,
+        deadline: chrono::DateTime<chrono::Utc>,
+    ) -> Option<solve::Request> {
+        let previous = self.delta_state.lock().unwrap().advance(
+            self.config.auction_delta_checkpoint_interval,
+            Instant::now(),
+            auction,
+        )?;
+        Some(
+            solve::Request::new_delta(
+                &previous,
+                auction,
+                trusted_tokens,
+                deadline,
+                self.config.compress_solve_request,
+            )
+            .await,
+        )
     }
 
     /// Sends a `/solve` request to the driver and manages all error cases and
@@ -1049,6 +1165,14 @@ struct Metrics {
         1_000, 5_000, 10_000, 50_000, 100_000, 500_000, 1_000_000, 2_000_000, 3_000_000, 4_000_000
     ))]
     solve_request_body_size: prometheus::Histogram,
+
+    /// Tracks the size in bytes of the `/solve` body built for drivers that
+    /// opted into incremental auctions. Matches `solve_request_body_size` on
+    /// checkpoint auctions, and on every auction while no driver has opted in.
+    #[metric(buckets(
+        1_000, 5_000, 10_000, 50_000, 100_000, 500_000, 1_000_000, 2_000_000, 3_000_000, 4_000_000
+    ))]
+    solve_request_delta_body_size: prometheus::Histogram,
 }
 
 impl Metrics {
@@ -1139,6 +1263,12 @@ impl Metrics {
     fn solve_request_body_size(size: usize) {
         Self::get().solve_request_body_size.observe(size as f64)
     }
+
+    fn solve_request_delta_body_size(size: usize) {
+        Self::get()
+            .solve_request_delta_body_size
+            .observe(size as f64)
+    }
 }
 
 pub mod observe {
@@ -1152,7 +1282,7 @@ pub mod observe {
     };
 
     pub fn log_auction_delta(
-        previous: &Option<domain::Auction>,
+        previous: Option<&domain::Auction>,
         current: &domain::Auction,
         start_block: &BlockInfo,
     ) {
@@ -1291,5 +1421,49 @@ mod tests {
         let deadline =
             pick_solve_deadline_impl(now, min_solve_time, slot_config.as_ref(), last_block);
         assert_eq!(deadline, "2026-06-01T12:00:13Z".parse::<Ts>().unwrap());
+    }
+
+    #[test]
+    fn delta_checkpoint_cadence() {
+        let auction = |id| domain::Auction {
+            id,
+            block: 0,
+            orders: vec![],
+            prices: Default::default(),
+            surplus_capturing_jit_order_owners: vec![],
+        };
+        let interval = Duration::from_secs(30);
+        let mut state = DeltaState::default();
+        let start = Instant::now();
+
+        // With a 30s interval the very first auction is sent in full (no
+        // previous auction yet) and so is the first auction that starts 30s or
+        // more after that checkpoint. Every delta is against the auction right
+        // before it.
+        let mut diffed_against = vec![];
+        for (id, offset) in (0..).zip([0, 10, 20, 30, 40, 50, 60, 70]) {
+            diffed_against.push(
+                state
+                    .advance(
+                        interval,
+                        start + Duration::from_secs(offset),
+                        &Arc::new(auction(id)),
+                    )
+                    .map(|prev| prev.id),
+            );
+        }
+        assert_eq!(
+            diffed_against,
+            [
+                None,
+                Some(0),
+                Some(1),
+                None,
+                Some(3),
+                Some(4),
+                None,
+                Some(6)
+            ]
+        );
     }
 }

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -194,7 +194,7 @@ impl RunLoop {
 
         Self::spawn_block_listener(eth.current_block().clone(), wake_runloop.clone());
 
-        let interval = config.auction_delta_checkpoint_interval.clone();
+        let interval = config.auction_delta_checkpoint_interval;
 
         Self {
             config,

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -676,9 +676,6 @@ impl RunLoop {
                 self.config.compress_solve_request,
             ),
             async {
-                if self.delta_drivers.is_empty() {
-                    return None;
-                }
                 self.build_delta_request(auction, &trusted_tokens, deadline)
                     .await
             },
@@ -753,6 +750,9 @@ impl RunLoop {
         trusted_tokens: &HashSet<Address>,
         deadline: chrono::DateTime<chrono::Utc>,
     ) -> Option<solve::Request> {
+        if self.delta_drivers.is_empty() {
+            return None;
+        }
         let previous = self
             .delta_state
             .lock()

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -44,7 +44,6 @@ use {
     shared::token_list::AutoUpdatingTokenList,
     std::{
         collections::{HashMap, HashSet},
-        iter::chain,
         num::NonZeroUsize,
         sync::{
             Arc,
@@ -175,8 +174,6 @@ pub struct RunLoop {
 
     /// Drivers that do NOT support delta auctions
     drivers: Vec<Arc<infra::Driver>>,
-    /// Drivers that do support delta auctions
-    delta_drivers: Vec<Arc<infra::Driver>>,
 }
 
 impl RunLoop {
@@ -197,10 +194,6 @@ impl RunLoop {
 
         Self::spawn_block_listener(eth.current_block().clone(), wake_runloop.clone());
 
-        let (delta_drivers, drivers) = drivers
-            .into_iter()
-            .partition(|driver| driver.supports_auction_deltas);
-
         let interval = config.auction_delta_checkpoint_interval.clone();
 
         Self {
@@ -215,7 +208,6 @@ impl RunLoop {
             wake_notify: wake_runloop,
             delta_state: std::sync::Mutex::new(DeltaState::new(interval)),
             drivers,
-            delta_drivers,
         }
     }
 
@@ -698,16 +690,13 @@ impl RunLoop {
     ) -> Vec<competition::Bid<Unscored>> {
         let (request, delta_request) = self.build_auction_requests(auction).await;
 
-        let mut bids = futures::future::join_all(chain(
-            self.drivers
-                .iter()
-                .cloned()
-                .map(|driver| self.solve(driver, request.clone())),
-            self.delta_drivers
-                .iter()
-                .cloned()
-                .map(|driver| self.solve(driver, delta_request.clone())),
-        ))
+        let mut bids = futures::future::join_all(self.drivers.iter().cloned().map(|driver| {
+            let solve_request = driver
+                .supports_auction_deltas
+                .then(|| delta_request.clone())
+                .unwrap_or_else(|| request.clone());
+            self.solve(driver, solve_request)
+        }))
         .await
         .into_iter()
         .flatten()
@@ -750,7 +739,11 @@ impl RunLoop {
         trusted_tokens: &HashSet<Address>,
         deadline: chrono::DateTime<chrono::Utc>,
     ) -> Option<solve::Request> {
-        if self.delta_drivers.is_empty() {
+        if !self
+            .drivers
+            .iter()
+            .any(|driver| driver.supports_auction_deltas)
+        {
             return None;
         }
         let previous = self

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -691,10 +691,11 @@ impl RunLoop {
         let (request, delta_request) = self.build_auction_requests(auction).await;
 
         let mut bids = futures::future::join_all(self.drivers.iter().cloned().map(|driver| {
-            let solve_request = driver
-                .supports_auction_deltas
-                .then(|| delta_request.clone())
-                .unwrap_or_else(|| request.clone());
+            let solve_request = if driver.supports_auction_deltas {
+                delta_request.clone()
+            } else {
+                request.clone()
+            };
             self.solve(driver, solve_request)
         }))
         .await

--- a/crates/autopilot/src/shadow.rs
+++ b/crates/autopilot/src/shadow.rs
@@ -85,7 +85,7 @@ impl RunLoop {
                 tokio::time::sleep(Duration::from_secs(1)).await;
                 continue;
             };
-            observe::log_auction_delta(&previous, &auction, &start_block);
+            observe::log_auction_delta(previous.as_ref(), &auction, &start_block);
             self.liveness.auction();
 
             self.single_run(&auction)


### PR DESCRIPTION
# Description
The current size of the auction is slightly untenable, the issue lies in the amount of orders that we need to send every auction, the worse part is that a lot of them are repeated. To curb this issue we must start sending deltas (or diffs if you may) instead of the list of auctions. The idea is as follows:

Currently we send the full auction:
```
Auction 1: [a, b, c, d, e] // d and e get solved
Auction 2: [a, b, c, x, y, z] // a, b and c, get re-sent
```

In the new scheme:
```
Auction 1: [a, b, c, d, e] // d and e get solved
Auction 2: {added: [x, y, z], removed: [d, e]} // driver will apply the delta to the previous auction
```

> Note, in the example it's more effort, but when the number of unchanged orders largely outweighs the number of changed, this saves quite a bit of space in the auction JSON

Additionally, every X seconds, a complete auction is sent so new drivers (or those that lost track) able to eventually catch up and start contributing. One of the benefits is that drivers no longer need to download a large payload, saving quite a bit of bandwidth and getting the relevant auction data faster.

This PR implements the above idea from the autopilot's perspective.

# Changes

* Order delta computation
* Inner driver list is split into two — those that support delta auctions and those who don't
* Since we need to keep the previous auction around, I started Arc'ing auctions to avoid expensive clones

## How to test
Added tests, furthermore, when adding support to the driver an E2E test is in order