### PR TITLE
[TRIVIAL] feat(solana-driver): add solana RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9783,6 +9783,7 @@ dependencies = [
  "reqwest 0.13.4",
  "serde",
  "serde-ext",
+ "solana-client",
  "solana-sdk",
  "tikv-jemallocator",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9784,6 +9784,7 @@ dependencies = [
  "serde",
  "serde-ext",
  "solana-client",
+ "solana-commitment-config",
  "solana-sdk",
  "tikv-jemallocator",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,6 +124,7 @@ shared = { path = "crates/shared" }
 signature-validator = { path = "crates/signature-validator" }
 simulator = { path = "crates/simulator" }
 solana-client = "4"
+solana-commitment-config = "3"
 solana-driver = { path = "crates/solana-driver" }
 solana-indexer = { path = "crates/solana-indexer" }
 solana-sdk = "4"

--- a/crates/solana-driver/Cargo.toml
+++ b/crates/solana-driver/Cargo.toml
@@ -26,6 +26,7 @@ reqwest = { workspace = true, features = ["json"] }
 serde = { workspace = true }
 serde-ext = { workspace = true }
 solana-client = { workspace = true }
+solana-commitment-config = { workspace = true }
 solana-sdk = { workspace = true }
 tikv-jemallocator = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal"] }

--- a/crates/solana-driver/Cargo.toml
+++ b/crates/solana-driver/Cargo.toml
@@ -25,6 +25,7 @@ observe = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
 serde = { workspace = true }
 serde-ext = { workspace = true }
+solana-client = { workspace = true }
 solana-sdk = { workspace = true }
 tikv-jemallocator = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal"] }

--- a/crates/solana-driver/src/infra/api/mod.rs
+++ b/crates/solana-driver/src/infra/api/mod.rs
@@ -7,6 +7,7 @@ use {
         routing::{get, post},
     },
     observe::tracing::distributed::axum::{make_span, record_trace_id},
+    solana_client::nonblocking::rpc_client::RpcClient,
     std::{net::SocketAddr, sync::Arc},
     tokio_util::sync::CancellationToken,
     tower::ServiceBuilder,
@@ -35,6 +36,7 @@ impl Api {
     /// drain in-flight requests before returning.
     pub async fn serve(
         listener: tokio::net::TcpListener,
+        rpc: Arc<RpcClient>,
         shutdown: CancellationToken,
     ) -> Result<(), std::io::Error> {
         // Propagate the OpenTelemetry trace context from incoming request headers and
@@ -54,7 +56,7 @@ impl Api {
             .layer(DefaultBodyLimit::disable())
             .layer(RequestDecompressionLayer::new())
             .layer(tracing_layer)
-            .with_state(State(Arc::new(Inner {})));
+            .with_state(State(Arc::new(Inner { rpc })));
 
         axum::serve(listener, app)
             .with_graceful_shutdown(shutdown.cancelled_owned())
@@ -72,6 +74,7 @@ impl Api {
 pub struct State(Arc<Inner>);
 
 struct Inner {
-    // Shared state fields will be added as the driver gains functionality
-    // (e.g. validated solutions for `/settle` to resolve).
+    /// The shared Solana RPC client.
+    #[expect(dead_code)]
+    rpc: Arc<RpcClient>,
 }

--- a/crates/solana-driver/src/run.rs
+++ b/crates/solana-driver/src/run.rs
@@ -3,7 +3,8 @@
 use {
     crate::infra::{Api, config, observe as infra_observe},
     clap::Parser,
-    std::{path::PathBuf, time::Duration},
+    solana_client::nonblocking::rpc_client::RpcClient,
+    std::{path::PathBuf, sync::Arc, time::Duration},
 };
 
 /// The Solana driver command line arguments.
@@ -34,11 +35,15 @@ pub async fn run(args: Args) {
     }
 
     let shutdown_token = tokio_util::sync::CancellationToken::new();
+    let rpc = Arc::new(RpcClient::new_with_timeout(
+        config.rpc.endpoint.to_string(),
+        config.rpc.request_timeout,
+    ));
     let api = Api {
         addr: config.http.bind_address,
     };
     let (listener, _addr) = api.bind().await.expect("failed to bind HTTP server");
-    let serve = Api::serve(listener, shutdown_token.clone());
+    let serve = Api::serve(listener, rpc, shutdown_token.clone());
 
     futures::pin_mut!(serve);
     tokio::select! {

--- a/crates/solana-driver/src/run.rs
+++ b/crates/solana-driver/src/run.rs
@@ -4,6 +4,7 @@ use {
     crate::infra::{Api, config, observe as infra_observe},
     clap::Parser,
     solana_client::nonblocking::rpc_client::RpcClient,
+    solana_commitment_config::CommitmentConfig,
     std::{path::PathBuf, sync::Arc, time::Duration},
 };
 
@@ -35,9 +36,10 @@ pub async fn run(args: Args) {
     }
 
     let shutdown_token = tokio_util::sync::CancellationToken::new();
-    let rpc = Arc::new(RpcClient::new_with_timeout(
+    let rpc = Arc::new(RpcClient::new_with_timeout_and_commitment(
         config.rpc.endpoint.to_string(),
         config.rpc.request_timeout,
+        CommitmentConfig::confirmed(),
     ));
     let api = Api {
         addr: config.http.bind_address,

--- a/crates/solana-driver/tests/api.rs
+++ b/crates/solana-driver/tests/api.rs
@@ -1,6 +1,15 @@
 //! Integration tests for the HTTP API server.
 
-use {solana_driver::infra::api::Api, std::net::SocketAddr, tokio_util::sync::CancellationToken};
+use {
+    solana_client::nonblocking::rpc_client::RpcClient,
+    solana_driver::infra::api::Api,
+    std::{net::SocketAddr, sync::Arc},
+    tokio_util::sync::CancellationToken,
+};
+
+fn mock_rpc() -> Arc<RpcClient> {
+    Arc::new(RpcClient::new_mock("succeeds".to_string()))
+}
 
 /// Spawn the API server on an ephemeral port and return its bound address.
 async fn spawn_server() -> SocketAddr {
@@ -10,7 +19,7 @@ async fn spawn_server() -> SocketAddr {
     let (listener, addr) = api.bind().await.unwrap();
     // A token that is never cancelled keeps the server alive for the test.
     let shutdown = CancellationToken::new();
-    tokio::spawn(async move { Api::serve(listener, shutdown).await.unwrap() });
+    tokio::spawn(async move { Api::serve(listener, mock_rpc(), shutdown).await.unwrap() });
     addr
 }
 
@@ -32,7 +41,7 @@ async fn shuts_down_cleanly_on_signal() {
     };
     let (listener, addr) = api.bind().await.unwrap();
     let shutdown_token = CancellationToken::new();
-    let serve = Api::serve(listener, shutdown_token.clone());
+    let serve = Api::serve(listener, mock_rpc(), shutdown_token.clone());
     let handle = tokio::spawn(async move { serve.await.unwrap() });
 
     // The server is up and serving requests.


### PR DESCRIPTION
# Description
Adds the Solana RPC to the `solana-driver` crate.


## How to test
`$ cargo test -p solana-driver`