### PR TITLE
feat(autopilot-svm) PR08: Solana seam implementations and a single auction cycle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1592,6 +1592,7 @@ dependencies = [
  "axum",
  "bigdecimal",
  "chain-types",
+ "chrono",
  "const-hex",
  "cow-solana-rpc",
  "database",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1589,10 +1589,13 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "axum",
  "bigdecimal",
  "chain-types",
  "const-hex",
+ "cow-solana-rpc",
  "database",
+ "futures",
  "reqwest 0.13.4",
  "serde",
  "serde_json",
@@ -1602,6 +1605,7 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+ "winner-selection",
 ]
 
 [[package]]
@@ -3961,6 +3965,7 @@ version = "0.1.0"
 dependencies = [
  "solana-commitment-config",
  "solana-rpc-client",
+ "solana-rpc-client-api",
  "url",
 ]
 

--- a/crates/autopilot-svm/Cargo.toml
+++ b/crates/autopilot-svm/Cargo.toml
@@ -9,6 +9,7 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 bigdecimal = { workspace = true }
 chain-types = { workspace = true }
+chrono = { workspace = true, features = ["serde"] }
 const-hex = { workspace = true }
 cow-solana-rpc = { workspace = true }
 database = { workspace = true }

--- a/crates/autopilot-svm/Cargo.toml
+++ b/crates/autopilot-svm/Cargo.toml
@@ -10,7 +10,9 @@ async-trait = { workspace = true }
 bigdecimal = { workspace = true }
 chain-types = { workspace = true }
 const-hex = { workspace = true }
+cow-solana-rpc = { workspace = true }
 database = { workspace = true }
+futures = { workspace = true }
 reqwest = { workspace = true, features = ["json"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -20,6 +22,10 @@ thiserror = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time"] }
 tracing = { workspace = true }
 url = { workspace = true }
+winner-selection = { workspace = true }
+
+[dev-dependencies]
+axum = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/autopilot-svm/src/domain/arbitrator.rs
+++ b/crates/autopilot-svm/src/domain/arbitrator.rs
@@ -47,7 +47,7 @@ impl WinnerSelection<SolanaCycle> for SolanaArbitrator {
         // An empty fee-policy list marks an order as part of the auction, the
         // arbitrator only scores such orders. The auction carries no protocol
         // fees.
-        // TODO: real fee policies arrive with the MVP protocol-fee support.
+        // TODO: real fee policies arrive with the protocol-fee support (post-MVP).
         let fee_policies = auction
             .orders
             .iter()

--- a/crates/autopilot-svm/src/domain/arbitrator.rs
+++ b/crates/autopilot-svm/src/domain/arbitrator.rs
@@ -1,0 +1,81 @@
+//! Winner selection over the chain-generic arbitrator.
+
+use {
+    crate::{
+        domain::{
+            auction::Auction,
+            cycle::{Ranking, SolanaCycle, Solution},
+        },
+        run_loop::WinnerSelection,
+    },
+    chain_types::{
+        ChainTypes,
+        solana::{Pubkey, Solana},
+    },
+    winner_selection::{Arbitrator, AuctionContext},
+};
+
+/// Runs the generic fair-combinatorial arbitrator over the drivers'
+/// solutions.
+pub struct SolanaArbitrator {
+    inner: Arbitrator<Solana>,
+}
+
+impl SolanaArbitrator {
+    pub fn new(max_winners: usize, wrapped_native: Pubkey) -> Self {
+        Self {
+            inner: Arbitrator {
+                max_winners,
+                wrapped_native,
+            },
+        }
+    }
+}
+
+impl WinnerSelection<SolanaCycle> for SolanaArbitrator {
+    fn arbitrate(&self, solutions: Vec<Solution>, auction: &Auction) -> Ranking {
+        let drivers = solutions
+            .iter()
+            .map(|solution| {
+                (
+                    (solution.inner.solver(), solution.inner.id()),
+                    solution.driver_index,
+                )
+            })
+            .collect();
+
+        // An empty fee-policy list marks an order as part of the auction, the
+        // arbitrator only scores such orders. The auction carries no protocol
+        // fees.
+        // TODO: real fee policies arrive with the MVP protocol-fee support.
+        let fee_policies = auction
+            .orders
+            .iter()
+            .map(|order| (order.uid, Vec::new()))
+            .collect();
+        // Every auction token is priced at the native denominator, i.e. 1:1
+        // to lamports, so scores compare raw surplus. Ranking within one
+        // token pair is exact, comparisons across pairs are not.
+        // TODO: replace with native price estimation.
+        let native_prices = auction
+            .orders
+            .iter()
+            .flat_map(|order| [order.sell_token, order.buy_token])
+            .map(|token| (token, Solana::NATIVE_PRICE_DENOMINATOR))
+            .collect();
+        let context = AuctionContext::<Solana> {
+            fee_policies,
+            surplus_capturing_jit_order_owners: Default::default(),
+            native_prices,
+        };
+
+        let inner = self.inner.arbitrate(
+            solutions
+                .into_iter()
+                .map(|solution| solution.inner)
+                .collect(),
+            &context,
+        );
+        Ranking { inner, drivers }
+    }
+}

--- a/crates/autopilot-svm/src/domain/auction.rs
+++ b/crates/autopilot-svm/src/domain/auction.rs
@@ -39,9 +39,6 @@ pub struct Auction {
     /// Autopilot-assigned id. Excluded from equality: the dedupe compares two
     /// cuts by content, and the id is allocated only for a fresh cut.
     pub id: i64,
-    /// Slot the auction was cut at. Excluded from equality for the same
-    /// reason: the tip moves every cycle, the content may not.
-    pub tip: u64,
     pub orders: Vec<Order>,
 }
 
@@ -79,24 +76,18 @@ mod tests {
     }
 
     #[test]
-    fn auction_equality_ignores_id_and_tip() {
+    fn auction_equality_ignores_id() {
         let orders = vec![order(10)];
         let a = Auction {
             id: 1,
-            tip: 100,
             orders: orders.clone(),
         };
-        let b = Auction {
-            id: 2,
-            tip: 200,
-            orders,
-        };
+        let b = Auction { id: 2, orders };
         assert_eq!(a, b);
         assert_ne!(
             a,
             Auction {
                 id: 1,
-                tip: 100,
                 orders: vec![],
             }
         );

--- a/crates/autopilot-svm/src/domain/auction.rs
+++ b/crates/autopilot-svm/src/domain/auction.rs
@@ -39,6 +39,9 @@ pub struct Auction {
     /// Autopilot-assigned id. Excluded from equality: the dedupe compares two
     /// cuts by content, and the id is allocated only for a fresh cut.
     pub id: i64,
+    /// Slot the auction was cut at. Excluded from equality for the same
+    /// reason: the tip moves every cycle, the content may not.
+    pub tip: u64,
     pub orders: Vec<Order>,
 }
 
@@ -76,18 +79,24 @@ mod tests {
     }
 
     #[test]
-    fn auction_equality_ignores_the_id() {
+    fn auction_equality_ignores_id_and_tip() {
         let orders = vec![order(10)];
         let a = Auction {
             id: 1,
+            tip: 100,
             orders: orders.clone(),
         };
-        let b = Auction { id: 2, orders };
+        let b = Auction {
+            id: 2,
+            tip: 200,
+            orders,
+        };
         assert_eq!(a, b);
         assert_ne!(
             a,
             Auction {
                 id: 1,
+                tip: 100,
                 orders: vec![],
             }
         );

--- a/crates/autopilot-svm/src/domain/cycle.rs
+++ b/crates/autopilot-svm/src/domain/cycle.rs
@@ -1,0 +1,64 @@
+//! The Solana instantiation of the auction loop's type vocabulary.
+
+use {
+    crate::{
+        domain::auction::Auction,
+        run_loop::{Cycle, RankingInfo},
+    },
+    chain_types::solana::{IntentHash, Pubkey, Solana},
+    std::collections::{HashMap, HashSet},
+    winner_selection::{Unscored, solution},
+};
+
+/// Marker type binding the generic loop to the Solana vocabulary.
+pub struct SolanaCycle;
+
+impl Cycle for SolanaCycle {
+    type Auction = Auction;
+    type OrderUid = IntentHash;
+    type Ranking = Ranking;
+    type Solution = Solution;
+    /// The chain progress marker is the slot.
+    type Tip = u64;
+}
+
+/// One driver's solution, attributed to the driver that proposed it so the
+/// executor can dispatch the settlement back to it.
+pub struct Solution {
+    /// Index into the configured driver list.
+    pub driver_index: usize,
+    pub inner: solution::Solution<Unscored, Solana>,
+}
+
+/// Key attributing a ranked solution back to its driver. The arbitrator
+/// keeps `(solver, solution id)` through ranking, the driver index does not
+/// survive it.
+pub type SolutionKey = (Pubkey, u64);
+
+/// Arbitrated solutions plus the driver attribution the generic ranking
+/// drops.
+pub struct Ranking {
+    pub inner: winner_selection::Ranking<Solana>,
+    /// Driver index per solution, keyed by `(solver, solution id)`.
+    pub drivers: HashMap<SolutionKey, usize>,
+}
+
+impl RankingInfo<SolanaCycle> for Ranking {
+    fn winner_count(&self) -> usize {
+        self.inner.winners().count()
+    }
+
+    fn winning_order_uids(&self) -> HashSet<IntentHash> {
+        self.inner
+            .winners()
+            .flat_map(|solution| solution.orders().iter().map(|order| order.uid))
+            .collect()
+    }
+
+    fn considered_order_uids(&self) -> HashSet<IntentHash> {
+        self.inner
+            .non_winners()
+            .flat_map(|solution| solution.orders().iter().map(|order| order.uid))
+            .collect()
+    }
+}

--- a/crates/autopilot-svm/src/domain/mod.rs
+++ b/crates/autopilot-svm/src/domain/mod.rs
@@ -1,3 +1,5 @@
-//! Domain types: the auction and its orders.
+//! Domain types: the auction, its orders, and the cycle vocabulary.
 
+pub mod arbitrator;
 pub mod auction;
+pub mod cycle;

--- a/crates/autopilot-svm/src/infra/competition.rs
+++ b/crates/autopilot-svm/src/infra/competition.rs
@@ -19,9 +19,6 @@ use {
     winner_selection::{Side, solution},
 };
 
-/// Solana's target slot time.
-const SLOT_DURATION: Duration = Duration::from_millis(400);
-
 /// Sends `/solve` to every driver and converts the answers into attributable
 /// solutions for the arbitrator.
 pub struct DriverCompetition {
@@ -44,10 +41,7 @@ impl SolverCompetition<SolanaCycle> for DriverCompetition {
     async fn solve(&self, auction: &Auction) -> Vec<Solution> {
         let request = &dto::SolveRequest {
             id: auction.id,
-            // The wire carries the deadline as a slot, so the wall-clock
-            // budget converts at the target slot time.
-            deadline_slot: auction.tip
-                + (self.solve_deadline.as_millis() / SLOT_DURATION.as_millis()) as u64,
+            deadline: chrono::Utc::now() + self.solve_deadline,
             orders: auction.orders.iter().map(dto::Order::from).collect(),
         };
         let by_uid: HashMap<IntentHash, &Order> = auction

--- a/crates/autopilot-svm/src/infra/competition.rs
+++ b/crates/autopilot-svm/src/infra/competition.rs
@@ -1,0 +1,140 @@
+//! Fans the auction out to the configured drivers.
+
+use {
+    crate::{
+        domain::{
+            auction::{Auction, Order, OrderKind},
+            cycle::{SolanaCycle, Solution},
+        },
+        infra::driver::{Driver, dto},
+        run_loop::SolverCompetition,
+    },
+    async_trait::async_trait,
+    chain_types::solana::{IntentHash, Solana},
+    std::{
+        collections::{HashMap, HashSet},
+        sync::Arc,
+        time::Duration,
+    },
+    winner_selection::{Side, solution},
+};
+
+/// Slots between the tip a solve request is stamped at and its deadline,
+/// the driver's whole thinking budget (~6s at 400ms slots, the EVM fast
+/// chains run 6s solve deadlines).
+/// TODO: make configurable.
+const SOLVE_DEADLINE_SLOTS: u64 = 15;
+
+/// Solana's target slot time.
+const SLOT_DURATION: Duration = Duration::from_millis(400);
+
+/// Sends `/solve` to every driver and converts the answers into attributable
+/// solutions for the arbitrator.
+pub struct DriverCompetition {
+    drivers: Vec<Arc<Driver>>,
+}
+
+impl DriverCompetition {
+    pub fn new(drivers: Vec<Arc<Driver>>) -> Self {
+        Self { drivers }
+    }
+}
+
+#[async_trait]
+impl SolverCompetition<SolanaCycle> for DriverCompetition {
+    async fn solve(&self, auction: &Auction) -> Vec<Solution> {
+        let request = &dto::SolveRequest {
+            id: auction.id,
+            deadline_slot: auction.tip + SOLVE_DEADLINE_SLOTS,
+            orders: auction.orders.iter().map(dto::Order::from).collect(),
+        };
+        let by_uid: HashMap<IntentHash, &Order> = auction
+            .orders
+            .iter()
+            .map(|order| (order.uid, order))
+            .collect();
+
+        // The deadline sent to the drivers is also enforced here: a response
+        // landing after it is dropped, so one hung driver cannot hold the
+        // loop for the HTTP client's whole ceiling.
+        let budget = SLOT_DURATION * u32::try_from(SOLVE_DEADLINE_SLOTS).expect("small constant");
+        let responses = futures::future::join_all(self.drivers.iter().enumerate().map(
+            |(driver_index, driver)| async move {
+                match tokio::time::timeout(budget, driver.solve(request)).await {
+                    Ok(Ok(response)) => Some((driver_index, driver, response)),
+                    Ok(Err(err)) => {
+                        tracing::warn!(driver = %driver.name, ?err, "solve failed");
+                        None
+                    }
+                    Err(_) => {
+                        tracing::warn!(driver = %driver.name, "solve missed the deadline");
+                        None
+                    }
+                }
+            },
+        ))
+        .await;
+
+        let mut solutions = Vec::new();
+        // `(solver, solution id)` attributes a ranked solution back to its
+        // driver, so a duplicate would misdispatch the settlement: keep the
+        // first and drop the rest.
+        let mut seen = HashSet::new();
+        for (driver_index, driver, response) in responses.into_iter().flatten() {
+            for dto_solution in response.solutions {
+                let duplicate = !seen.insert((dto_solution.solver, dto_solution.solution_id));
+                if duplicate {
+                    tracing::warn!(
+                        driver = %driver.name,
+                        solution_id = dto_solution.solution_id,
+                        "duplicate solver and solution id, dropped"
+                    );
+                    continue;
+                }
+                match convert(driver_index, dto_solution, &by_uid) {
+                    Some(solution) => solutions.push(solution),
+                    None => tracing::warn!(
+                        driver = %driver.name,
+                        "solution names an order outside the auction, dropped"
+                    ),
+                }
+            }
+        }
+        solutions
+    }
+}
+
+/// A wire solution becomes an arbitrator solution by joining each traded
+/// order against the auction for its limits and tokens. A trade naming an
+/// order outside the auction voids the whole solution: its intent cannot be
+/// scored.
+fn convert(
+    driver_index: usize,
+    dto_solution: dto::Solution,
+    by_uid: &HashMap<IntentHash, &Order>,
+) -> Option<Solution> {
+    let orders = dto_solution
+        .orders
+        .iter()
+        .map(|(uid, amounts)| {
+            let order = by_uid.get(uid)?;
+            Some(solution::Order::<Solana> {
+                uid: *uid,
+                sell_token: order.sell_token,
+                buy_token: order.buy_token,
+                sell_amount: order.sell_amount,
+                buy_amount: order.buy_amount,
+                executed_sell: amounts.executed_sell,
+                executed_buy: amounts.executed_buy,
+                side: match order.kind {
+                    OrderKind::Sell => Side::Sell,
+                    OrderKind::Buy => Side::Buy,
+                },
+            })
+        })
+        .collect::<Option<Vec<_>>>()?;
+    Some(Solution {
+        driver_index,
+        inner: solution::Solution::new(dto_solution.solution_id, dto_solution.solver, orders),
+    })
+}

--- a/crates/autopilot-svm/src/infra/competition.rs
+++ b/crates/autopilot-svm/src/infra/competition.rs
@@ -19,12 +19,6 @@ use {
     winner_selection::{Side, solution},
 };
 
-/// Slots between the tip a solve request is stamped at and its deadline,
-/// the driver's whole thinking budget (~6s at 400ms slots, the EVM fast
-/// chains run 6s solve deadlines).
-/// TODO: make configurable.
-const SOLVE_DEADLINE_SLOTS: u64 = 15;
-
 /// Solana's target slot time.
 const SLOT_DURATION: Duration = Duration::from_millis(400);
 
@@ -32,11 +26,16 @@ const SLOT_DURATION: Duration = Duration::from_millis(400);
 /// solutions for the arbitrator.
 pub struct DriverCompetition {
     drivers: Vec<Arc<Driver>>,
+    /// How long a driver gets to answer `/solve`.
+    solve_deadline: Duration,
 }
 
 impl DriverCompetition {
-    pub fn new(drivers: Vec<Arc<Driver>>) -> Self {
-        Self { drivers }
+    pub fn new(drivers: Vec<Arc<Driver>>, solve_deadline: Duration) -> Self {
+        Self {
+            drivers,
+            solve_deadline,
+        }
     }
 }
 
@@ -45,7 +44,10 @@ impl SolverCompetition<SolanaCycle> for DriverCompetition {
     async fn solve(&self, auction: &Auction) -> Vec<Solution> {
         let request = &dto::SolveRequest {
             id: auction.id,
-            deadline_slot: auction.tip + SOLVE_DEADLINE_SLOTS,
+            // The wire carries the deadline as a slot, so the wall-clock
+            // budget converts at the target slot time.
+            deadline_slot: auction.tip
+                + (self.solve_deadline.as_millis() / SLOT_DURATION.as_millis()) as u64,
             orders: auction.orders.iter().map(dto::Order::from).collect(),
         };
         let by_uid: HashMap<IntentHash, &Order> = auction
@@ -57,7 +59,7 @@ impl SolverCompetition<SolanaCycle> for DriverCompetition {
         // The deadline sent to the drivers is also enforced here: a response
         // landing after it is dropped, so one hung driver cannot hold the
         // loop for the HTTP client's whole ceiling.
-        let budget = SLOT_DURATION * u32::try_from(SOLVE_DEADLINE_SLOTS).expect("small constant");
+        let budget = self.solve_deadline;
         let responses = futures::future::join_all(self.drivers.iter().enumerate().map(
             |(driver_index, driver)| async move {
                 match tokio::time::timeout(budget, driver.solve(request)).await {

--- a/crates/autopilot-svm/src/infra/db.rs
+++ b/crates/autopilot-svm/src/infra/db.rs
@@ -102,10 +102,10 @@ ORDER BY slot, tx_signature
         .context("read solana.settlements by auction")
 }
 
-/// Cut an auction at the given tip from the open orders.
-pub async fn cut(ex: impl PgExecutor<'_>, id: i64, tip: u64, now_unix: i64) -> Result<Auction> {
+/// Cut an auction from the open orders.
+pub async fn cut(ex: impl PgExecutor<'_>, id: i64, now_unix: i64) -> Result<Auction> {
     let orders = orders_from_rows(open_orders(ex, now_unix).await?);
-    Ok(Auction { id, tip, orders })
+    Ok(Auction { id, orders })
 }
 
 /// A row the indexer wrote always converts (on-chain values fit the domain

--- a/crates/autopilot-svm/src/infra/db.rs
+++ b/crates/autopilot-svm/src/infra/db.rs
@@ -102,10 +102,10 @@ ORDER BY slot, tx_signature
         .context("read solana.settlements by auction")
 }
 
-/// Cut an auction from the orders currently open for solving.
-pub async fn cut(ex: impl PgExecutor<'_>, id: i64, now_unix: i64) -> Result<Auction> {
+/// Cut an auction at the given tip from the open orders.
+pub async fn cut(ex: impl PgExecutor<'_>, id: i64, tip: u64, now_unix: i64) -> Result<Auction> {
     let orders = orders_from_rows(open_orders(ex, now_unix).await?);
-    Ok(Auction { id, orders })
+    Ok(Auction { id, tip, orders })
 }
 
 /// A row the indexer wrote always converts (on-chain values fit the domain

--- a/crates/autopilot-svm/src/infra/driver/dto.rs
+++ b/crates/autopilot-svm/src/infra/driver/dto.rs
@@ -19,8 +19,8 @@ use {
 pub struct SolveRequest {
     /// Autopilot-assigned auction id.
     pub id: i64,
-    /// Slot after which a settlement for this auction is late.
-    pub deadline_slot: u64,
+    /// Wall-clock deadline for answering `/solve`.
+    pub deadline: chrono::DateTime<chrono::Utc>,
     pub orders: Vec<Order>,
 }
 
@@ -125,6 +125,8 @@ pub struct TradedAmounts {
 pub struct SettleRequest {
     pub auction_id: i64,
     pub solution_id: u64,
+    /// The last slot the settlement transaction may land in.
+    pub submission_deadline_slot: u64,
 }
 
 /// The driver's `/settle` answer.
@@ -165,11 +167,11 @@ mod tests {
     fn dtos_round_trip_and_pin_the_wire_format() {
         let request = SolveRequest {
             id: 7,
-            deadline_slot: 100,
+            deadline: "2026-01-01T00:00:00Z".parse().unwrap(),
             orders: vec![Order::from(&order())],
         };
         let json = serde_json::to_value(&request).unwrap();
-        assert_eq!(json["deadlineSlot"], 100);
+        assert_eq!(json["deadline"], "2026-01-01T00:00:00Z");
         assert_eq!(
             json["orders"][0]["uid"],
             "0x1111111111111111111111111111111111111111111111111111111111111111"
@@ -216,6 +218,18 @@ mod tests {
         assert_eq!(
             serde_json::from_value::<SettleResponse>(json).unwrap(),
             settle
+        );
+
+        let settle_request = SettleRequest {
+            auction_id: 7,
+            solution_id: 3,
+            submission_deadline_slot: 125,
+        };
+        let json = serde_json::to_value(&settle_request).unwrap();
+        assert_eq!(json["submissionDeadlineSlot"], 125);
+        assert_eq!(
+            serde_json::from_value::<SettleRequest>(json).unwrap(),
+            settle_request
         );
     }
 }

--- a/crates/autopilot-svm/src/infra/driver/mod.rs
+++ b/crates/autopilot-svm/src/infra/driver/mod.rs
@@ -1,7 +1,5 @@
 //! HTTP client for the Solana driver.
 
-#![expect(dead_code, reason = "consumed by the auction loop wiring")]
-
 pub mod dto;
 
 use {

--- a/crates/autopilot-svm/src/infra/executor.rs
+++ b/crates/autopilot-svm/src/infra/executor.rs
@@ -47,6 +47,7 @@ impl SettlementExecutor<SolanaCycle> for DriverExecutor {
             let request = dto::SettleRequest {
                 auction_id,
                 solution_id: winner.id(),
+                submission_deadline_slot: deadline,
             };
             tokio::spawn(async move {
                 match driver.settle(&request).await {

--- a/crates/autopilot-svm/src/infra/executor.rs
+++ b/crates/autopilot-svm/src/infra/executor.rs
@@ -1,0 +1,70 @@
+//! Dispatches winning solutions back to their drivers for settlement.
+
+use {
+    crate::{
+        domain::cycle::{Ranking, SolanaCycle},
+        infra::driver::{Driver, dto},
+        run_loop::SettlementExecutor,
+    },
+    async_trait::async_trait,
+    std::sync::Arc,
+};
+
+/// Slots a settlement may take after ranking before it counts as late.
+/// TODO: make configurable.
+const SUBMISSION_DEADLINE_SLOTS: u64 = 25;
+
+/// Sends `/settle` to each winner's driver. Submission runs detached, the
+/// loop starts the next cycle while settlements land.
+pub struct DriverExecutor {
+    drivers: Vec<Arc<Driver>>,
+}
+
+impl DriverExecutor {
+    pub fn new(drivers: Vec<Arc<Driver>>) -> Self {
+        Self { drivers }
+    }
+}
+
+#[async_trait]
+impl SettlementExecutor<SolanaCycle> for DriverExecutor {
+    fn submission_deadline(&self, tip: &u64) -> u64 {
+        tip + SUBMISSION_DEADLINE_SLOTS
+    }
+
+    async fn execute(&self, auction_id: i64, ranking: &Ranking, deadline: u64) {
+        for winner in ranking.inner.winners() {
+            let key = (winner.solver(), winner.id());
+            let Some(driver) = ranking
+                .drivers
+                .get(&key)
+                .and_then(|&index| self.drivers.get(index))
+            else {
+                tracing::error!(solution_id = winner.id(), "winner without a driver");
+                continue;
+            };
+            let driver = Arc::clone(driver);
+            let request = dto::SettleRequest {
+                auction_id,
+                solution_id: winner.id(),
+            };
+            tokio::spawn(async move {
+                match driver.settle(&request).await {
+                    Ok(response) => tracing::info!(
+                        driver = %driver.name,
+                        auction_id,
+                        deadline,
+                        tx_signature = %response.tx_signature,
+                        "settlement submitted"
+                    ),
+                    Err(err) => tracing::error!(
+                        driver = %driver.name,
+                        auction_id,
+                        ?err,
+                        "settlement failed"
+                    ),
+                }
+            });
+        }
+    }
+}

--- a/crates/autopilot-svm/src/infra/mod.rs
+++ b/crates/autopilot-svm/src/infra/mod.rs
@@ -1,5 +1,10 @@
-//! Infrastructure: database reads and the Postgres LISTEN session.
+//! Infrastructure: database access, driver clients, and the loop seams.
 
+pub mod competition;
 pub mod db;
 pub mod driver;
+pub mod executor;
 pub mod listen;
+pub mod observer;
+pub mod provider;
+pub mod trigger;

--- a/crates/autopilot-svm/src/infra/observer.rs
+++ b/crates/autopilot-svm/src/infra/observer.rs
@@ -1,0 +1,60 @@
+//! Competition bookkeeping. Everything is logged only: there are no
+//! competition tables (auction snapshots, proposed executions, order
+//! events) to write.
+//!
+//! TODO: persist the competition outcome once the tables exist. The
+//! settlement attribution (`solana.settlements.solution_uid`) depends on
+//! the persisted ranking.
+
+use {
+    crate::{
+        domain::{auction::Auction, cycle::Ranking},
+        run_loop::SettlementObserver,
+    },
+    async_trait::async_trait,
+    chain_types::solana::IntentHash,
+    std::collections::HashSet,
+};
+
+pub struct LogObserver;
+
+#[async_trait]
+impl SettlementObserver<crate::domain::cycle::SolanaCycle> for LogObserver {
+    fn on_orders_ready(&self, auction: &Auction) {
+        tracing::debug!(orders = auction.orders.len(), "auction entered competition");
+    }
+
+    async fn persist_competition_ranking(
+        &self,
+        _auction: &Auction,
+        tip: &u64,
+        ranking: &Ranking,
+        deadline: u64,
+    ) -> anyhow::Result<()> {
+        tracing::info!(
+            tip,
+            deadline,
+            winners = ranking.inner.winners().count(),
+            ranked = ranking.inner.ranked.len(),
+            filtered_out = ranking.inner.filtered_out.len(),
+            "competition ranked"
+        );
+        Ok(())
+    }
+
+    fn on_orders_matched(&self, executing: HashSet<IntentHash>, considered: HashSet<IntentHash>) {
+        tracing::debug!(
+            executing = executing.len(),
+            considered = considered.len(),
+            "orders matched"
+        );
+    }
+
+    fn on_competition_ended(&self, auction: &Auction, ranking: &Ranking) {
+        tracing::debug!(
+            auction_id = auction.id,
+            winners = ranking.inner.winners().count(),
+            "competition ended"
+        );
+    }
+}

--- a/crates/autopilot-svm/src/infra/provider.rs
+++ b/crates/autopilot-svm/src/infra/provider.rs
@@ -1,0 +1,70 @@
+//! Auction provider backed by the indexer-written tables.
+
+use {
+    crate::{domain::cycle::SolanaCycle, infra::db, run_loop::AuctionProvider},
+    async_trait::async_trait,
+    sqlx::PgPool,
+    std::{
+        sync::atomic::{AtomicI64, Ordering},
+        time::{SystemTime, UNIX_EPOCH},
+    },
+};
+
+/// Cuts auctions from the open orders the indexer persisted.
+pub struct DbAuctionProvider {
+    pool: PgPool,
+    /// Last allocated auction id. Ids are unix seconds, bumped past the
+    /// previous allocation when cycles land within the same second. Unique
+    /// only per process: no table allocates auction ids.
+    /// TODO: allocate from the auctions table sequence once competition
+    /// persistence lands, like the EVM `auctions.id` bigserial.
+    last_id: AtomicI64,
+}
+
+impl DbAuctionProvider {
+    pub fn new(pool: PgPool) -> Self {
+        Self {
+            pool,
+            last_id: AtomicI64::new(0),
+        }
+    }
+
+    /// Allocates the next auction id: the current unix second, or one past
+    /// the previous id when several cycles land within the same second, so
+    /// ids strictly increase within the process.
+    fn next_id(&self, now: i64) -> i64 {
+        let prev = self
+            .last_id
+            .update(Ordering::Relaxed, Ordering::Relaxed, |prev| {
+                now.max(prev + 1)
+            });
+        now.max(prev + 1)
+    }
+}
+
+fn now_unix() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock after the unix epoch")
+        .as_secs()
+        .try_into()
+        .expect("unix seconds fit i64")
+}
+
+#[async_trait]
+impl AuctionProvider<SolanaCycle> for DbAuctionProvider {
+    /// The order data is push-fed by the indexer, there is no cache to
+    /// refresh.
+    async fn sync_to_tip(&self, _tip: &u64) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    async fn cut_auction(&self, tip: &u64) -> Option<crate::domain::auction::Auction> {
+        let now = now_unix();
+        let auction = db::cut(&self.pool, self.next_id(now), *tip, now)
+            .await
+            .map_err(|err| tracing::warn!(?err, "failed to cut the auction"))
+            .ok()?;
+        (!auction.orders.is_empty()).then_some(auction)
+    }
+}

--- a/crates/autopilot-svm/src/infra/provider.rs
+++ b/crates/autopilot-svm/src/infra/provider.rs
@@ -59,9 +59,9 @@ impl AuctionProvider<SolanaCycle> for DbAuctionProvider {
         Ok(())
     }
 
-    async fn cut_auction(&self, tip: &u64) -> Option<crate::domain::auction::Auction> {
+    async fn cut_auction(&self, _tip: &u64) -> Option<crate::domain::auction::Auction> {
         let now = now_unix();
-        let auction = db::cut(&self.pool, self.next_id(now), *tip, now)
+        let auction = db::cut(&self.pool, self.next_id(now), now)
             .await
             .map_err(|err| tracing::warn!(?err, "failed to cut the auction"))
             .ok()?;

--- a/crates/autopilot-svm/src/infra/trigger.rs
+++ b/crates/autopilot-svm/src/infra/trigger.rs
@@ -1,0 +1,54 @@
+//! Chain-driven cycle trigger: wakes the loop once per new slot.
+
+use {
+    crate::{domain::cycle::SolanaCycle, run_loop::CycleTrigger},
+    async_trait::async_trait,
+    cow_solana_rpc::SolanaRPC,
+    std::{
+        sync::atomic::{AtomicU64, Ordering},
+        time::Duration,
+    },
+};
+
+/// How often the trigger asks the node for the current slot. Half a slot, so
+/// a new slot is typically observed within one poll of its arrival.
+const POLL_INTERVAL: Duration = Duration::from_millis(200);
+
+/// Polls the node for the slot and yields each newly observed one.
+pub struct SlotTrigger {
+    rpc: SolanaRPC,
+    tip: AtomicU64,
+}
+
+impl SlotTrigger {
+    pub fn new(rpc: SolanaRPC) -> Self {
+        Self {
+            rpc,
+            tip: AtomicU64::new(0),
+        }
+    }
+}
+
+#[async_trait]
+impl CycleTrigger<SolanaCycle> for SlotTrigger {
+    async fn next_cycle(&mut self) -> u64 {
+        loop {
+            match self.rpc.slot().await {
+                Ok(slot) => {
+                    let previous = self.tip.fetch_max(slot, Ordering::Relaxed);
+                    if slot > previous {
+                        return slot;
+                    }
+                }
+                Err(err) => tracing::warn!(?err, "failed to poll the slot"),
+            }
+            tokio::time::sleep(POLL_INTERVAL).await;
+        }
+    }
+
+    // TODO: poll in the background so the tip observed after ranking is
+    // fresher than the cut tip once the submission deadline is enforced.
+    fn current_tip(&self) -> u64 {
+        self.tip.load(Ordering::Relaxed)
+    }
+}

--- a/crates/autopilot-svm/src/lib.rs
+++ b/crates/autopilot-svm/src/lib.rs
@@ -1,8 +1,11 @@
 //! Solana-side autopilot components built on a chain-generic auction loop.
 
-#![expect(dead_code, reason = "consumed by the auction loop wiring")]
+#![expect(dead_code, reason = "consumed by the binary wiring")]
 
 pub mod run_loop;
 
 mod domain;
 mod infra;
+
+#[cfg(test)]
+mod tests;

--- a/crates/autopilot-svm/src/tests.rs
+++ b/crates/autopilot-svm/src/tests.rs
@@ -1,0 +1,182 @@
+//! The BE-184 checkpoint: one full auction cycle through [`AuctionLoop`]
+//! against the real database and a mocked driver.
+
+use {
+    crate::{
+        domain::{arbitrator::SolanaArbitrator, cycle::SolanaCycle},
+        infra::{
+            competition::DriverCompetition,
+            driver::{Driver, dto},
+            executor::DriverExecutor,
+            observer::LogObserver,
+            provider::DbAuctionProvider,
+        },
+        run_loop::{
+            AuctionLoop,
+            AuctionProvider,
+            CycleTrigger,
+            RankingInfo,
+            SolverCompetition,
+            WinnerSelection,
+        },
+    },
+    async_trait::async_trait,
+    axum::{Json, Router, extract::State, routing::post},
+    chain_types::solana::{IntentHash, Pubkey, Signature},
+    database::byte_array::ByteArray,
+    sqlx::PgPool,
+    std::{collections::HashMap, net::SocketAddr, sync::Arc},
+    tokio::sync::mpsc,
+    url::Url,
+};
+
+/// A trigger pinned to one slot: the test drives exactly one cycle.
+struct FixedTrigger(u64);
+
+#[async_trait]
+impl CycleTrigger<SolanaCycle> for FixedTrigger {
+    async fn next_cycle(&mut self) -> u64 {
+        self.0
+    }
+
+    fn current_tip(&self) -> u64 {
+        self.0
+    }
+}
+
+#[derive(Clone)]
+struct MockDriverState {
+    solution: dto::Solution,
+    settles: mpsc::UnboundedSender<dto::SettleRequest>,
+}
+
+async fn handle_solve(State(state): State<MockDriverState>) -> Json<serde_json::Value> {
+    Json(
+        serde_json::to_value(&dto::SolveResponse {
+            solutions: vec![state.solution.clone()],
+        })
+        .unwrap(),
+    )
+}
+
+async fn handle_settle(
+    State(state): State<MockDriverState>,
+    Json(request): Json<dto::SettleRequest>,
+) -> Json<serde_json::Value> {
+    state.settles.send(request).unwrap();
+    Json(
+        serde_json::to_value(&dto::SettleResponse {
+            tx_signature: Signature([9; 64]),
+        })
+        .unwrap(),
+    )
+}
+
+/// Serves `/solve` with one canned solution and records every `/settle`.
+async fn spawn_mock_driver(state: MockDriverState) -> SocketAddr {
+    let app = Router::new()
+        .route("/solve", post(handle_solve))
+        .route("/settle", post(handle_settle))
+        .with_state(state);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    addr
+}
+
+async fn seed_open_order(pool: &PgPool, uid: [u8; 32], tip: i64) {
+    sqlx::query(
+        "TRUNCATE solana.trades, solana.settlements, solana.order_pda, solana.orders, \
+         solana.indexer_state",
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query("INSERT INTO solana.indexer_state (slot) VALUES ($1)")
+        .bind(tip)
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query(
+        r#"
+INSERT INTO solana.orders (uid, owner, sell_token, buy_token, sell_token_account,
+    buy_token_account, sell_amount, buy_amount, valid_to, kind,
+    partially_fillable, app_data, creation_timestamp, order_pda)
+VALUES ($1, $2, $2, $3, $2, $2, 1000, 500, $4, 'sell'::OrderKind, false, $2, now(), $5)
+        "#,
+    )
+    .bind(uid)
+    .bind(ByteArray([0xAA; 32]))
+    .bind(ByteArray([0xAB; 32]))
+    .bind(i64::from(u32::MAX))
+    .bind(ByteArray([0xB0; 32]))
+    .execute(pool)
+    .await
+    .unwrap();
+    sqlx::query("INSERT INTO solana.order_pda (order_uid, created_by) VALUES ($1, $2)")
+        .bind(uid)
+        .bind(ByteArray([0xAA; 32]))
+        .execute(pool)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+#[ignore = "needs the solana.* schema applied to the local database"]
+async fn solana_db_mock_cycle_dispatches_the_settlement() {
+    let pool = PgPool::connect("postgresql://").await.unwrap();
+    let uid = [0x11; 32];
+    let tip = 500_u64;
+    seed_open_order(&pool, uid, i64::try_from(tip).unwrap()).await;
+
+    // Selling 1000 for at least 500 and receiving 600 clears the limit, so
+    // the solution scores its 100 surplus and wins.
+    let solution = dto::Solution {
+        solution_id: 7,
+        score: 100,
+        solver: Pubkey([0xCC; 32]),
+        orders: HashMap::from([(
+            IntentHash(uid),
+            dto::TradedAmounts {
+                executed_sell: 1000,
+                executed_buy: 600,
+            },
+        )]),
+    };
+    let wrapped_native = Pubkey([0xFE; 32]);
+    let (settles, mut settled) = mpsc::unbounded_channel();
+    let addr = spawn_mock_driver(MockDriverState { solution, settles }).await;
+    let driver = Arc::new(Driver::new(
+        "mock".to_string(),
+        &Url::parse(&format!("http://{addr}")).unwrap(),
+    ));
+
+    // Stage probes: pinpoint the failing phase before driving the loop.
+    {
+        let provider = DbAuctionProvider::new(pool.clone());
+        let auction = provider.cut_auction(&tip).await.expect("auction cut");
+        assert_eq!(auction.orders.len(), 1, "open order in the auction");
+        let competition = DriverCompetition::new(vec![Arc::clone(&driver)]);
+        let solutions = competition.solve(&auction).await;
+        assert_eq!(solutions.len(), 1, "driver solution converted");
+        let ranking = SolanaArbitrator::new(1, wrapped_native).arbitrate(solutions, &auction);
+        assert_eq!(ranking.winner_count(), 1, "solution won");
+    }
+
+    let mut auction_loop = AuctionLoop::new(
+        Box::new(FixedTrigger(tip)),
+        Box::new(DbAuctionProvider::new(pool)),
+        Box::new(DriverCompetition::new(vec![Arc::clone(&driver)])),
+        Box::new(SolanaArbitrator::new(1, wrapped_native)),
+        Box::new(DriverExecutor::new(vec![driver])),
+        Box::new(LogObserver),
+    );
+    auction_loop.run_cycle().await;
+
+    let settle = tokio::time::timeout(std::time::Duration::from_secs(5), settled.recv())
+        .await
+        .expect("settlement dispatched before the timeout")
+        .expect("settle channel open");
+    assert_eq!(settle.solution_id, 7);
+    assert!(settle.auction_id > 0);
+}

--- a/crates/autopilot-svm/src/tests.rs
+++ b/crates/autopilot-svm/src/tests.rs
@@ -25,7 +25,7 @@ use {
     chain_types::solana::{IntentHash, Pubkey, Signature},
     database::byte_array::ByteArray,
     sqlx::PgPool,
-    std::{collections::HashMap, net::SocketAddr, sync::Arc},
+    std::{collections::HashMap, net::SocketAddr, sync::Arc, time::Duration},
     tokio::sync::mpsc,
     url::Url,
 };
@@ -156,7 +156,7 @@ async fn solana_db_mock_cycle_dispatches_the_settlement() {
         let provider = DbAuctionProvider::new(pool.clone());
         let auction = provider.cut_auction(&tip).await.expect("auction cut");
         assert_eq!(auction.orders.len(), 1, "open order in the auction");
-        let competition = DriverCompetition::new(vec![Arc::clone(&driver)]);
+        let competition = DriverCompetition::new(vec![Arc::clone(&driver)], Duration::from_secs(6));
         let solutions = competition.solve(&auction).await;
         assert_eq!(solutions.len(), 1, "driver solution converted");
         let ranking = SolanaArbitrator::new(1, wrapped_native).arbitrate(solutions, &auction);
@@ -166,14 +166,17 @@ async fn solana_db_mock_cycle_dispatches_the_settlement() {
     let mut auction_loop = AuctionLoop::new(
         Box::new(FixedTrigger(tip)),
         Box::new(DbAuctionProvider::new(pool)),
-        Box::new(DriverCompetition::new(vec![Arc::clone(&driver)])),
+        Box::new(DriverCompetition::new(
+            vec![Arc::clone(&driver)],
+            Duration::from_secs(6),
+        )),
         Box::new(SolanaArbitrator::new(1, wrapped_native)),
         Box::new(DriverExecutor::new(vec![driver])),
         Box::new(LogObserver),
     );
     auction_loop.run_cycle().await;
 
-    let settle = tokio::time::timeout(std::time::Duration::from_secs(5), settled.recv())
+    let settle = tokio::time::timeout(Duration::from_secs(5), settled.recv())
         .await
         .expect("settlement dispatched before the timeout")
         .expect("settle channel open");

--- a/crates/cow-solana-rpc/Cargo.toml
+++ b/crates/cow-solana-rpc/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/lib.rs"
 [dependencies]
 solana-commitment-config = { workspace = true }
 solana-rpc-client = { workspace = true }
+solana-rpc-client-api = { workspace = true }
 url = { workspace = true }
 
 [features]

--- a/crates/cow-solana-rpc/src/lib.rs
+++ b/crates/cow-solana-rpc/src/lib.rs
@@ -1,12 +1,9 @@
 //! Solana JSON-RPC client wrapper.
 
-pub use solana_commitment_config::CommitmentConfig;
+pub use {solana_commitment_config::CommitmentConfig, solana_rpc_client_api::client_error::Error};
 use {solana_rpc_client::nonblocking::rpc_client::RpcClient, std::time::Duration, url::Url};
 
 pub struct SolanaRPC {
-    /// Not yet read: helper methods that use the underlying client will be
-    /// added in follow-up PRs.
-    #[expect(dead_code)]
     inner: RpcClient,
 }
 
@@ -34,5 +31,10 @@ impl SolanaRPC {
         Self {
             inner: RpcClient::new_mock(url),
         }
+    }
+
+    /// The node's current slot at the client's commitment level.
+    pub async fn slot(&self) -> Result<u64, Error> {
+        self.inner.get_slot().await
     }
 }


### PR DESCRIPTION
# Description
The chain-generic loop from #4709 gets its Solana implementations, and the whole thing runs one real cycle end to end: wake on a new slot, cut the auction from the indexer-written tables, fan it out to the drivers, rank with the generic arbitrator (`winner-selection` instantiated with `chain_types::Solana`, max_winners = 1), and dispatch `/settle` to the winner's driver.

Two deviations from the Linear issue text worth noting here explicitly:

- The trigger is chain-driven (slot polling via `cow-solana-rpc`, which gains its first helper, `slot()`), not a `solana_new_order` NOTIFY. On a 400ms-slot chain the next tip wake is at most half a second away, so an order notify buys nothing, and the auction dedupe already suppresses no-change cycles.
- The arbitrator prices every auction token at the native denominator (1:1 to lamports), so scores compare raw surplus. Native price estimation does not exist yet. Ranking within one token pair is exact, comparisons across pairs are not, which covers the demo.

Known demo-scope stubs, each marked in code: the observer only logs (no competition tables exist), auction ids are process-local unix seconds (no auctions table), solve/submission deadlines are consts until the config PR, and the tip observed after ranking equals the cut tip (the trigger only polls inside `next_cycle`), which stays inert while the submission deadline is only logged.

# Changes
- `domain/cycle.rs` binds the loop vocabulary: tip = slot, uid = intent hash, plus driver attribution that survives ranking (`(solver, solution id)` back to the driver index)
- `domain/arbitrator.rs` runs the generic fair-combinatorial arbitrator, marking auction orders via empty fee-policy entries
- `infra/trigger.rs` polls the slot and wakes the loop once per new one
- `infra/provider.rs` cuts auctions from `solana.orders` (the freshness check against the indexer watermark waits for BE-203, today the watermark stalls between settlements and would false-alarm)
- `infra/competition.rs` fans `/solve` out to all drivers and joins wire solutions against the auction for limits and sides
- The solve deadline is enforced on the fan-out, a driver answering past it is dropped for the cycle
- `infra/executor.rs` dispatches `/settle` to each winner's driver, detached
- Duplicate `(solver, solution id)` pairs are dropped before ranking, a collision would misdispatch the settlement
- The auction carries the slot it was cut at, excluded from the dedupe equality like the id

# How to test
New DB-backed mock-cycle test (the BE-184 checkpoint): a seeded open order, a canned axum driver, one `run_cycle`, and the `/settle` request asserted, plus stage asserts that localize a failure to cut, solve, or ranking.