### PR TITLE
allow orders with zero score

### DIFF
--- a/crates/winner-selection/src/arbitrator.rs
+++ b/crates/winner-selection/src/arbitrator.rs
@@ -70,8 +70,15 @@ impl<C: ChainTypes> Arbitrator<C> {
         let (mut solutions, scores_by_solution) =
             self.compute_scores_by_solution(solutions, context);
 
-        // Discard any solutions with a score of 0 as they are invalid
-        solutions.retain(|solution| !solution.score().is_zero());
+        // only keep solutions that settle at least 1 order that the mechanism "cares about"
+        solutions.retain(|solution| {
+            solution
+                .orders()
+                .iter()
+                .filter(|order| context.contributes_to_score(&order.uid))
+                .count()
+                > 0
+        });
 
         // Sort by score descending
         solutions.sort_by_key(|solution| Reverse(solution.score()));

--- a/crates/winner-selection/src/arbitrator.rs
+++ b/crates/winner-selection/src/arbitrator.rs
@@ -70,7 +70,8 @@ impl<C: ChainTypes> Arbitrator<C> {
         let (mut solutions, scores_by_solution) =
             self.compute_scores_by_solution(solutions, context);
 
-        // only keep solutions that settle at least 1 order that the mechanism "cares about"
+        // only keep solutions that settle at least 1 order that the mechanism "cares
+        // about"
         solutions.retain(|solution| {
             solution
                 .orders()

--- a/crates/winner-selection/src/arbitrator.rs
+++ b/crates/winner-selection/src/arbitrator.rs
@@ -76,9 +76,7 @@ impl<C: ChainTypes> Arbitrator<C> {
             solution
                 .orders()
                 .iter()
-                .filter(|order| context.contributes_to_score(&order.uid))
-                .count()
-                > 0
+                .any(|order| context.contributes_to_score(&order.uid))
         });
 
         // Sort by score descending

--- a/crates/winner-selection/src/tests.rs
+++ b/crates/winner-selection/src/tests.rs
@@ -261,6 +261,42 @@ fn evm_surplus_fee_policy_doubles_score() {
     assert_eq!(ranking.ranked[0].score(), U256::from(10u64));
 }
 
+/// A solution that only settles a scoring order at exactly the limit price
+/// scores zero, but is still retained (and wins if unopposed) because it
+/// contributes to score. Previously the arbitrator dropped any zero-score
+/// solution outright.
+#[test]
+fn zero_score_solution_is_kept_when_it_settles_a_scoring_order() {
+    let uid = evm_uid(1, 0xaa);
+    let (token_a, token_b) = (Address::repeat_byte(1), Address::repeat_byte(2));
+    let solver = Address::repeat_byte(3);
+    let context = AuctionContext::<Evm> {
+        fee_policies: HashMap::from([(uid, vec![])]),
+        native_prices: HashMap::from([(token_b, U256::from(EVM_UNIT_PRICE))]),
+        ..Default::default()
+    };
+    // `sell_order` uses sell_amount=100, buy_amount=90; executing at 90
+    // hits the limit exactly and yields zero surplus.
+    let solutions = vec![Solution::new(
+        1,
+        solver,
+        vec![sell_order::<Evm>(uid, token_a, token_b, 90, U256::from)],
+    )];
+    let arbitrator = Arbitrator::<Evm> {
+        max_winners: 1,
+        wrapped_native: Address::repeat_byte(0xff),
+    };
+
+    let ranking = arbitrator.arbitrate(solutions, &context);
+
+    assert_eq!(
+        ranking.winners().map(|s| s.id()).collect::<Vec<_>>(),
+        vec![1]
+    );
+    assert_eq!(ranking.ranked[0].score(), U256::from(0u64));
+    assert!(ranking.filtered_out.is_empty());
+}
+
 /// JIT attribution diverges by design: the EVM UID embeds the owner, the
 /// Solana intent hash does not, so a JIT-owner order scores on EVM and the
 /// equivalent solution dies scoreless on Solana.

--- a/crates/winner-selection/src/tests.rs
+++ b/crates/winner-selection/src/tests.rs
@@ -263,8 +263,7 @@ fn evm_surplus_fee_policy_doubles_score() {
 
 /// A solution that only settles a scoring order at exactly the limit price
 /// scores zero, but is still retained (and wins if unopposed) because it
-/// contributes to score. Previously the arbitrator dropped any zero-score
-/// solution outright.
+/// contributes to score.
 #[test]
 fn zero_score_solution_is_kept_when_it_settles_a_scoring_order() {
     let uid = evm_uid(1, 0xaa);


### PR DESCRIPTION
# Description
There are some tokens with 0 decimals which means that even 1 wei is non-trivial money. For those orders it's often not possible to actually provide surplus due to rounding.
However, those orders should still be tradeable.

# Changes
Instead of requiring that a solution has a positive (non-zero) score we now only require that the solution contains at least 1 order the protocol "cares about". Those are orders that contribute to the score (e.g. user orders, JIT orders that are allowed to capture surplus).

## How to test
added a unit test that fails on `main` and passes with the PR changes.
