### PR TITLE
feat(solana-orderbook) PR01: crate skeleton with config and HTTP server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10153,6 +10153,7 @@ dependencies = [
 name = "solana-orderbook"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "axum",
  "clap",
  "configs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10150,6 +10150,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-orderbook"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "clap",
+ "configs",
+ "futures",
+ "observe",
+ "reqwest 0.13.4",
+ "serde",
+ "sqlx",
+ "tikv-jemallocator",
+ "tokio",
+ "tokio-util",
+ "toml",
+ "tower 0.5.3",
+ "tower-http",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "solana-packet"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/configs/src/lib.rs
+++ b/crates/configs/src/lib.rs
@@ -5,6 +5,7 @@ pub mod deserialize_env;
 pub mod fee_factor;
 pub mod gas_price_estimation;
 pub mod http_client;
+pub mod loader;
 pub mod native_price;
 pub mod native_price_estimators;
 pub mod order_quoting;

--- a/crates/configs/src/loader.rs
+++ b/crates/configs/src/loader.rs
@@ -1,0 +1,27 @@
+//! Loading TOML configuration files into typed configs.
+
+use {serde::de::DeserializeOwned, std::path::Path, tokio::fs};
+
+/// Load a TOML configuration file into its typed form.
+///
+/// # Panics
+///
+/// Panics if the file cannot be read or does not parse into `C`. The parse
+/// error itself is only printed with `TOML_TRACE_ERROR=1`, it may leak
+/// secrets.
+pub async fn load_toml<C: DeserializeOwned>(path: &Path) -> C {
+    let data = fs::read_to_string(path)
+        .await
+        .unwrap_or_else(|e| panic!("I/O error while reading {path:?}: {e:?}"));
+
+    toml::de::from_str(&data).unwrap_or_else(|err| {
+        if std::env::var("TOML_TRACE_ERROR").is_ok_and(|v| v == "1") {
+            panic!("failed to parse TOML config at {path:?}: {err:#?}")
+        } else {
+            panic!(
+                "failed to parse TOML config at: {path:?}. Set TOML_TRACE_ERROR=1 to print \
+                 parsing error but this may leak secrets."
+            )
+        }
+    })
+}

--- a/crates/solana-orderbook/Cargo.toml
+++ b/crates/solana-orderbook/Cargo.toml
@@ -16,6 +16,7 @@ name = "solana-orderbook"
 path = "src/main.rs"
 
 [dependencies]
+async-trait = { workspace = true }
 axum = { workspace = true }
 clap = { workspace = true }
 configs = { workspace = true }
@@ -28,7 +29,7 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal"] }
 tokio-util = { workspace = true }
 toml = { workspace = true }
 tower = { workspace = true }
-tower-http = { workspace = true, features = ["decompression-br", "trace"] }
+tower-http = { workspace = true, features = ["cors", "decompression-br", "trace"] }
 tracing = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 

--- a/crates/solana-orderbook/Cargo.toml
+++ b/crates/solana-orderbook/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "solana-orderbook"
+version = "0.1.0"
+authors = ["Cow Protocol Developers <dev@cow.fi>"]
+edition = "2024"
+license = "GPL-3.0-or-later"
+description = "Solana orderbook API for CoW Protocol"
+repository = "https://github.com/cowprotocol/services"
+
+[lib]
+name = "solana_orderbook"
+path = "src/lib.rs"
+
+[[bin]]
+name = "solana-orderbook"
+path = "src/main.rs"
+
+[dependencies]
+axum = { workspace = true }
+clap = { workspace = true }
+configs = { workspace = true }
+futures = { workspace = true }
+observe = { workspace = true }
+serde = { workspace = true }
+sqlx = { workspace = true }
+tikv-jemallocator = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "signal"] }
+tokio-util = { workspace = true }
+toml = { workspace = true }
+tower = { workspace = true }
+tower-http = { workspace = true, features = ["decompression-br", "trace"] }
+tracing = { workspace = true }
+url = { workspace = true, features = ["serde"] }
+
+[dev-dependencies]
+reqwest = { workspace = true, features = ["json"] }
+
+[features]
+default = []
+
+[lints]
+workspace = true

--- a/crates/solana-orderbook/example.toml
+++ b/crates/solana-orderbook/example.toml
@@ -1,0 +1,12 @@
+# Example configuration for the Solana orderbook.
+
+# The Postgres database the indexer writes to.
+db-url = "postgresql://"
+
+[http]
+bind-address = "0.0.0.0:8080"
+
+[logging]
+filter = "info,solana_orderbook=debug"
+# stderr-threshold = "warn"
+# use-json = false

--- a/crates/solana-orderbook/example.toml
+++ b/crates/solana-orderbook/example.toml
@@ -1,7 +1,10 @@
 # Example configuration for the Solana orderbook.
 
-# The Postgres database the indexer writes to.
-db-url = "postgresql://"
+[database]
+# The Postgres database the indexer writes to. Reads prefer read-url when set,
+# and a value like "%DB_READ_URL" reads the URL from that environment variable.
+write-url = "postgresql://"
+# read-url = "%DB_READ_URL"
 
 [http]
 bind-address = "0.0.0.0:8080"

--- a/crates/solana-orderbook/src/infra/api/mod.rs
+++ b/crates/solana-orderbook/src/infra/api/mod.rs
@@ -4,7 +4,8 @@ use {
     axum::{Router, http, routing::get},
     observe::tracing::distributed::axum::{make_span, record_trace_id},
     sqlx::PgPool,
-    std::{net::SocketAddr, sync::Arc},
+    std::{io, net::SocketAddr, sync::Arc},
+    tokio::net::TcpListener,
     tokio_util::sync::CancellationToken,
     tower::ServiceBuilder,
     tower_http::{
@@ -27,8 +28,8 @@ pub struct Api {
 impl Api {
     /// Bind to the configured address, returning the listener and the actual
     /// bound address (which differs from `addr` when binding to port 0).
-    pub async fn bind(&self) -> Result<(tokio::net::TcpListener, SocketAddr), std::io::Error> {
-        let listener = tokio::net::TcpListener::bind(self.addr).await?;
+    pub async fn bind(&self) -> Result<(TcpListener, SocketAddr), io::Error> {
+        let listener = TcpListener::bind(self.addr).await?;
         let local_addr = listener.local_addr()?;
         tracing::info!(port = local_addr.port(), "serving solana orderbook");
         Ok((listener, local_addr))
@@ -38,9 +39,9 @@ impl Api {
     /// drain in-flight requests before returning.
     pub async fn serve(
         self,
-        listener: tokio::net::TcpListener,
+        listener: TcpListener,
         shutdown: CancellationToken,
-    ) -> Result<(), std::io::Error> {
+    ) -> Result<(), io::Error> {
         // Propagate the OpenTelemetry trace context from incoming request headers and
         // record the trace id on the request span, so logs can be correlated across
         // services. `make_span` sets the parent context and an empty `trace_id` field;

--- a/crates/solana-orderbook/src/infra/api/mod.rs
+++ b/crates/solana-orderbook/src/infra/api/mod.rs
@@ -1,0 +1,81 @@
+//! HTTP API server.
+
+use {
+    axum::{Router, routing::get},
+    observe::tracing::distributed::axum::{make_span, record_trace_id},
+    sqlx::PgPool,
+    std::{net::SocketAddr, sync::Arc},
+    tokio_util::sync::CancellationToken,
+    tower::ServiceBuilder,
+    tower_http::{decompression::RequestDecompressionLayer, trace::TraceLayer},
+};
+
+pub mod routes;
+
+/// The Solana orderbook HTTP API server.
+pub struct Api {
+    /// Address the server binds to and listens on.
+    pub addr: SocketAddr,
+    /// The database the indexer writes to.
+    pub pool: PgPool,
+}
+
+impl Api {
+    /// Bind to the configured address, returning the listener and the actual
+    /// bound address (which differs from `addr` when binding to port 0).
+    pub async fn bind(&self) -> Result<(tokio::net::TcpListener, SocketAddr), std::io::Error> {
+        let listener = tokio::net::TcpListener::bind(self.addr).await?;
+        let local_addr = listener.local_addr()?;
+        tracing::info!(port = local_addr.port(), "serving solana orderbook");
+        Ok((listener, local_addr))
+    }
+
+    /// Serve the API on the given listener until `shutdown` resolves, then
+    /// drain in-flight requests before returning.
+    pub async fn serve(
+        self,
+        listener: tokio::net::TcpListener,
+        shutdown: CancellationToken,
+    ) -> Result<(), std::io::Error> {
+        // Propagate the OpenTelemetry trace context from incoming request headers and
+        // record the trace id on the request span, so logs can be correlated across
+        // services. `make_span` sets the parent context and an empty `trace_id` field;
+        // `record_trace_id` then fills it in.
+        let tracing_layer = ServiceBuilder::new()
+            .layer(TraceLayer::new_for_http().make_span_with(make_span))
+            .map_request(record_trace_id);
+
+        let state = State::new(self.pool);
+
+        let app = Router::new()
+            .route("/healthz", get(routes::healthz))
+            .layer(RequestDecompressionLayer::new())
+            .layer(tracing_layer)
+            .with_state(state);
+
+        axum::serve(listener, app)
+            .with_graceful_shutdown(shutdown.cancelled_owned())
+            .await
+    }
+}
+
+/// Shared state available to all route handlers.
+#[derive(Clone)]
+pub struct State(Arc<Inner>);
+
+impl State {
+    fn new(pool: PgPool) -> Self {
+        Self(Arc::new(Inner { pool }))
+    }
+
+    /// The database handle the order, trades, and auction endpoints read
+    /// from.
+    pub fn pool(&self) -> &PgPool {
+        &self.0.pool
+    }
+}
+
+struct Inner {
+    /// The database the indexer writes to.
+    pool: PgPool,
+}

--- a/crates/solana-orderbook/src/infra/api/mod.rs
+++ b/crates/solana-orderbook/src/infra/api/mod.rs
@@ -1,13 +1,17 @@
 //! HTTP API server.
 
 use {
-    axum::{Router, routing::get},
+    axum::{Router, http, routing::get},
     observe::tracing::distributed::axum::{make_span, record_trace_id},
     sqlx::PgPool,
     std::{net::SocketAddr, sync::Arc},
     tokio_util::sync::CancellationToken,
     tower::ServiceBuilder,
-    tower_http::{decompression::RequestDecompressionLayer, trace::TraceLayer},
+    tower_http::{
+        cors::{Any, CorsLayer},
+        decompression::RequestDecompressionLayer,
+        trace::TraceLayer,
+    },
 };
 
 pub mod routes;
@@ -47,8 +51,16 @@ impl Api {
 
         let state = State::new(self.pool);
 
+        // Browsers call this API directly, so it answers cross-origin
+        // requests like the EVM orderbook does.
+        let cors = CorsLayer::new()
+            .allow_origin(Any)
+            .allow_methods([http::Method::GET, http::Method::OPTIONS, http::Method::HEAD])
+            .allow_headers([http::header::ORIGIN, http::header::CONTENT_TYPE]);
+
         let app = Router::new()
             .route("/healthz", get(routes::healthz))
+            .layer(cors)
             .layer(RequestDecompressionLayer::new())
             .layer(tracing_layer)
             .with_state(state);

--- a/crates/solana-orderbook/src/infra/api/routes/healthz.rs
+++ b/crates/solana-orderbook/src/infra/api/routes/healthz.rs
@@ -1,0 +1,3 @@
+pub async fn healthz() -> axum::http::StatusCode {
+    axum::http::StatusCode::OK
+}

--- a/crates/solana-orderbook/src/infra/api/routes/mod.rs
+++ b/crates/solana-orderbook/src/infra/api/routes/mod.rs
@@ -1,0 +1,3 @@
+mod healthz;
+
+pub use healthz::healthz;

--- a/crates/solana-orderbook/src/infra/config.rs
+++ b/crates/solana-orderbook/src/infra/config.rs
@@ -1,0 +1,82 @@
+//! Configuration of infrastructural components.
+
+use {
+    configs::shared::LoggingConfig,
+    serde::Deserialize,
+    std::{net::SocketAddr, path::Path},
+    tokio::fs,
+};
+
+/// Load the orderbook configuration from a TOML file.
+///
+/// # Panics
+///
+/// This method panics if the config is invalid or on I/O errors.
+pub async fn load(path: &Path) -> Config {
+    let data = fs::read_to_string(path)
+        .await
+        .unwrap_or_else(|e| panic!("I/O error while reading {path:?}: {e:?}"));
+
+    toml::de::from_str(&data).unwrap_or_else(|err| {
+        if std::env::var("TOML_TRACE_ERROR").is_ok_and(|v| v == "1") {
+            panic!("failed to parse TOML config at {path:?}: {err:#?}")
+        } else {
+            panic!(
+                "failed to parse TOML config at: {path:?}. Set TOML_TRACE_ERROR=1 to print \
+                 parsing error but this may leak secrets."
+            )
+        }
+    })
+}
+
+/// Configuration of infrastructural components.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct Config {
+    /// Postgres connection URL of the database the indexer writes to.
+    #[serde(default = "default_db_url")]
+    pub db_url: url::Url,
+    /// HTTP API server configuration.
+    pub http: Http,
+    /// Logging configuration.
+    #[serde(default)]
+    pub logging: LoggingConfig,
+}
+
+impl Config {
+    /// Build the `observe::Config` for the tracing framework from the logging
+    /// configuration.
+    pub fn observe_config(&self) -> observe::Config {
+        observe::Config::new(
+            &self.logging.filter,
+            self.logging.stderr_threshold,
+            self.logging.use_json,
+            None,
+        )
+    }
+}
+
+fn default_db_url() -> url::Url {
+    "postgresql://".parse().expect("valid default database URL")
+}
+
+/// HTTP API server configuration.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct Http {
+    /// Address the HTTP API server binds to and listens on.
+    pub bind_address: SocketAddr,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn loads_the_example_config() {
+        let config = load(Path::new("example.toml")).await;
+        assert_eq!(config.db_url.as_str(), "postgresql://");
+        assert_eq!(config.http.bind_address, "0.0.0.0:8080".parse().unwrap());
+        assert_eq!(config.logging.filter, "info,solana_orderbook=debug");
+    }
+}

--- a/crates/solana-orderbook/src/infra/config.rs
+++ b/crates/solana-orderbook/src/infra/config.rs
@@ -1,7 +1,7 @@
 //! Configuration of infrastructural components.
 
 use {
-    configs::shared::LoggingConfig,
+    configs::{database::DatabasePoolConfig, shared::LoggingConfig},
     serde::Deserialize,
     std::{net::SocketAddr, path::Path},
     tokio::fs,
@@ -33,9 +33,10 @@ pub async fn load(path: &Path) -> Config {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct Config {
-    /// Postgres connection URL of the database the indexer writes to.
-    #[serde(default = "default_db_url")]
-    pub db_url: url::Url,
+    /// Connection configuration for the database the indexer writes to. The
+    /// orderbook only reads, so the read URL wins when configured.
+    #[serde(default)]
+    pub database: DatabasePoolConfig,
     /// HTTP API server configuration.
     pub http: Http,
     /// Logging configuration.
@@ -56,10 +57,6 @@ impl Config {
     }
 }
 
-fn default_db_url() -> url::Url {
-    "postgresql://".parse().expect("valid default database URL")
-}
-
 /// HTTP API server configuration.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
@@ -75,7 +72,8 @@ mod tests {
     #[tokio::test]
     async fn loads_the_example_config() {
         let config = load(Path::new("example.toml")).await;
-        assert_eq!(config.db_url.as_str(), "postgresql://");
+        assert_eq!(config.database.write_url.as_str(), "postgresql://");
+        assert!(config.database.read_url.is_none());
         assert_eq!(config.http.bind_address, "0.0.0.0:8080".parse().unwrap());
         assert_eq!(config.logging.filter, "info,solana_orderbook=debug");
     }

--- a/crates/solana-orderbook/src/infra/mod.rs
+++ b/crates/solana-orderbook/src/infra/mod.rs
@@ -1,0 +1,8 @@
+//! Infrastructure layer: concrete implementations of the orderbook's external
+//! dependencies (configuration, database, HTTP API, observability).
+
+pub mod api;
+pub mod config;
+pub mod observe;
+
+pub use self::api::Api;

--- a/crates/solana-orderbook/src/infra/observe/mod.rs
+++ b/crates/solana-orderbook/src/infra/observe/mod.rs
@@ -1,0 +1,9 @@
+//! Observability for the Solana orderbook, built on the shared `observe`
+//! crate.
+
+/// Set up the observability. The `obs_config` argument configures the tokio
+/// tracing framework.
+pub fn init(obs_config: observe::Config) {
+    observe::panic_hook::install();
+    observe::tracing::init::initialize_reentrant(&obs_config);
+}

--- a/crates/solana-orderbook/src/lib.rs
+++ b/crates/solana-orderbook/src/lib.rs
@@ -1,0 +1,8 @@
+//! The Solana orderbook API.
+
+#![forbid(unsafe_code)]
+
+pub mod infra;
+mod run;
+
+pub use self::run::{run, start};

--- a/crates/solana-orderbook/src/main.rs
+++ b/crates/solana-orderbook/src/main.rs
@@ -1,0 +1,7 @@
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
+#[tokio::main]
+async fn main() {
+    solana_orderbook::start(std::env::args()).await;
+}

--- a/crates/solana-orderbook/src/run.rs
+++ b/crates/solana-orderbook/src/run.rs
@@ -78,10 +78,9 @@ pub async fn run(args: Args) {
     infra_observe::init(config.observe_config());
 
     let version = observe::version::git_version();
-    tracing::info!(%version, "running solana orderbook");
-    if std::env::var("TOML_TRACE_ERROR").is_ok_and(|v| v == "1") {
-        tracing::info!(?config, "loaded config");
-    }
+    // Secrets stay out of the log through the config types' redacting Debug
+    // impls.
+    tracing::info!(%version, ?config, "running solana orderbook");
 
     let pool = read_pool(&config.database).await;
     let metrics = serve_probes(pool.clone(), config.http.bind_address);

--- a/crates/solana-orderbook/src/run.rs
+++ b/crates/solana-orderbook/src/run.rs
@@ -3,10 +3,45 @@
 use {
     crate::infra::{Api, config, observe as infra_observe},
     clap::Parser,
+    configs::database::DatabasePoolConfig,
     observe::metrics::{DEFAULT_METRICS_PORT, LivenessChecking, serve_metrics},
     sqlx::{Executor, PgPool, postgres::PgPoolOptions},
-    std::{path::PathBuf, sync::Arc, time::Duration},
+    std::{net::SocketAddr, path::PathBuf, sync::Arc, time::Duration},
+    tokio::task::JoinHandle,
 };
+
+/// Connect the read pool: the replica URL wins when configured, and every
+/// connection gets the read statement timeout.
+async fn read_pool(database: &DatabasePoolConfig) -> PgPool {
+    let url = database.read_url.as_ref().unwrap_or(&database.write_url);
+    let timeout_ms = database.statement_timeout.as_millis();
+    PgPoolOptions::new()
+        .max_connections(database.max_connections.get())
+        .after_connect(move |conn, _meta| {
+            Box::pin(async move {
+                conn.execute(format!("SET statement_timeout = {timeout_ms}").as_str())
+                    .await?;
+                Ok(())
+            })
+        })
+        .connect(url.as_str())
+        .await
+        .expect("database connection")
+}
+
+/// Serve the metrics and probe routes on the API address with the metrics
+/// port.
+fn serve_probes(pool: PgPool, api_address: SocketAddr) -> JoinHandle<()> {
+    let mut metrics_address = api_address;
+    metrics_address.set_port(DEFAULT_METRICS_PORT);
+    tracing::info!(%metrics_address, "serving metrics");
+    serve_metrics(
+        Arc::new(Liveness { pool }),
+        metrics_address,
+        Default::default(),
+        Default::default(),
+    )
+}
 
 /// Fails the liveness probe when the database is unreachable.
 struct Liveness {
@@ -48,33 +83,8 @@ pub async fn run(args: Args) {
         tracing::info!(?config, "loaded config");
     }
 
-    // The orderbook only reads, so the replica URL wins when configured and
-    // every connection gets the read statement timeout.
-    let database = &config.database;
-    let url = database.read_url.as_ref().unwrap_or(&database.write_url);
-    let timeout_ms = database.statement_timeout.as_millis();
-    let pool = PgPoolOptions::new()
-        .max_connections(database.max_connections.get())
-        .after_connect(move |conn, _meta| {
-            Box::pin(async move {
-                conn.execute(format!("SET statement_timeout = {timeout_ms}").as_str())
-                    .await?;
-                Ok(())
-            })
-        })
-        .connect(url.as_str())
-        .await
-        .expect("database connection");
-
-    let mut metrics_address = config.http.bind_address;
-    metrics_address.set_port(DEFAULT_METRICS_PORT);
-    tracing::info!(%metrics_address, "serving metrics");
-    let metrics = serve_metrics(
-        Arc::new(Liveness { pool: pool.clone() }),
-        metrics_address,
-        Default::default(),
-        Default::default(),
-    );
+    let pool = read_pool(&config.database).await;
+    let metrics = serve_probes(pool.clone(), config.http.bind_address);
 
     let shutdown_token = tokio_util::sync::CancellationToken::new();
     let api = Api {

--- a/crates/solana-orderbook/src/run.rs
+++ b/crates/solana-orderbook/src/run.rs
@@ -3,9 +3,22 @@
 use {
     crate::infra::{Api, config, observe as infra_observe},
     clap::Parser,
+    observe::metrics::{DEFAULT_METRICS_PORT, LivenessChecking, serve_metrics},
     sqlx::PgPool,
-    std::{path::PathBuf, time::Duration},
+    std::{path::PathBuf, sync::Arc, time::Duration},
 };
+
+/// Fails the liveness probe when the database is unreachable.
+struct Liveness {
+    pool: PgPool,
+}
+
+#[async_trait::async_trait]
+impl LivenessChecking for Liveness {
+    async fn is_alive(&self) -> bool {
+        sqlx::query("SELECT 1").execute(&self.pool).await.is_ok()
+    }
+}
 
 /// The Solana orderbook command line arguments.
 #[derive(Debug, Parser)]
@@ -39,6 +52,16 @@ pub async fn run(args: Args) {
         .await
         .expect("database connection");
 
+    let mut metrics_address = config.http.bind_address;
+    metrics_address.set_port(DEFAULT_METRICS_PORT);
+    tracing::info!(%metrics_address, "serving metrics");
+    let metrics = serve_metrics(
+        Arc::new(Liveness { pool: pool.clone() }),
+        metrics_address,
+        Default::default(),
+        Default::default(),
+    );
+
     let shutdown_token = tokio_util::sync::CancellationToken::new();
     let api = Api {
         addr: config.http.bind_address,
@@ -50,6 +73,7 @@ pub async fn run(args: Args) {
     futures::pin_mut!(serve);
     tokio::select! {
         result = &mut serve => panic!("serve task exited: {result:?}"),
+        result = metrics => panic!("metrics server exited: {result:?}"),
         _ = observe::shutdown::shutdown_signal() => {
             tracing::info!("Gracefully shutting down API");
             shutdown_token.cancel();

--- a/crates/solana-orderbook/src/run.rs
+++ b/crates/solana-orderbook/src/run.rs
@@ -34,7 +34,6 @@ async fn read_pool(database: &DatabasePoolConfig) -> PgPool {
 fn serve_probes(pool: PgPool, api_address: SocketAddr) -> JoinHandle<()> {
     let mut metrics_address = api_address;
     metrics_address.set_port(DEFAULT_METRICS_PORT);
-    tracing::info!(%metrics_address, "serving metrics");
     serve_metrics(
         Arc::new(Liveness { pool }),
         metrics_address,

--- a/crates/solana-orderbook/src/run.rs
+++ b/crates/solana-orderbook/src/run.rs
@@ -1,0 +1,62 @@
+//! Orderbook entry-point logic.
+
+use {
+    crate::infra::{Api, config, observe as infra_observe},
+    clap::Parser,
+    sqlx::PgPool,
+    std::{path::PathBuf, time::Duration},
+};
+
+/// The Solana orderbook command line arguments.
+#[derive(Debug, Parser)]
+#[command(author, version, about)]
+pub struct Args {
+    /// Path to the TOML configuration file.
+    #[arg(long, env)]
+    config: PathBuf,
+}
+
+/// The orderbook entry-point. Parses command-line arguments and runs the
+/// orderbook.
+pub async fn start(args: impl Iterator<Item = String>) {
+    let args = Args::parse_from(args);
+    run(args).await;
+}
+
+/// Runs the orderbook, blocking until the shutdown signal is received.
+pub async fn run(args: Args) {
+    let config = config::load(&args.config).await;
+
+    infra_observe::init(config.observe_config());
+
+    let version = observe::version::git_version();
+    tracing::info!(%version, "running solana orderbook");
+    if std::env::var("TOML_TRACE_ERROR").is_ok_and(|v| v == "1") {
+        tracing::info!(?config, "loaded config");
+    }
+
+    let pool = PgPool::connect(config.db_url.as_str())
+        .await
+        .expect("database connection");
+
+    let shutdown_token = tokio_util::sync::CancellationToken::new();
+    let api = Api {
+        addr: config.http.bind_address,
+        pool,
+    };
+    let (listener, _addr) = api.bind().await.expect("failed to bind HTTP server");
+    let serve = api.serve(listener, shutdown_token.clone());
+
+    futures::pin_mut!(serve);
+    tokio::select! {
+        result = &mut serve => panic!("serve task exited: {result:?}"),
+        _ = observe::shutdown::shutdown_signal() => {
+            tracing::info!("Gracefully shutting down API");
+            shutdown_token.cancel();
+            match tokio::time::timeout(Duration::from_secs(20), serve).await {
+                Ok(inner) => inner.expect("API failed during shutdown"),
+                Err(_) => panic!("API shutdown exceeded timeout"),
+            }
+        }
+    }
+}

--- a/crates/solana-orderbook/src/run.rs
+++ b/crates/solana-orderbook/src/run.rs
@@ -4,7 +4,7 @@ use {
     crate::infra::{Api, config, observe as infra_observe},
     clap::Parser,
     observe::metrics::{DEFAULT_METRICS_PORT, LivenessChecking, serve_metrics},
-    sqlx::PgPool,
+    sqlx::{Executor, PgPool, postgres::PgPoolOptions},
     std::{path::PathBuf, sync::Arc, time::Duration},
 };
 
@@ -48,7 +48,21 @@ pub async fn run(args: Args) {
         tracing::info!(?config, "loaded config");
     }
 
-    let pool = PgPool::connect(config.db_url.as_str())
+    // The orderbook only reads, so the replica URL wins when configured and
+    // every connection gets the read statement timeout.
+    let database = &config.database;
+    let url = database.read_url.as_ref().unwrap_or(&database.write_url);
+    let timeout_ms = database.statement_timeout.as_millis();
+    let pool = PgPoolOptions::new()
+        .max_connections(database.max_connections.get())
+        .after_connect(move |conn, _meta| {
+            Box::pin(async move {
+                conn.execute(format!("SET statement_timeout = {timeout_ms}").as_str())
+                    .await?;
+                Ok(())
+            })
+        })
+        .connect(url.as_str())
         .await
         .expect("database connection");
 

--- a/crates/solana-orderbook/tests/api.rs
+++ b/crates/solana-orderbook/tests/api.rs
@@ -1,0 +1,59 @@
+//! Integration tests for the HTTP API server.
+
+use {
+    solana_orderbook::infra::api::Api,
+    sqlx::PgPool,
+    std::net::SocketAddr,
+    tokio_util::sync::CancellationToken,
+};
+
+fn mock_api() -> Api {
+    Api {
+        addr: "0.0.0.0:0".parse().unwrap(),
+        // A lazy pool never connects unless queried, and `/healthz` does not
+        // query, so the tests run without a database.
+        pool: PgPool::connect_lazy("postgresql://").unwrap(),
+    }
+}
+
+/// Spawn the API server on an ephemeral port and return its bound address.
+async fn spawn_server() -> SocketAddr {
+    let api = mock_api();
+    let (listener, addr) = api.bind().await.unwrap();
+    // A token that is never cancelled keeps the server alive for the test.
+    let shutdown = CancellationToken::new();
+    tokio::spawn(async move { api.serve(listener, shutdown).await.unwrap() });
+    addr
+}
+
+#[tokio::test]
+async fn healthz_returns_200() {
+    let addr = spawn_server().await;
+    let response = reqwest::Client::new()
+        .get(format!("http://{addr}/healthz"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+}
+
+#[tokio::test]
+async fn shuts_down_cleanly_on_signal() {
+    let api = mock_api();
+    let (listener, addr) = api.bind().await.unwrap();
+    let shutdown_token = CancellationToken::new();
+    let serve = api.serve(listener, shutdown_token.clone());
+    let handle = tokio::spawn(async move { serve.await.unwrap() });
+
+    // The server is up and serving requests.
+    let response = reqwest::Client::new()
+        .get(format!("http://{addr}/healthz"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+    // Trigger graceful shutdown and assert the serve future completes cleanly.
+    shutdown_token.cancel();
+    handle.await.unwrap();
+}


### PR DESCRIPTION
# Description
The frontend integrates against a read-only orderbook API before the end of Q3 (BE-222, agreed in Slack). This PR bootstraps the `solana-orderbook` crate the endpoints land in: TOML config, a Postgres pool over the database the indexer writes to, and an axum server with `/healthz`. Same layout as the solana-driver crate.

The GET endpoints for order, trades, and auction come next (BE-223 to BE-225).

# Changes
- New `solana-orderbook` crate: config, database pool, HTTP server, healthz
- The shared `DatabasePoolConfig` drives the pool: the read replica URL wins when configured, connections get the read statement timeout
- CORS headers on the API (browsers call it directly) and the observe metrics server with a database-backed liveness probe, mirroring the EVM orderbook

# How to test
New config load and API server tests.
