### PR TITLE
solana-driver: Autopilot interface

### DIFF
--- a/crates/autopilot-svm/src/infra/driver/dto.rs
+++ b/crates/autopilot-svm/src/infra/driver/dto.rs
@@ -18,8 +18,10 @@ use {
 #[serde(rename_all = "camelCase")]
 pub struct SolveRequest {
     /// Autopilot-assigned auction id.
+    #[serde_as(as = "DisplayFromStr")]
     pub id: i64,
     /// Slot after which a settlement for this auction is late.
+    #[serde_as(as = "DisplayFromStr")]
     pub deadline_slot: u64,
     pub orders: Vec<Order>,
 }
@@ -96,6 +98,7 @@ pub struct SolveResponse {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Solution {
+    #[serde_as(as = "DisplayFromStr")]
     pub solution_id: u64,
     /// Total surplus in lamports, decimal string on the wire.
     #[serde_as(as = "DisplayFromStr")]
@@ -120,10 +123,13 @@ pub struct TradedAmounts {
 }
 
 /// Asks the driver to submit a previously proposed solution.
+#[serde_as]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SettleRequest {
+    #[serde_as(as = "DisplayFromStr")]
     pub auction_id: i64,
+    #[serde_as(as = "DisplayFromStr")]
     pub solution_id: u64,
 }
 
@@ -169,7 +175,8 @@ mod tests {
             orders: vec![Order::from(&order())],
         };
         let json = serde_json::to_value(&request).unwrap();
-        assert_eq!(json["deadlineSlot"], 100);
+        assert_eq!(json["id"], "7");
+        assert_eq!(json["deadlineSlot"], "100");
         assert_eq!(
             json["orders"][0]["uid"],
             "0x1111111111111111111111111111111111111111111111111111111111111111"
@@ -203,6 +210,7 @@ mod tests {
             }],
         };
         let json = serde_json::to_value(&solve).unwrap();
+        assert_eq!(json["solutions"][0]["solutionId"], "3");
         assert_eq!(json["solutions"][0]["score"], "12345");
         assert_eq!(
             serde_json::from_value::<SolveResponse>(json).unwrap(),
@@ -216,6 +224,18 @@ mod tests {
         assert_eq!(
             serde_json::from_value::<SettleResponse>(json).unwrap(),
             settle
+        );
+
+        let settle_request = SettleRequest {
+            auction_id: 7,
+            solution_id: 3,
+        };
+        let json = serde_json::to_value(&settle_request).unwrap();
+        assert_eq!(json["auctionId"], "7");
+        assert_eq!(json["solutionId"], "3");
+        assert_eq!(
+            serde_json::from_value::<SettleRequest>(json).unwrap(),
+            settle_request
         );
     }
 }

--- a/crates/solana-driver/src/domain/auction.rs
+++ b/crates/solana-driver/src/domain/auction.rs
@@ -1,15 +1,58 @@
 //! Domain model of an auction the driver asks solver engines to fill.
 
-use {super::order_uid::OrderUid, serde::Serialize, solana_sdk::pubkey::Pubkey};
+use {
+    super::{order_uid::OrderUid, slot::Slot},
+    serde::Serialize,
+    solana_sdk::pubkey::Pubkey,
+    std::fmt,
+};
+
+/// The autopilot-assigned identifier of an auction.
+///
+/// The id must be positive. The autopilot assigns positive ids, and the
+/// engine boundary later reads the id as `u64`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct Id(pub i64);
+
+impl Id {
+    /// Construct a validated auction id. Reject non-positive values.
+    pub fn new(id: i64) -> Result<Self, InvalidAuctionId> {
+        if id <= 0 {
+            return Err(InvalidAuctionId(id));
+        }
+        Ok(Self(id))
+    }
+}
+
+impl TryFrom<i64> for Id {
+    type Error = InvalidAuctionId;
+
+    fn try_from(id: i64) -> Result<Self, Self::Error> {
+        Self::new(id)
+    }
+}
+
+impl fmt::Display for Id {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+/// A non-positive auction id.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("auction id must be positive, got {0}")]
+pub struct InvalidAuctionId(pub i64);
 
 /// A collection of orders the driver wants solvers to fill.
 #[derive(Clone, Debug)]
 pub struct Auction {
-    pub id: i64,
+    pub id: Id,
     pub orders: Vec<Order>,
+    /// Slot after which a settlement for this auction is late.
+    pub deadline_slot: Slot,
     /// Absolute deadline by which solver engines must return solutions. The
-    /// driver derives each request's timeout as the time remaining until this
-    /// instant, and skips the request entirely if the deadline has passed.
+    /// driver derives each request's timeout as the time left until this
+    /// instant. It skips the request if the deadline has passed.
     pub deadline: chrono::DateTime<chrono::Utc>,
 }
 
@@ -17,11 +60,18 @@ pub struct Auction {
 #[derive(Clone, Debug)]
 pub struct Order {
     pub uid: OrderUid,
-    pub sell_mint: Pubkey,
-    pub buy_mint: Pubkey,
-    /// Sell amount for sells, buy amount for buys.
-    pub amount: u64,
+    pub owner: Pubkey,
+    pub sell_token: Pubkey,
+    pub buy_token: Pubkey,
+    pub sell_token_account: Pubkey,
+    pub buy_token_account: Pubkey,
+    pub sell_amount: u64,
+    pub buy_amount: u64,
+    /// Unix seconds.
+    pub valid_to: u32,
     pub side: Side,
+    pub partially_fillable: bool,
+    pub order_pda: Pubkey,
 }
 
 /// Direction of the trade.
@@ -30,4 +80,22 @@ pub struct Order {
 pub enum Side {
     Sell,
     Buy,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn id_accepts_positive_values() {
+        assert_eq!(Id::new(1).unwrap(), Id(1));
+        assert_eq!(Id::try_from(42).unwrap(), Id(42));
+    }
+
+    #[test]
+    fn id_rejects_non_positive_values() {
+        for id in [0, -1, i64::MIN] {
+            assert_eq!(Id::new(id).unwrap_err(), InvalidAuctionId(id));
+        }
+    }
 }

--- a/crates/solana-driver/src/domain/auction.rs
+++ b/crates/solana-driver/src/domain/auction.rs
@@ -12,7 +12,7 @@ use {
 /// The id must be positive. The autopilot assigns positive ids, and the
 /// engine boundary later reads the id as `u64`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
-pub struct Id(pub i64);
+pub struct Id(i64);
 
 impl Id {
     /// Construct a validated auction id. Reject non-positive values.
@@ -21,6 +21,11 @@ impl Id {
             return Err(InvalidAuctionId(id));
         }
         Ok(Self(id))
+    }
+
+    /// The raw id value. Guaranteed positive by construction.
+    pub fn get(self) -> i64 {
+        self.0
     }
 }
 

--- a/crates/solana-driver/src/domain/competition.rs
+++ b/crates/solana-driver/src/domain/competition.rs
@@ -1,0 +1,100 @@
+//! The competition: the driver runs one auction across its configured solver
+//! engines.
+//!
+//! `Competition` owns the solve flow (concurrent fan-out to engines, reindexing
+//! engine-local solution ids to driver-unique ones) and the settle seam. It
+//! holds the concrete `infra::solver::Solver` clients.
+
+use {
+    super::{Auction, auction::Id, solution::Solution},
+    crate::infra::solver::{Error as SolverError, Solver},
+};
+
+/// Orchestrates one auction across the configured solver engines.
+pub struct Competition {
+    solvers: Vec<Solver>,
+}
+
+impl Competition {
+    /// Build a competition from the configured solver engines.
+    pub fn new(solvers: Vec<Solver>) -> Self {
+        Self { solvers }
+    }
+
+    /// Fan the auction out to every engine concurrently and collect their
+    /// solutions.
+    ///
+    /// The driver logs and drops a failing engine. A partial failure must not
+    /// kill the auction: the remaining engines still propose solutions. If
+    /// every engine fails, the driver returns `Error::Solver`.
+    ///
+    /// The driver reindexes engine-local solution ids to driver-unique ids. The
+    /// autopilot then addresses a solution by `(auction_id, solution_id)`
+    /// without collisions across engines.
+    pub async fn solve(&self, auction: &Auction) -> Result<Vec<Solution>, Error> {
+        // TODO: add a timeout and stream results out of the fan-out (via
+        // `FuturesUnordered`) while the timeout has not expired.
+        let results = futures::future::join_all(self.solvers.iter().map(|solver| {
+            let name = solver.name().to_owned();
+            async move {
+                let result = solver.solve(auction).await;
+                (name, result)
+            }
+        }))
+        .await;
+
+        let mut solutions = Vec::new();
+        let mut any_success = false;
+        let mut last_error = None;
+        for (name, result) in results {
+            match result {
+                Ok(mut engine_solutions) => {
+                    any_success = true;
+                    solutions.append(&mut engine_solutions);
+                }
+                Err(error) => {
+                    tracing::warn!(solver = %name, %error, "solver engine failed");
+                    last_error = Some(error);
+                }
+            }
+        }
+
+        // If every engine failed, return the failure. A partial failure (some
+        // engines succeeded) still returns the successful solutions.
+        if !any_success && let Some(error) = last_error {
+            return Err(Error::Solver(error));
+        }
+
+        // Reindex engine-local solution ids to driver-unique ids. The autopilot
+        // addresses solutions by (auction_id, solution_id), so ids must be
+        // unique across engines within one auction.
+        for (index, solution) in solutions.iter_mut().enumerate() {
+            tracing::debug!(
+                solver = %solution.solver,
+                engine_id = solution.id,
+                driver_id = index,
+                "reindexing solution id"
+            );
+            solution.id = index as u64;
+        }
+
+        // TODO: store the proposed solutions in the solution cache keyed by
+        // (auction_id, solution_id) once the cache lands. The cache also
+        // prevents double settles and evicts old entries.
+
+        Ok(solutions)
+    }
+
+    /// Submit a previously proposed solution on chain.
+    pub fn settle(&self, _auction_id: Id, _solution_id: u64) -> Result<(), Error> {
+        unimplemented!("will be implemented in follow-up PRs")
+    }
+}
+
+/// An error the competition reports to the API layer.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// A solver engine failed to produce solutions.
+    #[error("solver engine failed: {0}")]
+    Solver(#[from] SolverError),
+}

--- a/crates/solana-driver/src/domain/competition.rs
+++ b/crates/solana-driver/src/domain/competition.rs
@@ -1,82 +1,30 @@
-//! The competition: the driver runs one auction across its configured solver
-//! engines.
+//! The competition: the driver runs one auction through a single solver engine.
 //!
-//! `Competition` owns the solve flow (concurrent fan-out to engines, reindexing
-//! engine-local solution ids to driver-unique ones) and the settle seam. It
-//! holds the concrete `infra::solver::Solver` clients.
+//! `Competition` owns the solve flow (calling the engine) and the settle entry
+//! point. It holds the concrete `infra::solver::Solver` client. One
+//! `Competition` per solver engine is mounted on the API under `/{name}`.
 
 use {
     super::{Auction, auction::Id, solution::Solution},
     crate::infra::solver::{Error as SolverError, Solver},
 };
 
-/// Orchestrates one auction across the configured solver engines.
+/// Orchestrates one auction through a single solver engine.
 pub struct Competition {
-    solvers: Vec<Solver>,
+    solver: Solver,
 }
 
 impl Competition {
-    /// Build a competition from the configured solver engines.
-    pub fn new(solvers: Vec<Solver>) -> Self {
-        Self { solvers }
+    /// Build a competition from a single solver engine.
+    pub fn new(solver: Solver) -> Self {
+        Self { solver }
     }
 
-    /// Fan the auction out to every engine concurrently and collect their
-    /// solutions.
+    /// Send the auction to the solver engine and return its solutions.
     ///
-    /// The driver logs and drops a failing engine. A partial failure must not
-    /// kill the auction: the remaining engines still propose solutions. If
-    /// every engine fails, the driver returns `Error::Solver`.
-    ///
-    /// The driver reindexes engine-local solution ids to driver-unique ids. The
-    /// autopilot then addresses a solution by `(auction_id, solution_id)`
-    /// without collisions across engines.
+    /// If the engine fails, the driver returns `Error::Solver`.
     pub async fn solve(&self, auction: &Auction) -> Result<Vec<Solution>, Error> {
-        // TODO: add a timeout and stream results out of the fan-out (via
-        // `FuturesUnordered`) while the timeout has not expired.
-        let results = futures::future::join_all(self.solvers.iter().map(|solver| {
-            let name = solver.name().to_owned();
-            async move {
-                let result = solver.solve(auction).await;
-                (name, result)
-            }
-        }))
-        .await;
-
-        let mut solutions = Vec::new();
-        let mut any_success = false;
-        let mut last_error = None;
-        for (name, result) in results {
-            match result {
-                Ok(mut engine_solutions) => {
-                    any_success = true;
-                    solutions.append(&mut engine_solutions);
-                }
-                Err(error) => {
-                    tracing::warn!(solver = %name, %error, "solver engine failed");
-                    last_error = Some(error);
-                }
-            }
-        }
-
-        // If every engine failed, return the failure. A partial failure (some
-        // engines succeeded) still returns the successful solutions.
-        if !any_success && let Some(error) = last_error {
-            return Err(Error::Solver(error));
-        }
-
-        // Reindex engine-local solution ids to driver-unique ids. The autopilot
-        // addresses solutions by (auction_id, solution_id), so ids must be
-        // unique across engines within one auction.
-        for (index, solution) in solutions.iter_mut().enumerate() {
-            tracing::debug!(
-                solver = %solution.solver,
-                engine_id = solution.id,
-                driver_id = index,
-                "reindexing solution id"
-            );
-            solution.id = index as u64;
-        }
+        let solutions = self.solver.solve(auction).await?;
 
         // TODO: store the proposed solutions in the solution cache keyed by
         // (auction_id, solution_id) once the cache lands. The cache also
@@ -94,7 +42,7 @@ impl Competition {
 /// An error the competition reports to the API layer.
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    /// A solver engine failed to produce solutions.
+    /// The solver engine failed to produce solutions.
     #[error("solver engine failed: {0}")]
     Solver(#[from] SolverError),
 }

--- a/crates/solana-driver/src/domain/mod.rs
+++ b/crates/solana-driver/src/domain/mod.rs
@@ -1,13 +1,14 @@
 //! Domain model of the Solana driver.
-//!
-//! These types describe the concepts the driver works with — auctions and
-//! solutions — independent of any wire format or RPC representation.
 
 pub mod auction;
+pub mod competition;
 pub mod order_uid;
+pub mod slot;
 pub mod solution;
 
 pub use self::{
-    auction::{Auction, Order, Side},
+    auction::{Auction, Id, Order, Side},
+    competition::Competition,
+    slot::Slot,
     solution::{Solution, Trade},
 };

--- a/crates/solana-driver/src/domain/slot.rs
+++ b/crates/solana-driver/src/domain/slot.rs
@@ -1,0 +1,13 @@
+//! A Solana slot number.
+
+use std::fmt;
+
+/// A Solana slot number.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct Slot(pub u64);
+
+impl fmt::Display for Slot {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}

--- a/crates/solana-driver/src/domain/slot.rs
+++ b/crates/solana-driver/src/domain/slot.rs
@@ -1,5 +1,7 @@
 //! A Solana slot number.
-
+///
+/// TODO: consolidate `Slot` (and other shared Solana primitive types) into the
+/// `chain-types` crate.
 use std::fmt;
 
 /// A Solana slot number.

--- a/crates/solana-driver/src/domain/solution.rs
+++ b/crates/solana-driver/src/domain/solution.rs
@@ -3,6 +3,7 @@
 use {
     super::order_uid::OrderUid,
     solana_sdk::{instruction::Instruction, pubkey::Pubkey},
+    std::collections::HashMap,
 };
 
 /// A single solver engine's response to one auction.
@@ -11,6 +12,12 @@ pub struct Solution {
     pub id: u64,
     /// The on-chain identity of the solver that produced this solution.
     pub solver: Pubkey,
+    /// Uniform clearing prices by mint: the sell mint maps to the amount
+    /// bought and the buy mint to the amount sold, so for every trade
+    /// `executed_sell * price_sell == executed_buy * price_buy`. The engine
+    /// currently only produces single-order solutions, so the pair is the
+    /// executed swap's ratio.
+    pub prices: HashMap<Pubkey, u64>,
     pub trades: Vec<Trade>,
     /// Solana instructions to execute as part of the settlement.
     pub interactions: Vec<Instruction>,

--- a/crates/solana-driver/src/domain/solution.rs
+++ b/crates/solana-driver/src/domain/solution.rs
@@ -3,7 +3,7 @@
 use {
     super::order_uid::OrderUid,
     solana_sdk::{instruction::Instruction, pubkey::Pubkey},
-    std::collections::HashMap,
+    std::{collections::HashMap, num::NonZero},
 };
 
 /// A single solver engine's response to one auction.
@@ -17,7 +17,7 @@ pub struct Solution {
     /// `executed_sell * price_sell == executed_buy * price_buy`. The engine
     /// currently only produces single-order solutions, so the pair is the
     /// executed swap's ratio.
-    pub prices: HashMap<Pubkey, u64>,
+    pub prices: HashMap<Pubkey, NonZero<u64>>,
     pub trades: Vec<Trade>,
     /// Solana instructions to execute as part of the settlement.
     pub interactions: Vec<Instruction>,
@@ -31,6 +31,8 @@ pub struct Solution {
 #[derive(Clone, Debug)]
 pub struct Trade {
     pub order_uid: OrderUid,
-    /// Sell-token units for sell orders, buy-token units for buy orders.
-    pub executed_amount: u64,
+    /// Sell-token units executed.
+    pub executed_sell: u64,
+    /// Buy-token units executed.
+    pub executed_buy: u64,
 }

--- a/crates/solana-driver/src/infra/api/error.rs
+++ b/crates/solana-driver/src/infra/api/error.rs
@@ -1,0 +1,61 @@
+//! The wire error shape shared by every API route.
+
+use {
+    crate::{
+        domain::{auction, competition},
+        infra::api::routes::AuctionError,
+    },
+    serde::Serialize,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "PascalCase")]
+pub(crate) enum Kind {
+    InvalidAuctionId,
+    SolverFailed,
+}
+
+/// The wire error body.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Error {
+    kind: Kind,
+    description: &'static str,
+}
+
+impl From<Kind> for (axum::http::StatusCode, axum::Json<Error>) {
+    fn from(kind: Kind) -> Self {
+        let description = match kind {
+            Kind::InvalidAuctionId => "Invalid ID specified in the auction",
+            Kind::SolverFailed => "Solver engine returned an invalid response",
+        };
+        (
+            axum::http::StatusCode::BAD_REQUEST,
+            axum::Json(Error { kind, description }),
+        )
+    }
+}
+
+impl From<auction::InvalidAuctionId> for (axum::http::StatusCode, axum::Json<Error>) {
+    fn from(_: auction::InvalidAuctionId) -> Self {
+        Kind::InvalidAuctionId.into()
+    }
+}
+
+impl From<competition::Error> for (axum::http::StatusCode, axum::Json<Error>) {
+    fn from(value: competition::Error) -> Self {
+        match value {
+            competition::Error::Solver(_) => Kind::SolverFailed,
+        }
+        .into()
+    }
+}
+
+impl From<AuctionError> for (axum::http::StatusCode, axum::Json<Error>) {
+    fn from(value: AuctionError) -> Self {
+        match value {
+            AuctionError::InvalidAuctionId => Kind::InvalidAuctionId,
+        }
+        .into()
+    }
+}

--- a/crates/solana-driver/src/infra/api/error.rs
+++ b/crates/solana-driver/src/infra/api/error.rs
@@ -25,14 +25,17 @@ pub struct Error {
 
 impl From<Kind> for (axum::http::StatusCode, axum::Json<Error>) {
     fn from(kind: Kind) -> Self {
-        let description = match kind {
-            Kind::InvalidAuctionId => "Invalid ID specified in the auction",
-            Kind::SolverFailed => "Solver engine returned an invalid response",
+        let (status, description) = match kind {
+            Kind::InvalidAuctionId => (
+                axum::http::StatusCode::BAD_REQUEST,
+                "Invalid ID specified in the auction",
+            ),
+            Kind::SolverFailed => (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                "All solver engines failed to produce solutions",
+            ),
         };
-        (
-            axum::http::StatusCode::BAD_REQUEST,
-            axum::Json(Error { kind, description }),
-        )
+        (status, axum::Json(Error { kind, description }))
     }
 }
 

--- a/crates/solana-driver/src/infra/api/mod.rs
+++ b/crates/solana-driver/src/infra/api/mod.rs
@@ -1,12 +1,8 @@
 //! HTTP API server.
 
 use {
-    crate::domain,
-    axum::{
-        Router,
-        extract::DefaultBodyLimit,
-        routing::{get, post},
-    },
+    crate::{domain, infra::solver::Solver},
+    axum::{Router, extract::DefaultBodyLimit, routing::get},
     cow_solana_rpc::SolanaRPC,
     observe::tracing::distributed::axum::{make_span, record_trace_id},
     std::{net::SocketAddr, sync::Arc},
@@ -24,10 +20,11 @@ pub use self::error::Error;
 pub struct Api {
     /// Address the server binds to and listens on.
     pub addr: SocketAddr,
-    /// The shared Solana RPC client.
-    pub rpc: SolanaRPC,
-    /// The competition that runs auctions across solver engines.
-    pub competition: domain::Competition,
+    /// The shared Solana RPC client, wrapped in `Arc` so each solver engine's
+    /// state can hold a clone.
+    pub rpc: Arc<SolanaRPC>,
+    /// The solver engines.
+    pub solvers: Vec<Solver>,
 }
 
 impl Api {
@@ -55,18 +52,31 @@ impl Api {
             .layer(TraceLayer::new_for_http().make_span_with(make_span))
             .map_request(record_trace_id);
 
-        let state = State::new(self.rpc, self.competition);
+        // Global routes (healthz) live at the root.
+        let mut app = Router::new().route("/healthz", get(routes::healthz));
 
-        let app = Router::new()
-            .route("/healthz", get(routes::healthz))
-            .route("/solve", post(routes::solve))
-            .route("/settle", post(routes::settle))
+        // Mount one router per solver engine under `/{solver_name}`.
+        for solver in self.solvers {
+            let solver_name = solver.name().to_owned();
+            let competition = domain::Competition::new(solver);
+            let state = State::new(self.rpc.clone(), competition);
+
+            let router = Router::new()
+                .route("/solve", axum::routing::post(routes::solve))
+                .route("/settle", axum::routing::post(routes::settle))
+                .with_state(state);
+
+            let path = format!("/{solver_name}");
+            tracing::debug!(path = %path, "mounting solver");
+            app = app.nest(&path, router);
+        }
+
+        let app = app
             // Disable the request body limit: solver payloads (auctions and solutions)
             // can exceed axum's 2MB default.
             .layer(DefaultBodyLimit::disable())
             .layer(RequestDecompressionLayer::new())
-            .layer(tracing_layer)
-            .with_state(state);
+            .layer(tracing_layer);
 
         axum::serve(listener, app)
             .with_graceful_shutdown(shutdown.cancelled_owned())
@@ -74,17 +84,17 @@ impl Api {
     }
 }
 
-/// Shared state available to all route handlers.
+/// Shared state available to all route handlers for one solver engine.
 #[derive(Clone)]
 pub struct State(Arc<Inner>);
 
 impl State {
     /// Build the shared state the handlers operate on.
-    fn new(rpc: SolanaRPC, competition: domain::Competition) -> Self {
+    fn new(rpc: Arc<SolanaRPC>, competition: domain::Competition) -> Self {
         Self(Arc::new(Inner { rpc, competition }))
     }
 
-    /// The competition that runs auctions across solver engines.
+    /// The competition that runs auctions for this solver engine.
     fn competition(&self) -> &domain::Competition {
         &self.0.competition
     }
@@ -93,7 +103,7 @@ impl State {
 struct Inner {
     /// The shared Solana RPC client.
     #[expect(dead_code, reason = "used by the deadline and submission follow-ups")]
-    rpc: SolanaRPC,
-    /// The competition that runs auctions across solver engines.
+    rpc: Arc<SolanaRPC>,
+    /// The competition that runs auctions for this solver engine.
     competition: domain::Competition,
 }

--- a/crates/solana-driver/src/infra/api/mod.rs
+++ b/crates/solana-driver/src/infra/api/mod.rs
@@ -1,7 +1,7 @@
 //! HTTP API server.
 
 use {
-    crate::infra::solver,
+    crate::domain,
     axum::{
         Router,
         extract::DefaultBodyLimit,
@@ -15,7 +15,10 @@ use {
     tower_http::{decompression::RequestDecompressionLayer, trace::TraceLayer},
 };
 
+pub mod error;
 pub mod routes;
+
+pub use self::error::Error;
 
 /// The Solana driver HTTP API server.
 pub struct Api {
@@ -23,8 +26,8 @@ pub struct Api {
     pub addr: SocketAddr,
     /// The shared Solana RPC client.
     pub rpc: SolanaRPC,
-    /// Configured solver engines.
-    pub solvers: Vec<solver::Solver>,
+    /// The competition that runs auctions across solver engines.
+    pub competition: domain::Competition,
 }
 
 impl Api {
@@ -45,14 +48,14 @@ impl Api {
         shutdown: CancellationToken,
     ) -> Result<(), std::io::Error> {
         // Propagate the OpenTelemetry trace context from incoming request headers and
-        // record the trace id on the request span, so logs can be correlated across
-        // services. `make_span` sets the parent context and an empty `trace_id` field;
-        // `record_trace_id` then fills it in.
+        // record the trace id on the request span, so the driver can correlate logs
+        // across services. `make_span` sets the parent context and an empty
+        // `trace_id` field. `record_trace_id` then fills it in.
         let tracing_layer = ServiceBuilder::new()
             .layer(TraceLayer::new_for_http().make_span_with(make_span))
             .map_request(record_trace_id);
 
-        let state = State::new(self.rpc, self.solvers);
+        let state = State::new(self.rpc, self.competition);
 
         let app = Router::new()
             .route("/healthz", get(routes::healthz))
@@ -73,20 +76,24 @@ impl Api {
 
 /// Shared state available to all route handlers.
 #[derive(Clone)]
-#[expect(dead_code)]
 pub struct State(Arc<Inner>);
 
 impl State {
     /// Build the shared state the handlers operate on.
-    fn new(rpc: SolanaRPC, solvers: Vec<solver::Solver>) -> Self {
-        Self(Arc::new(Inner { rpc, solvers }))
+    fn new(rpc: SolanaRPC, competition: domain::Competition) -> Self {
+        Self(Arc::new(Inner { rpc, competition }))
+    }
+
+    /// The competition that runs auctions across solver engines.
+    fn competition(&self) -> &domain::Competition {
+        &self.0.competition
     }
 }
 
-#[expect(dead_code)]
 struct Inner {
     /// The shared Solana RPC client.
+    #[expect(dead_code, reason = "used by the deadline and submission follow-ups")]
     rpc: SolanaRPC,
-    /// Configured solver engines.
-    solvers: Vec<solver::Solver>,
+    /// The competition that runs auctions across solver engines.
+    competition: domain::Competition,
 }

--- a/crates/solana-driver/src/infra/api/routes/mod.rs
+++ b/crates/solana-driver/src/infra/api/routes/mod.rs
@@ -2,4 +2,8 @@ mod healthz;
 mod settle;
 mod solve;
 
-pub use {healthz::healthz, settle::settle, solve::solve};
+pub use self::{
+    healthz::healthz,
+    settle::settle,
+    solve::{AuctionError, solve},
+};

--- a/crates/solana-driver/src/infra/api/routes/settle/dto/mod.rs
+++ b/crates/solana-driver/src/infra/api/routes/settle/dto/mod.rs
@@ -1,0 +1,6 @@
+//! Wire DTOs for the `/settle` route.
+
+mod settle_request;
+mod settle_response;
+
+pub use self::{settle_request::SettleRequest, settle_response::SettleResponse};

--- a/crates/solana-driver/src/infra/api/routes/settle/dto/settle_request.rs
+++ b/crates/solana-driver/src/infra/api/routes/settle/dto/settle_request.rs
@@ -18,6 +18,9 @@ pub struct SettleRequest {
     pub auction_id: i64,
     #[serde_as(as = "DisplayFromStr")]
     pub solution_id: u64,
+    /// Slot after which a settlement for this auction is late.
+    #[serde_as(as = "DisplayFromStr")]
+    pub deadline_slot: u64,
 }
 
 #[cfg(test)]
@@ -31,10 +34,12 @@ mod tests {
         let request = SettleRequest {
             auction_id: 7,
             solution_id: 3,
+            deadline_slot: 100,
         };
         let expected = serde_json::json!({
             "auctionId": "7",
-            "solutionId": "3"
+            "solutionId": "3",
+            "deadlineSlot": "100"
         });
         assert_eq!(serde_json::to_value(&request).unwrap(), expected);
     }

--- a/crates/solana-driver/src/infra/api/routes/settle/dto/settle_request.rs
+++ b/crates/solana-driver/src/infra/api/routes/settle/dto/settle_request.rs
@@ -1,0 +1,41 @@
+//! Inbound `/settle` request: asks the driver to submit a previously proposed
+//! solution.
+//!
+//! This is the driver's own mirror of `autopilot-svm`'s
+//! `infra/driver/dto.rs::SettleRequest`.
+
+use {
+    serde::{Deserialize, Serialize},
+    serde_with::{DisplayFromStr, serde_as},
+};
+
+/// Asks the driver to submit a previously proposed solution.
+#[serde_as]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SettleRequest {
+    #[serde_as(as = "DisplayFromStr")]
+    pub auction_id: i64,
+    #[serde_as(as = "DisplayFromStr")]
+    pub solution_id: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pins the wire format: both fields are decimal strings. This matches
+    /// the EVM driver's convention of writing integer ids as strings.
+    #[test]
+    fn settle_request_pins_the_wire_format() {
+        let request = SettleRequest {
+            auction_id: 7,
+            solution_id: 3,
+        };
+        let expected = serde_json::json!({
+            "auctionId": "7",
+            "solutionId": "3"
+        });
+        assert_eq!(serde_json::to_value(&request).unwrap(), expected);
+    }
+}

--- a/crates/solana-driver/src/infra/api/routes/settle/dto/settle_response.rs
+++ b/crates/solana-driver/src/infra/api/routes/settle/dto/settle_response.rs
@@ -1,0 +1,41 @@
+//! Outbound `/settle` response: the transaction signature of the submitted
+//! settlement.
+//!
+//! This is the driver's own mirror of `autopilot-svm`'s
+//! `infra/driver/dto.rs::SettleResponse`. The driver pins the wire shape here
+//! even though on-chain submission is not implemented yet. The autopilot
+//! already deserializes this shape.
+
+use {
+    serde::{Deserialize, Serialize},
+    serde_with::{DisplayFromStr, serde_as},
+    solana_sdk::signature::Signature,
+};
+
+/// The driver's `/settle` answer.
+#[serde_as]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SettleResponse {
+    /// Transaction signature of the submitted settlement.
+    #[serde_as(as = "DisplayFromStr")]
+    tx_signature: Signature,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pins the wire format against the same literal as
+    /// `autopilot-svm/src/infra/driver/dto.rs::tests`.
+    #[test]
+    fn settle_response_pins_the_wire_format() {
+        let settle = SettleResponse {
+            tx_signature: Signature::from([9; 64]),
+        };
+        let expected = serde_json::json!({
+            "txSignature": "BUguQsv2ZuHus54HAFzjdJHzZBkygAjKhEeYwSG19tUfUyvvz3worsdQCdAXDNjakJHioSiyxhFiDJrm8XpSXRA"
+        });
+        assert_eq!(serde_json::to_value(&settle).unwrap(), expected);
+    }
+}

--- a/crates/solana-driver/src/infra/api/routes/settle/mod.rs
+++ b/crates/solana-driver/src/infra/api/routes/settle/mod.rs
@@ -1,5 +1,35 @@
-use crate::infra::api::State;
+pub mod dto;
 
-pub async fn settle(_state: axum::extract::State<State>) -> axum::http::StatusCode {
-    axum::http::StatusCode::NOT_IMPLEMENTED
+use {
+    crate::{
+        domain::auction,
+        infra::api::{State, error::Error},
+    },
+    axum::{Json, http::StatusCode},
+    tracing::Instrument,
+};
+
+/// Handle `POST /settle`: validate the request, then submit the solution.
+///
+/// On-chain settlement will be implemented in follow-up PRs; until then
+/// this route will panic.
+pub async fn settle(
+    state: axum::extract::State<State>,
+    Json(request): Json<dto::SettleRequest>,
+) -> Result<Json<dto::SettleResponse>, (StatusCode, Json<Error>)> {
+    let auction_id = auction::Id::try_from(request.auction_id)?;
+    let solution_id = request.solution_id;
+
+    let handle_request = async {
+        state.competition().settle(auction_id, solution_id)?;
+        unreachable!("competition.settle panics until on-chain settlement is implemented")
+    };
+
+    handle_request
+        .instrument(tracing::info_span!(
+            "/settle",
+            auction_id = %auction_id,
+            solution_id
+        ))
+        .await
 }

--- a/crates/solana-driver/src/infra/api/routes/settle/mod.rs
+++ b/crates/solana-driver/src/infra/api/routes/settle/mod.rs
@@ -22,7 +22,7 @@ pub async fn settle(
 
     let handle_request = async {
         state.competition().settle(auction_id, solution_id)?;
-        unreachable!("competition.settle panics until on-chain settlement is implemented")
+        unimplemented!("competition.settle panics until on-chain settlement is implemented")
     };
 
     handle_request

--- a/crates/solana-driver/src/infra/api/routes/solve/dto/mod.rs
+++ b/crates/solana-driver/src/infra/api/routes/solve/dto/mod.rs
@@ -1,0 +1,9 @@
+//! Wire DTOs for the `/solve` route.
+
+mod solve_request;
+mod solve_response;
+
+pub use self::{
+    solve_request::{Error as AuctionError, SolveRequest},
+    solve_response::SolveResponse,
+};

--- a/crates/solana-driver/src/infra/api/routes/solve/dto/solve_request.rs
+++ b/crates/solana-driver/src/infra/api/routes/solve/dto/solve_request.rs
@@ -1,0 +1,202 @@
+//! Inbound `/solve` request: the auction the autopilot posts to the driver.
+//!
+//! This is the driver's own mirror of `autopilot-svm`'s
+//! `infra/driver/dto.rs::SolveRequest`. The pinned-literal test below (which
+//! uses the same literals as the autopilot's own test) keeps the wire format
+//! in sync.
+
+use {
+    crate::domain::{self, order_uid::OrderUid},
+    serde::{Deserialize, Serialize},
+    serde_with::{DisplayFromStr, serde_as},
+    solana_sdk::pubkey::Pubkey,
+    std::time::Duration,
+};
+
+/// Placeholder solve budget until the deadline is derived from `deadline_slot`.
+// TODO: derive the deadline from `deadline_slot` via
+// `SolanaRPC::get_block_time`/`get_slot`.
+const SOLVE_DEADLINE: Duration = Duration::from_secs(15);
+
+/// The auction posted to `/solve`.
+#[serde_as]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SolveRequest {
+    /// Autopilot-assigned auction id.
+    #[serde_as(as = "DisplayFromStr")]
+    id: i64,
+    /// Slot after which a settlement for this auction is late.
+    #[serde_as(as = "DisplayFromStr")]
+    deadline_slot: u64,
+    orders: Vec<Order>,
+}
+
+/// One solvable order in the auction.
+#[serde_as]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Order {
+    #[serde_as(as = "DisplayFromStr")]
+    uid: OrderUid,
+    #[serde_as(as = "DisplayFromStr")]
+    owner: Pubkey,
+    #[serde_as(as = "DisplayFromStr")]
+    sell_token: Pubkey,
+    #[serde_as(as = "DisplayFromStr")]
+    buy_token: Pubkey,
+    #[serde_as(as = "DisplayFromStr")]
+    sell_token_account: Pubkey,
+    #[serde_as(as = "DisplayFromStr")]
+    buy_token_account: Pubkey,
+    #[serde_as(as = "DisplayFromStr")]
+    sell_amount: u64,
+    #[serde_as(as = "DisplayFromStr")]
+    buy_amount: u64,
+    /// Unix seconds.
+    valid_to: u32,
+    kind: Kind,
+    partially_fillable: bool,
+    #[serde_as(as = "DisplayFromStr")]
+    order_pda: Pubkey,
+}
+
+/// Whether the order sells or buys an exact amount.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+enum Kind {
+    Sell,
+    Buy,
+}
+
+impl From<Kind> for domain::Side {
+    fn from(kind: Kind) -> Self {
+        match kind {
+            Kind::Sell => domain::Side::Sell,
+            Kind::Buy => domain::Side::Buy,
+        }
+    }
+}
+
+impl From<Order> for domain::Order {
+    fn from(order: Order) -> Self {
+        Self {
+            uid: order.uid,
+            owner: order.owner,
+            sell_token: order.sell_token,
+            buy_token: order.buy_token,
+            sell_token_account: order.sell_token_account,
+            buy_token_account: order.buy_token_account,
+            sell_amount: order.sell_amount,
+            buy_amount: order.buy_amount,
+            valid_to: order.valid_to,
+            side: order.kind.into(),
+            partially_fillable: order.partially_fillable,
+            order_pda: order.order_pda,
+        }
+    }
+}
+
+/// A `/solve` request that could not become a domain auction.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("invalid auction id")]
+    InvalidAuctionId,
+}
+
+impl From<domain::auction::InvalidAuctionId> for Error {
+    fn from(_: domain::auction::InvalidAuctionId) -> Self {
+        Self::InvalidAuctionId
+    }
+}
+
+impl SolveRequest {
+    /// Convert the wire request into a domain auction.
+    ///
+    /// The driver uses `now + SOLVE_DEADLINE` as a placeholder for the
+    /// wall-clock `deadline`.
+    pub fn into_domain(self) -> Result<domain::Auction, Error> {
+        let id = domain::auction::Id::try_from(self.id)?;
+        // TODO: derive the deadline from `deadline_slot` via
+        // `SolanaRPC::get_block_time`/`get_slot` once that type adds these methods.
+        let deadline = chrono::Utc::now()
+            + chrono::Duration::from_std(SOLVE_DEADLINE)
+                .expect("solve-deadline fits in a chrono duration");
+        Ok(domain::Auction {
+            id,
+            orders: self.orders.into_iter().map(Into::into).collect(),
+            deadline_slot: domain::Slot(self.deadline_slot),
+            deadline,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pubkey(byte: u8) -> Pubkey {
+        Pubkey::new_from_array([byte; 32])
+    }
+
+    fn order() -> Order {
+        Order {
+            uid: OrderUid([0x11; 32]),
+            owner: Pubkey::new_from_array([0x22; 32]),
+            sell_token: Pubkey::new_from_array([0x33; 32]),
+            buy_token: Pubkey::new_from_array([0x44; 32]),
+            sell_token_account: Pubkey::new_from_array([0x55; 32]),
+            buy_token_account: Pubkey::new_from_array([0x66; 32]),
+            sell_amount: u64::MAX,
+            buy_amount: 2_000,
+            valid_to: 42,
+            kind: Kind::Sell,
+            partially_fillable: false,
+            order_pda: Pubkey::new_from_array([0x77; 32]),
+        }
+    }
+
+    /// Pins the wire format against the same literals as
+    /// `autopilot-svm/src/infra/driver/dto.rs::tests`, so drift between the two
+    /// crates breaks a test.
+    #[test]
+    fn solve_request_pins_the_wire_format() {
+        let request = SolveRequest {
+            id: 7,
+            deadline_slot: 100,
+            orders: vec![order()],
+        };
+        let expected = serde_json::json!({
+            "id": "7",
+            "deadlineSlot": "100",
+            "orders": [{
+                "uid": "0x1111111111111111111111111111111111111111111111111111111111111111",
+                "owner": "3JF3sEqM796hk5WFqA6EtmEwJQ9quALszsfJyvXNQKy3",
+                "sellToken": pubkey(0x33).to_string(),
+                "buyToken": pubkey(0x44).to_string(),
+                "sellTokenAccount": pubkey(0x55).to_string(),
+                "buyTokenAccount": pubkey(0x66).to_string(),
+                "sellAmount": "18446744073709551615",
+                "buyAmount": "2000",
+                "validTo": 42,
+                "kind": "sell",
+                "partiallyFillable": false,
+                "orderPda": pubkey(0x77).to_string(),
+            }]
+        });
+        assert_eq!(serde_json::to_value(&request).unwrap(), expected);
+    }
+
+    #[test]
+    fn into_domain_rejects_non_positive_id() {
+        let request = SolveRequest {
+            id: 0,
+            deadline_slot: 100,
+            orders: vec![order()],
+        };
+        let err = request
+            .into_domain()
+            .expect_err("non-positive id must be rejected");
+        assert!(matches!(err, Error::InvalidAuctionId));
+    }
+}

--- a/crates/solana-driver/src/infra/api/routes/solve/dto/solve_request.rs
+++ b/crates/solana-driver/src/infra/api/routes/solve/dto/solve_request.rs
@@ -10,12 +10,7 @@ use {
     serde::{Deserialize, Serialize},
     serde_with::{DisplayFromStr, serde_as},
     solana_sdk::pubkey::Pubkey,
-    std::time::Duration,
 };
-
-/// Placeholder solve budget until the wire `deadline` is piped into the domain.
-const SOLVE_DEADLINE: Duration = Duration::from_secs(15);
-
 /// The auction posted to `/solve`.
 #[serde_as]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -108,22 +103,14 @@ impl From<domain::auction::InvalidAuctionId> for Error {
 
 impl SolveRequest {
     /// Convert the wire request into a domain auction.
-    ///
-    /// The driver uses `now + SOLVE_DEADLINE` as a placeholder for the
-    /// timestamp `deadline`.
     pub fn into_domain(self) -> Result<domain::Auction, Error> {
         let id = domain::auction::Id::try_from(self.id)?;
-        // TODO: pipe the wire `deadline` into the domain once the placeholder
-        // solve budget is replaced.
-        let deadline = chrono::Utc::now()
-            + chrono::Duration::from_std(SOLVE_DEADLINE)
-                .expect("solve-deadline fits in a chrono duration");
         Ok(domain::Auction {
             id,
             orders: self.orders.into_iter().map(Into::into).collect(),
             // Placeholder; the domain does not consume it yet.
             deadline_slot: domain::Slot(0),
-            deadline,
+            deadline: self.deadline,
         })
     }
 }

--- a/crates/solana-driver/src/infra/api/routes/solve/dto/solve_response.rs
+++ b/crates/solana-driver/src/infra/api/routes/solve/dto/solve_response.rs
@@ -52,47 +52,64 @@ pub struct TradedAmounts {
 impl SolveResponse {
     /// Build the wire response from the driver's domain solutions.
     ///
-    /// `auction` supplies each order's side.
+    /// `auction` supplies each order's side and tokens.
     pub fn new(solutions: Vec<domain::Solution>, auction: &domain::Auction) -> Self {
-        let sides: HashMap<OrderUid, domain::Side> = auction
+        let auction_orders: HashMap<OrderUid, &domain::Order> = auction
             .orders
             .iter()
-            .map(|order| (order.uid, order.side))
+            .map(|order| (order.uid, order))
             .collect();
         Self {
             solutions: solutions
                 .into_iter()
-                .map(|solution| Solution::new(solution, &sides))
+                .map(|solution| Solution::new(solution, &auction_orders))
                 .collect(),
         }
     }
 }
 
 impl Solution {
-    fn new(solution: domain::Solution, sides: &HashMap<OrderUid, domain::Side>) -> Self {
-        let orders = solution
-            .trades
+    fn new(solution: domain::Solution, auction_orders: &HashMap<OrderUid, &domain::Order>) -> Self {
+        let domain::Solution {
+            id,
+            prices,
+            trades,
+            solver,
+            ..
+        } = solution;
+        let orders = trades
             .into_iter()
             .map(|trade| {
-                // WARN: As of now, the engine implementation only reports one executed amount,
-                // on the order's own side.  We fill that side and leave the other side at 0 as
-                // a placeholder.
-                //
-                // TODO: the counterpart amount isn't on the engine wire yet, so the `0` below
-                // is knowingly wrong. The autopilot must not persist it or compute over it as
-                // if it were real. The driver will replace it once the engine wire carries both
-                // legs (or clearing prices arrive).
-                //
-                // TODO: once the engine wire carries both trade legs, `domain::Trade` will hold
-                // the side directly and this lookup (plus the `.expect`) goes
-                // away entirely.
-                let side = sides.get(&trade.order_uid).copied().expect(
+                let order = auction_orders.get(&trade.order_uid).expect(
                     "trade uid is known by construction: Solutions::into_domain rejects unknown \
                      uids",
                 );
-                let (executed_sell, executed_buy) = match side {
-                    domain::Side::Sell => (trade.executed_amount, 0),
-                    domain::Side::Buy => (0, trade.executed_amount),
+                // The engine reports one executed amount, on the order's own side, plus uniform
+                // clearing prices per mint. Derive the counterpart leg from the prices so the
+                // autopilot sees a real trade on both sides instead of a zero placeholder.
+                let price_sell = prices
+                    .get(&order.sell_token)
+                    .expect("engine reports a clearing price for every traded sell mint");
+                let price_buy = prices
+                    .get(&order.buy_token)
+                    .expect("engine reports a clearing price for every traded buy mint");
+                let (executed_sell, executed_buy) = match order.side {
+                    domain::Side::Sell => {
+                        let executed_buy = trade
+                            .executed_amount
+                            .checked_mul(*price_sell)
+                            .and_then(|v| v.checked_div(*price_buy))
+                            .expect("clearing prices yield a valid counterpart amount");
+                        (trade.executed_amount, executed_buy)
+                    }
+                    domain::Side::Buy => {
+                        let executed_sell = trade
+                            .executed_amount
+                            .checked_mul(*price_buy)
+                            .and_then(|v| v.checked_div(*price_sell))
+                            .expect("clearing prices yield a valid counterpart amount");
+                        (executed_sell, trade.executed_amount)
+                    }
                 };
                 (
                     trade.order_uid,
@@ -104,11 +121,11 @@ impl Solution {
             })
             .collect();
         Self {
-            solution_id: solution.id,
-            // TODO: the driver stubs the score to 0 until surplus math is done, which needs both
-            // executed amounts and native price functionality.
+            solution_id: id,
+            // TODO: the driver stubs the score to 0 until surplus math is done, which needs
+            // native price functionality.
             score: 0,
-            solver: solution.solver,
+            solver,
             orders,
         }
     }
@@ -152,13 +169,10 @@ mod tests {
         assert_eq!(serde_json::to_value(&solve).unwrap(), expected);
     }
 
-    /// A sell order fills `executedSell` and zero-fills `executedBuy`. A buy
-    /// order does the reverse. The zero is the placeholder.
-    ///
-    /// TODO: temporary — obsolete once the engine wire carries both legs (or
-    /// clearing prices arrive), at which point the zero placeholder goes away.
+    /// A sell order fills `executedSell` and derives `executedBuy` from the
+    /// clearing prices. A buy order does the reverse.
     #[test]
-    fn new_fills_the_side_matching_amount() {
+    fn new_derives_the_counterpart_leg_from_clearing_prices() {
         let auction = domain::Auction {
             id: domain::auction::Id::new(1).unwrap(),
             orders: vec![
@@ -179,6 +193,11 @@ mod tests {
         let solutions = vec![domain::Solution {
             id: 0,
             solver: Pubkey::new_from_array([0x33; 32]),
+            // Sell mint prices at the amount bought, buy mint at the amount sold.
+            prices: HashMap::from([
+                (Pubkey::new_from_array([0x33; 32]), 200),
+                (Pubkey::new_from_array([0x44; 32]), 100),
+            ]),
             trades: vec![
                 domain::Trade {
                     order_uid: OrderUid([0x11; 32]),
@@ -197,9 +216,11 @@ mod tests {
         let response = SolveResponse::new(solutions, &auction);
         let solution = &response.solutions[0];
         assert_eq!(solution.score, 0, "score is stubbed to 0");
+        // Sell order: 100 sold, 100 * 200 / 100 = 200 bought.
         assert_eq!(solution.orders[&OrderUid([0x11; 32])].executed_sell, 100);
-        assert_eq!(solution.orders[&OrderUid([0x11; 32])].executed_buy, 0);
-        assert_eq!(solution.orders[&OrderUid([0x22; 32])].executed_sell, 0);
+        assert_eq!(solution.orders[&OrderUid([0x11; 32])].executed_buy, 200);
+        // Buy order: 200 bought, 200 * 100 / 200 = 100 sold.
+        assert_eq!(solution.orders[&OrderUid([0x22; 32])].executed_sell, 100);
         assert_eq!(solution.orders[&OrderUid([0x22; 32])].executed_buy, 200);
     }
 

--- a/crates/solana-driver/src/infra/api/routes/solve/dto/solve_response.rs
+++ b/crates/solana-driver/src/infra/api/routes/solve/dto/solve_response.rs
@@ -51,71 +51,26 @@ pub struct TradedAmounts {
 
 impl SolveResponse {
     /// Build the wire response from the driver's domain solutions.
-    ///
-    /// `auction` supplies each order's side and tokens.
-    pub fn new(solutions: Vec<domain::Solution>, auction: &domain::Auction) -> Self {
-        let auction_orders: HashMap<OrderUid, &domain::Order> = auction
-            .orders
-            .iter()
-            .map(|order| (order.uid, order))
-            .collect();
+    pub fn new(solutions: Vec<domain::Solution>) -> Self {
         Self {
-            solutions: solutions
-                .into_iter()
-                .map(|solution| Solution::new(solution, &auction_orders))
-                .collect(),
+            solutions: solutions.into_iter().map(Solution::new).collect(),
         }
     }
 }
 
 impl Solution {
-    fn new(solution: domain::Solution, auction_orders: &HashMap<OrderUid, &domain::Order>) -> Self {
+    fn new(solution: domain::Solution) -> Self {
         let domain::Solution {
-            id,
-            prices,
-            trades,
-            solver,
-            ..
+            id, trades, solver, ..
         } = solution;
         let orders = trades
             .into_iter()
             .map(|trade| {
-                let order = auction_orders.get(&trade.order_uid).expect(
-                    "trade uid is known by construction: Solutions::into_domain rejects unknown \
-                     uids",
-                );
-                // The engine reports one executed amount, on the order's own side, plus uniform
-                // clearing prices per mint. Derive the counterpart leg from the prices so the
-                // autopilot sees a real trade on both sides instead of a zero placeholder.
-                let price_sell = prices
-                    .get(&order.sell_token)
-                    .expect("engine reports a clearing price for every traded sell mint");
-                let price_buy = prices
-                    .get(&order.buy_token)
-                    .expect("engine reports a clearing price for every traded buy mint");
-                let (executed_sell, executed_buy) = match order.side {
-                    domain::Side::Sell => {
-                        let executed_buy = trade
-                            .executed_amount
-                            .checked_mul(*price_sell)
-                            .and_then(|v| v.checked_div(*price_buy))
-                            .expect("clearing prices yield a valid counterpart amount");
-                        (trade.executed_amount, executed_buy)
-                    }
-                    domain::Side::Buy => {
-                        let executed_sell = trade
-                            .executed_amount
-                            .checked_mul(*price_buy)
-                            .and_then(|v| v.checked_div(*price_sell))
-                            .expect("clearing prices yield a valid counterpart amount");
-                        (executed_sell, trade.executed_amount)
-                    }
-                };
                 (
                     trade.order_uid,
                     TradedAmounts {
-                        executed_sell,
-                        executed_buy,
+                        executed_sell: trade.executed_sell,
+                        executed_buy: trade.executed_buy,
                     },
                 )
             })
@@ -167,77 +122,5 @@ mod tests {
             }]
         });
         assert_eq!(serde_json::to_value(&solve).unwrap(), expected);
-    }
-
-    /// A sell order fills `executedSell` and derives `executedBuy` from the
-    /// clearing prices. A buy order does the reverse.
-    #[test]
-    fn new_derives_the_counterpart_leg_from_clearing_prices() {
-        let auction = domain::Auction {
-            id: domain::auction::Id::new(1).unwrap(),
-            orders: vec![
-                domain::Order {
-                    uid: OrderUid([0x11; 32]),
-                    side: domain::Side::Sell,
-                    ..order()
-                },
-                domain::Order {
-                    uid: OrderUid([0x22; 32]),
-                    side: domain::Side::Buy,
-                    ..order()
-                },
-            ],
-            deadline_slot: domain::Slot(1),
-            deadline: chrono::Utc::now(),
-        };
-        let solutions = vec![domain::Solution {
-            id: 0,
-            solver: Pubkey::new_from_array([0x33; 32]),
-            // Sell mint prices at the amount bought, buy mint at the amount sold.
-            prices: HashMap::from([
-                (Pubkey::new_from_array([0x33; 32]), 200),
-                (Pubkey::new_from_array([0x44; 32]), 100),
-            ]),
-            trades: vec![
-                domain::Trade {
-                    order_uid: OrderUid([0x11; 32]),
-                    executed_amount: 100,
-                },
-                domain::Trade {
-                    order_uid: OrderUid([0x22; 32]),
-                    executed_amount: 200,
-                },
-            ],
-            interactions: Vec::new(),
-            address_lookup_tables: Vec::new(),
-            cu_estimate: None,
-        }];
-
-        let response = SolveResponse::new(solutions, &auction);
-        let solution = &response.solutions[0];
-        assert_eq!(solution.score, 0, "score is stubbed to 0");
-        // Sell order: 100 sold, 100 * 200 / 100 = 200 bought.
-        assert_eq!(solution.orders[&OrderUid([0x11; 32])].executed_sell, 100);
-        assert_eq!(solution.orders[&OrderUid([0x11; 32])].executed_buy, 200);
-        // Buy order: 200 bought, 200 * 100 / 200 = 100 sold.
-        assert_eq!(solution.orders[&OrderUid([0x22; 32])].executed_sell, 100);
-        assert_eq!(solution.orders[&OrderUid([0x22; 32])].executed_buy, 200);
-    }
-
-    fn order() -> domain::Order {
-        domain::Order {
-            uid: OrderUid([0x11; 32]),
-            owner: Pubkey::new_from_array([0x22; 32]),
-            sell_token: Pubkey::new_from_array([0x33; 32]),
-            buy_token: Pubkey::new_from_array([0x44; 32]),
-            sell_token_account: Pubkey::new_from_array([0x55; 32]),
-            buy_token_account: Pubkey::new_from_array([0x66; 32]),
-            sell_amount: 1_000,
-            buy_amount: 2_000,
-            valid_to: 42,
-            side: domain::Side::Sell,
-            partially_fillable: false,
-            order_pda: Pubkey::new_from_array([0x77; 32]),
-        }
     }
 }

--- a/crates/solana-driver/src/infra/api/routes/solve/dto/solve_response.rs
+++ b/crates/solana-driver/src/infra/api/routes/solve/dto/solve_response.rs
@@ -26,7 +26,6 @@ pub struct SolveResponse {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Solution {
-    #[serde_as(as = "DisplayFromStr")]
     solution_id: u64,
     /// Total surplus in lamports, decimal string on the wire.
     #[serde_as(as = "DisplayFromStr")]
@@ -139,7 +138,7 @@ mod tests {
         };
         let expected = serde_json::json!({
             "solutions": [{
-                "solutionId": "3",
+                "solutionId": 3,
                 "score": "12345",
                 "solver": "3JF3sEqM796hk5WFqA6EtmEwJQ9quALszsfJyvXNQKy3",
                 "orders": {

--- a/crates/solana-driver/src/infra/api/routes/solve/dto/solve_response.rs
+++ b/crates/solana-driver/src/infra/api/routes/solve/dto/solve_response.rs
@@ -157,7 +157,7 @@ mod tests {
     #[test]
     fn new_fills_the_side_matching_amount() {
         let auction = domain::Auction {
-            id: domain::auction::Id(1),
+            id: domain::auction::Id::new(1).unwrap(),
             orders: vec![
                 domain::Order {
                     uid: OrderUid([0x11; 32]),

--- a/crates/solana-driver/src/infra/api/routes/solve/dto/solve_response.rs
+++ b/crates/solana-driver/src/infra/api/routes/solve/dto/solve_response.rs
@@ -1,0 +1,219 @@
+//! Outbound `/solve` response: the solutions the driver proposes to the
+//! autopilot.
+//!
+//! This is the driver's own mirror of `autopilot-svm`'s
+//! `infra/driver/dto.rs::SolveResponse`. The pinned-literal test below keeps
+//! the wire format in sync.
+
+use {
+    crate::domain::{self, order_uid::OrderUid},
+    serde::{Deserialize, Serialize},
+    serde_with::{DisplayFromStr, serde_as},
+    solana_sdk::pubkey::Pubkey,
+    std::collections::HashMap,
+};
+
+/// The driver's `/solve` answer.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SolveResponse {
+    solutions: Vec<Solution>,
+}
+
+/// One proposed solution: enough to rank it, detect order overlap between
+/// winners, and attribute its settlement on chain.
+#[serde_as]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Solution {
+    #[serde_as(as = "DisplayFromStr")]
+    solution_id: u64,
+    /// Total surplus in lamports, decimal string on the wire.
+    #[serde_as(as = "DisplayFromStr")]
+    score: u64,
+    /// The keypair the driver settles with, the on-chain solver identity.
+    #[serde_as(as = "DisplayFromStr")]
+    solver: Pubkey,
+    /// Executed amounts per filled order.
+    #[serde_as(as = "HashMap<DisplayFromStr, _>")]
+    orders: HashMap<OrderUid, TradedAmounts>,
+}
+
+/// What a solution executes for one order.
+#[serde_as]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TradedAmounts {
+    #[serde_as(as = "DisplayFromStr")]
+    executed_sell: u64,
+    #[serde_as(as = "DisplayFromStr")]
+    executed_buy: u64,
+}
+
+impl SolveResponse {
+    /// Build the wire response from the driver's domain solutions.
+    ///
+    /// `auction` supplies each order's side.
+    pub fn new(solutions: Vec<domain::Solution>, auction: &domain::Auction) -> Self {
+        let sides: HashMap<OrderUid, domain::Side> = auction
+            .orders
+            .iter()
+            .map(|order| (order.uid, order.side))
+            .collect();
+        Self {
+            solutions: solutions
+                .into_iter()
+                .map(|solution| Solution::new(solution, &sides))
+                .collect(),
+        }
+    }
+}
+
+impl Solution {
+    fn new(solution: domain::Solution, sides: &HashMap<OrderUid, domain::Side>) -> Self {
+        let orders = solution
+            .trades
+            .into_iter()
+            .map(|trade| {
+                // WARN: As of now, the engine implementation only reports one executed amount,
+                // on the order's own side.  We fill that side and leave the other side at 0 as
+                // a placeholder.
+                //
+                // TODO: the counterpart amount isn't on the engine wire yet, so the `0` below
+                // is knowingly wrong. The autopilot must not persist it or compute over it as
+                // if it were real. The driver will replace it once the engine wire carries both
+                // legs (or clearing prices arrive).
+                let side = sides.get(&trade.order_uid).copied().expect(
+                    "trade uid is known by construction: Solutions::into_domain rejects unknown \
+                     uids",
+                );
+                let (executed_sell, executed_buy) = match side {
+                    domain::Side::Sell => (trade.executed_amount, 0),
+                    domain::Side::Buy => (0, trade.executed_amount),
+                };
+                (
+                    trade.order_uid,
+                    TradedAmounts {
+                        executed_sell,
+                        executed_buy,
+                    },
+                )
+            })
+            .collect();
+        Self {
+            solution_id: solution.id,
+            // TODO: the driver stubs the score to 0 until surplus math is done, which needs both
+            // executed amounts and native price functionality.
+            score: 0,
+            solver: solution.solver,
+            orders,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pins the wire format against the same literals as
+    /// `autopilot-svm/src/infra/driver/dto.rs::tests`.
+    #[test]
+    fn solve_response_pins_the_wire_format() {
+        let solve = SolveResponse {
+            solutions: vec![Solution {
+                solution_id: 3,
+                score: 12_345,
+                solver: Pubkey::new_from_array([0x22; 32]),
+                orders: HashMap::from([(
+                    OrderUid([0x11; 32]),
+                    TradedAmounts {
+                        executed_sell: 100,
+                        executed_buy: 200,
+                    },
+                )]),
+            }],
+        };
+        let expected = serde_json::json!({
+            "solutions": [{
+                "solutionId": "3",
+                "score": "12345",
+                "solver": "3JF3sEqM796hk5WFqA6EtmEwJQ9quALszsfJyvXNQKy3",
+                "orders": {
+                    "0x1111111111111111111111111111111111111111111111111111111111111111": {
+                        "executedSell": "100",
+                        "executedBuy": "200"
+                    }
+                }
+            }]
+        });
+        assert_eq!(serde_json::to_value(&solve).unwrap(), expected);
+    }
+
+    /// A sell order fills `executedSell` and zero-fills `executedBuy`. A buy
+    /// order does the reverse. The zero is the placeholder.
+    ///
+    /// TODO: temporary — obsolete once the engine wire carries both legs (or
+    /// clearing prices arrive), at which point the zero placeholder goes away.
+    #[test]
+    fn new_fills_the_side_matching_amount() {
+        let auction = domain::Auction {
+            id: domain::auction::Id(1),
+            orders: vec![
+                domain::Order {
+                    uid: OrderUid([0x11; 32]),
+                    side: domain::Side::Sell,
+                    ..order()
+                },
+                domain::Order {
+                    uid: OrderUid([0x22; 32]),
+                    side: domain::Side::Buy,
+                    ..order()
+                },
+            ],
+            deadline_slot: domain::Slot(1),
+            deadline: chrono::Utc::now(),
+        };
+        let solutions = vec![domain::Solution {
+            id: 0,
+            solver: Pubkey::new_from_array([0x33; 32]),
+            trades: vec![
+                domain::Trade {
+                    order_uid: OrderUid([0x11; 32]),
+                    executed_amount: 100,
+                },
+                domain::Trade {
+                    order_uid: OrderUid([0x22; 32]),
+                    executed_amount: 200,
+                },
+            ],
+            interactions: Vec::new(),
+            address_lookup_tables: Vec::new(),
+            cu_estimate: None,
+        }];
+
+        let response = SolveResponse::new(solutions, &auction);
+        let solution = &response.solutions[0];
+        assert_eq!(solution.score, 0, "score is stubbed to 0 (D3)");
+        assert_eq!(solution.orders[&OrderUid([0x11; 32])].executed_sell, 100);
+        assert_eq!(solution.orders[&OrderUid([0x11; 32])].executed_buy, 0);
+        assert_eq!(solution.orders[&OrderUid([0x22; 32])].executed_sell, 0);
+        assert_eq!(solution.orders[&OrderUid([0x22; 32])].executed_buy, 200);
+    }
+
+    fn order() -> domain::Order {
+        domain::Order {
+            uid: OrderUid([0x11; 32]),
+            owner: Pubkey::new_from_array([0x22; 32]),
+            sell_token: Pubkey::new_from_array([0x33; 32]),
+            buy_token: Pubkey::new_from_array([0x44; 32]),
+            sell_token_account: Pubkey::new_from_array([0x55; 32]),
+            buy_token_account: Pubkey::new_from_array([0x66; 32]),
+            sell_amount: 1_000,
+            buy_amount: 2_000,
+            valid_to: 42,
+            side: domain::Side::Sell,
+            partially_fillable: false,
+            order_pda: Pubkey::new_from_array([0x77; 32]),
+        }
+    }
+}

--- a/crates/solana-driver/src/infra/api/routes/solve/dto/solve_response.rs
+++ b/crates/solana-driver/src/infra/api/routes/solve/dto/solve_response.rs
@@ -83,6 +83,10 @@ impl Solution {
                 // is knowingly wrong. The autopilot must not persist it or compute over it as
                 // if it were real. The driver will replace it once the engine wire carries both
                 // legs (or clearing prices arrive).
+                //
+                // TODO: once the engine wire carries both trade legs, `domain::Trade` will hold
+                // the side directly and this lookup (plus the `.expect`) goes
+                // away entirely.
                 let side = sides.get(&trade.order_uid).copied().expect(
                     "trade uid is known by construction: Solutions::into_domain rejects unknown \
                      uids",

--- a/crates/solana-driver/src/infra/api/routes/solve/dto/solve_response.rs
+++ b/crates/solana-driver/src/infra/api/routes/solve/dto/solve_response.rs
@@ -193,7 +193,7 @@ mod tests {
 
         let response = SolveResponse::new(solutions, &auction);
         let solution = &response.solutions[0];
-        assert_eq!(solution.score, 0, "score is stubbed to 0 (D3)");
+        assert_eq!(solution.score, 0, "score is stubbed to 0");
         assert_eq!(solution.orders[&OrderUid([0x11; 32])].executed_sell, 100);
         assert_eq!(solution.orders[&OrderUid([0x11; 32])].executed_buy, 0);
         assert_eq!(solution.orders[&OrderUid([0x22; 32])].executed_sell, 0);

--- a/crates/solana-driver/src/infra/api/routes/solve/mod.rs
+++ b/crates/solana-driver/src/infra/api/routes/solve/mod.rs
@@ -1,5 +1,24 @@
-use crate::infra::api::State;
+pub mod dto;
 
-pub async fn solve(_state: axum::extract::State<State>) -> axum::http::StatusCode {
-    axum::http::StatusCode::NOT_IMPLEMENTED
+pub use dto::AuctionError;
+use {
+    crate::infra::api::{State, error::Error as ApiError},
+    axum::{Json, http::StatusCode},
+    tracing::Instrument,
+};
+
+/// Handle `POST /solve`: parse the autopilot's auction, fan it out to the
+/// configured solver engines, and answer with the converted solutions.
+pub async fn solve(
+    state: axum::extract::State<State>,
+    Json(request): Json<dto::SolveRequest>,
+) -> Result<Json<dto::SolveResponse>, (StatusCode, Json<ApiError>)> {
+    let auction = request.into_domain()?;
+    let auction_id = auction.id;
+    let solutions = state
+        .competition()
+        .solve(&auction)
+        .instrument(tracing::info_span!("/solve", auction_id = %auction_id))
+        .await?;
+    Ok(Json(dto::SolveResponse::new(solutions, &auction)))
 }

--- a/crates/solana-driver/src/infra/api/routes/solve/mod.rs
+++ b/crates/solana-driver/src/infra/api/routes/solve/mod.rs
@@ -20,5 +20,5 @@ pub async fn solve(
         .solve(&auction)
         .instrument(tracing::info_span!("/solve", auction_id = %auction_id))
         .await?;
-    Ok(Json(dto::SolveResponse::new(solutions, &auction)))
+    Ok(Json(dto::SolveResponse::new(solutions)))
 }

--- a/crates/solana-driver/src/infra/api/routes/solve/mod.rs
+++ b/crates/solana-driver/src/infra/api/routes/solve/mod.rs
@@ -7,8 +7,8 @@ use {
     tracing::Instrument,
 };
 
-/// Handle `POST /solve`: parse the autopilot's auction, fan it out to the
-/// configured solver engines, and answer with the converted solutions.
+/// Handle `POST /solve`: parse the autopilot's auction, send it to this
+/// solver engine, and answer with the converted solutions.
 pub async fn solve(
     state: axum::extract::State<State>,
     Json(request): Json<dto::SolveRequest>,

--- a/crates/solana-driver/src/infra/solver/dto/auction.rs
+++ b/crates/solana-driver/src/infra/solver/dto/auction.rs
@@ -80,7 +80,7 @@ impl Auction {
     /// as its buy-side counterpart on the same premise.
     pub fn new(auction: &domain::Auction, taker: Pubkey) -> Self {
         Self {
-            id: auction.id.0,
+            id: auction.id.get(),
             taker,
             orders: auction
                 .orders

--- a/crates/solana-driver/src/infra/solver/dto/auction.rs
+++ b/crates/solana-driver/src/infra/solver/dto/auction.rs
@@ -52,13 +52,20 @@ impl Order {
     /// The `taker` is the solver that signs the settlement transaction; the
     /// driver derives `buy_destination` as its ATA for the buy mint on the same
     /// premise as the sell token.
+    ///
+    /// The engine wire carries a single `amount` on the order's side, so the
+    /// driver projects the side-matching amount (`sell_amount` for sells,
+    /// `buy_amount` for buys) from the full domain order.
     fn from_order_and_taker(order: &domain::Order, taker: Pubkey) -> Self {
         Self {
             uid: order.uid,
-            sell_mint: order.sell_mint,
-            buy_mint: order.buy_mint,
-            buy_destination: associated_token_address(&taker, &order.buy_mint),
-            amount: order.amount,
+            sell_mint: order.sell_token,
+            buy_mint: order.buy_token,
+            buy_destination: associated_token_address(&taker, &order.buy_token),
+            amount: match order.side {
+                Side::Sell => order.sell_amount,
+                Side::Buy => order.buy_amount,
+            },
             side: order.side,
         }
     }
@@ -73,7 +80,7 @@ impl Auction {
     /// as its buy-side counterpart on the same premise.
     pub fn new(auction: &domain::Auction, taker: Pubkey) -> Self {
         Self {
-            id: auction.id,
+            id: auction.id.0,
             taker,
             orders: auction
                 .orders

--- a/crates/solana-driver/src/infra/solver/dto/solution.rs
+++ b/crates/solana-driver/src/infra/solver/dto/solution.rs
@@ -3,14 +3,18 @@
 //! The wire format matches `solana-solvers/src/dto/solution.rs`.
 
 use {
-    crate::{domain, domain::order_uid::OrderUid, infra::solver::dto::auction::Auction},
+    crate::{
+        domain,
+        domain::{Side, order_uid::OrderUid},
+        infra::solver::dto::auction::{Auction, Order},
+    },
     serde::Deserialize,
     serde_with::serde_as,
     solana_sdk::{
         instruction::{AccountMeta as SdkAccountMeta, Instruction as SdkInstruction},
         pubkey::Pubkey,
     },
-    std::collections::HashMap,
+    std::{collections::HashMap, num::NonZero},
 };
 
 /// The solutions one engine returned for one auction. This wrapper owns the
@@ -33,7 +37,7 @@ pub struct Solution {
     /// currently only produces single-order solutions, so the pair is the
     /// executed swap's ratio.
     #[serde_as(as = "HashMap<serde_with::DisplayFromStr, serde_with::DisplayFromStr>")]
-    pub prices: HashMap<Pubkey, u64>,
+    pub prices: HashMap<Pubkey, NonZero<u64>>,
     pub trades: Vec<Trade>,
     pub interactions: Vec<Instruction>,
     /// Optional solver estimate of total settlement compute units.
@@ -56,6 +60,57 @@ pub struct Trade {
     /// Sell-token units for sell orders, buy-token units for buy orders.
     #[serde_as(as = "serde_with::DisplayFromStr")]
     pub executed_amount: u64,
+}
+
+impl Trade {
+    /// Convert this wire trade into a domain trade, deriving the counterpart
+    /// leg from the clearing prices.
+    fn into_domain(
+        self,
+        order: &Order,
+        price_sell: NonZero<u64>,
+        price_buy: NonZero<u64>,
+    ) -> Result<domain::Trade, Error> {
+        if self.executed_amount > order.amount {
+            return Err(Error::ExecutedAmountExceedsOrderAmount(
+                self.order_uid,
+                self.executed_amount,
+                order.amount,
+            ));
+        }
+
+        // The engine reports one executed amount, on the order's own side, plus
+        // uniform clearing prices per mint. Derive the counterpart leg from the
+        // prices so the domain trade carries a real amount on both sides.
+        let counterpart = match order.side {
+            Side::Sell => Self::counterpart(self.executed_amount, price_sell, price_buy),
+            Side::Buy => Self::counterpart(self.executed_amount, price_buy, price_sell),
+        }
+        .ok_or(Error::InvalidClearingPrice(self.order_uid))?;
+
+        let (executed_sell, executed_buy) = match order.side {
+            Side::Sell => (self.executed_amount, counterpart),
+            Side::Buy => (counterpart, self.executed_amount),
+        };
+
+        Ok(domain::Trade {
+            order_uid: self.order_uid,
+            executed_sell,
+            executed_buy,
+        })
+    }
+
+    /// Derive the counterpart leg from the executed amount and the two clearing
+    /// prices. Both prices are `NonZero`, and the u128 product and quotient
+    /// always fit, so only the shrink back to u64 can fail.
+    fn counterpart(
+        executed: u64,
+        price_own: NonZero<u64>,
+        price_other: NonZero<u64>,
+    ) -> Option<u64> {
+        u64::try_from((executed as u128) * (price_own.get() as u128) / (price_other.get() as u128))
+            .ok()
+    }
 }
 
 /// A Solana instruction the solver supplies, carried verbatim.
@@ -109,6 +164,12 @@ pub enum Error {
     /// A trade executes more than the order amount.
     #[error("trade {0} executes {1} but order amount is {2}")]
     ExecutedAmountExceedsOrderAmount(OrderUid, u64, u64),
+    /// The engine did not report a clearing price for a mint a trade touches.
+    #[error("trade {0} has no clearing price for mint {1}")]
+    MissingClearingPrice(OrderUid, Pubkey),
+    /// The clearing prices do not yield a valid counterpart amount.
+    #[error("trade {0} has invalid clearing prices")]
+    InvalidClearingPrice(OrderUid),
 }
 
 impl Solutions {
@@ -122,42 +183,46 @@ impl Solutions {
         auction: &Auction,
         solver: Pubkey,
     ) -> Result<Vec<domain::Solution>, Error> {
-        let allowed_orders: HashMap<OrderUid, u64> =
-            auction.orders.iter().map(|o| (o.uid, o.amount)).collect();
+        let allowed_orders: HashMap<OrderUid, &Order> =
+            auction.orders.iter().map(|o| (o.uid, o)).collect();
 
         self.solutions
             .into_iter()
             .map(|solution| {
-                let trades = solution
-                    .trades
+                let Solution {
+                    id,
+                    prices,
+                    trades,
+                    interactions,
+                    cu_estimate,
+                    address_lookup_tables,
+                } = solution;
+                let trades = trades
                     .into_iter()
                     .map(|trade| {
-                        let amount = match allowed_orders.get(&trade.order_uid) {
-                            Some(&amount) => amount,
-                            None => return Err(Error::UnknownOrderUid(trade.order_uid)),
-                        };
-                        if trade.executed_amount > amount {
-                            return Err(Error::ExecutedAmountExceedsOrderAmount(
-                                trade.order_uid,
-                                trade.executed_amount,
-                                amount,
-                            ));
-                        }
-                        Ok(domain::Trade {
-                            order_uid: trade.order_uid,
-                            executed_amount: trade.executed_amount,
-                        })
+                        let order = allowed_orders
+                            .get(&trade.order_uid)
+                            .copied()
+                            .ok_or(Error::UnknownOrderUid(trade.order_uid))?;
+                        let price_sell = prices.get(&order.sell_mint).copied().ok_or(
+                            Error::MissingClearingPrice(trade.order_uid, order.sell_mint),
+                        )?;
+                        let price_buy = prices
+                            .get(&order.buy_mint)
+                            .copied()
+                            .ok_or(Error::MissingClearingPrice(trade.order_uid, order.buy_mint))?;
+                        trade.into_domain(order, price_sell, price_buy)
                     })
                     .collect::<Result<_, _>>()?;
 
                 Ok(domain::Solution {
-                    id: solution.id,
+                    id,
                     solver,
-                    prices: solution.prices,
+                    prices,
                     trades,
-                    interactions: solution.interactions.into_iter().map(Into::into).collect(),
-                    address_lookup_tables: solution.address_lookup_tables,
-                    cu_estimate: solution.cu_estimate,
+                    interactions: interactions.into_iter().map(Into::into).collect(),
+                    address_lookup_tables,
+                    cu_estimate,
                 })
             })
             .collect()
@@ -175,6 +240,10 @@ mod tests {
 
     fn pubkey(byte: u8) -> Pubkey {
         Pubkey::new_from_array([byte; 32])
+    }
+
+    fn nz(value: u64) -> NonZero<u64> {
+        NonZero::new(value).unwrap()
     }
 
     fn sample_auction_dto() -> Auction {
@@ -244,6 +313,119 @@ mod tests {
         assert_eq!(err, Error::UnknownOrderUid(OrderUid([0xff; 32])));
     }
 
+    /// A sell order fills `executed_sell` and derives `executed_buy` from the
+    /// clearing prices. A buy order does the reverse.
+    #[test]
+    fn derives_both_legs_from_clearing_prices() {
+        let solutions = Solutions {
+            solutions: vec![Solution {
+                id: 1,
+                prices: HashMap::from([(pubkey(1), nz(2_000)), (pubkey(2), nz(1_000))]),
+                trades: vec![Trade {
+                    order_uid: OrderUid([8; 32]),
+                    executed_amount: 1_000,
+                }],
+                interactions: vec![],
+                cu_estimate: None,
+                address_lookup_tables: vec![],
+            }],
+        };
+        let domain = solutions
+            .into_domain(&sample_auction_dto(), pubkey(6))
+            .unwrap();
+        let trade = &domain[0].trades[0];
+        // Sell order: 1000 sold, 1000 * 2000 / 1000 = 2000 bought.
+        assert_eq!(trade.executed_sell, 1_000);
+        assert_eq!(trade.executed_buy, 2_000);
+    }
+
+    /// A trade whose mint has no clearing price rejects the whole response.
+    #[test]
+    fn rejects_missing_clearing_price() {
+        let solutions = Solutions {
+            solutions: vec![Solution {
+                id: 1,
+                prices: HashMap::from([(pubkey(1), nz(2_000))]),
+                trades: vec![Trade {
+                    order_uid: OrderUid([8; 32]),
+                    executed_amount: 1_000,
+                }],
+                interactions: vec![],
+                cu_estimate: None,
+                address_lookup_tables: vec![],
+            }],
+        };
+        let err = solutions
+            .into_domain(&sample_auction_dto(), pubkey(6))
+            .unwrap_err();
+        assert_eq!(
+            err,
+            Error::MissingClearingPrice(OrderUid([8; 32]), pubkey(2))
+        );
+    }
+
+    /// The intermediate product of two u64s can overflow u64 even when the
+    /// final result fits back in u64; the u128 math must still succeed.
+    #[test]
+    fn derives_counterpart_that_overflows_u64_product() {
+        let auction = Auction {
+            id: 1,
+            taker: pubkey(3),
+            orders: vec![Order {
+                uid: OrderUid([8; 32]),
+                sell_mint: pubkey(1),
+                buy_mint: pubkey(2),
+                buy_destination: util::associated_token_address(&pubkey(3), &pubkey(2)),
+                amount: u64::MAX,
+                side: Side::Sell,
+            }],
+            deadline: chrono::Utc::now() + chrono::Duration::seconds(60),
+        };
+        let solutions = Solutions {
+            solutions: vec![Solution {
+                id: 1,
+                // price_sell = 2, price_buy = 2: u64::MAX * 2 overflows u64 but
+                // fits in u128, and / 2 lands back on u64::MAX.
+                prices: HashMap::from([(pubkey(1), nz(2)), (pubkey(2), nz(2))]),
+                trades: vec![Trade {
+                    order_uid: OrderUid([8; 32]),
+                    executed_amount: u64::MAX,
+                }],
+                interactions: vec![],
+                cu_estimate: None,
+                address_lookup_tables: vec![],
+            }],
+        };
+        let domain = solutions.into_domain(&auction, pubkey(6)).unwrap();
+        let trade = &domain[0].trades[0];
+        assert_eq!(trade.executed_sell, u64::MAX);
+        assert_eq!(trade.executed_buy, u64::MAX);
+    }
+
+    /// A zero clearing price is invalid: it would settle a leg against
+    /// nothing, so the whole response fails to parse.
+    #[test]
+    fn rejects_zero_clearing_price() {
+        let bad = json!({
+            "solutions": [{
+                "id": 1,
+                "prices": {
+                    (pubkey(1).to_string()): "0",
+                    (pubkey(2).to_string()): "1000",
+                },
+                "trades": [{
+                    "orderUid": format!("0x{}", "08".repeat(32)),
+                    "executedAmount": "1000",
+                }],
+                "interactions": [],
+            }],
+        });
+        assert!(
+            serde_json::from_value::<Solutions>(bad).is_err(),
+            "a zero clearing price must be rejected at parse time"
+        );
+    }
+
     /// Pins the inbound `/solve` response shape against the literal the
     /// `solana-solvers` `Solution` serializes.
     #[test]
@@ -275,7 +457,7 @@ mod tests {
         let expected = Solutions {
             solutions: vec![Solution {
                 id: 1,
-                prices: HashMap::from([(pubkey(1), 2_000), (pubkey(2), 1_000)]),
+                prices: HashMap::from([(pubkey(1), nz(2_000)), (pubkey(2), nz(1_000))]),
                 trades: vec![Trade {
                     order_uid: OrderUid([8; 32]),
                     executed_amount: 1_000,

--- a/crates/solana-driver/src/infra/solver/dto/solution.rs
+++ b/crates/solana-driver/src/infra/solver/dto/solution.rs
@@ -27,6 +27,13 @@ pub struct Solutions {
 #[serde(rename_all = "camelCase")]
 pub struct Solution {
     pub id: u64,
+    /// Uniform clearing prices by mint: the sell mint maps to the amount
+    /// bought and the buy mint to the amount sold, so for every trade
+    /// `executed_sell * price_sell == executed_buy * price_buy`. The engine
+    /// currently only produces single-order solutions, so the pair is the
+    /// executed swap's ratio.
+    #[serde_as(as = "HashMap<serde_with::DisplayFromStr, serde_with::DisplayFromStr>")]
+    pub prices: HashMap<Pubkey, u64>,
     pub trades: Vec<Trade>,
     pub interactions: Vec<Instruction>,
     /// Optional solver estimate of total settlement compute units.
@@ -146,6 +153,7 @@ impl Solutions {
                 Ok(domain::Solution {
                     id: solution.id,
                     solver,
+                    prices: solution.prices,
                     trades,
                     interactions: solution.interactions.into_iter().map(Into::into).collect(),
                     address_lookup_tables: solution.address_lookup_tables,
@@ -190,6 +198,10 @@ mod tests {
         let bad = json!({
             "solutions": [{
                 "id": 1,
+                "prices": {
+                    (pubkey(1).to_string()): "2000",
+                    (pubkey(2).to_string()): "1000",
+                },
                 "trades": [{
                     "orderUid": format!("0x{}", "08".repeat(32)),
                     "executedAmount": "1001",
@@ -213,6 +225,10 @@ mod tests {
         let bad = json!({
             "solutions": [{
                 "id": 1,
+                "prices": {
+                    (pubkey(1).to_string()): "2000",
+                    (pubkey(2).to_string()): "1000",
+                },
                 "trades": [{
                     "orderUid": format!("0x{}", "ff".repeat(32)),
                     "executedAmount": "1000",
@@ -235,6 +251,10 @@ mod tests {
         let json = json!({
             "solutions": [{
                 "id": 1,
+                "prices": {
+                    (pubkey(1).to_string()): "2000",
+                    (pubkey(2).to_string()): "1000",
+                },
                 "trades": [{
                     "orderUid": format!("0x{}", "08".repeat(32)),
                     "executedAmount": "1000",
@@ -255,6 +275,7 @@ mod tests {
         let expected = Solutions {
             solutions: vec![Solution {
                 id: 1,
+                prices: HashMap::from([(pubkey(1), 2_000), (pubkey(2), 1_000)]),
                 trades: vec![Trade {
                     order_uid: OrderUid([8; 32]),
                     executed_amount: 1_000,

--- a/crates/solana-driver/src/infra/solver/mod.rs
+++ b/crates/solana-driver/src/infra/solver/mod.rs
@@ -141,7 +141,7 @@ mod tests {
             max_in_flight: NonZero::new(1).unwrap(),
         });
         let auction = domain::Auction {
-            id: domain::Id(1),
+            id: domain::Id::new(1).unwrap(),
             orders: Vec::new(),
             deadline_slot: domain::Slot(1),
             // Well in the past: the request must be skipped entirely.

--- a/crates/solana-driver/src/infra/solver/mod.rs
+++ b/crates/solana-driver/src/infra/solver/mod.rs
@@ -28,6 +28,11 @@ pub struct Solver {
 }
 
 impl Solver {
+    /// The human-readable name of this solver, for logs and metrics.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
     /// Build a solver client from its configuration.
     pub fn new(config: &config::Solver) -> Self {
         Self {
@@ -136,8 +141,9 @@ mod tests {
             max_in_flight: NonZero::new(1).unwrap(),
         });
         let auction = domain::Auction {
-            id: 0,
+            id: domain::Id(1),
             orders: Vec::new(),
+            deadline_slot: domain::Slot(1),
             // Well in the past: the request must be skipped entirely.
             deadline: chrono::Utc::now() - chrono::Duration::seconds(10),
         };

--- a/crates/solana-driver/src/run.rs
+++ b/crates/solana-driver/src/run.rs
@@ -1,13 +1,10 @@
 //! Driver entry-point logic.
 
 use {
-    crate::{
-        domain,
-        infra::{Api, config, observe as infra_observe, solver},
-    },
+    crate::infra::{Api, config, observe as infra_observe, solver},
     clap::Parser,
     cow_solana_rpc::{CommitmentConfig, SolanaRPC},
-    std::{path::PathBuf, time::Duration},
+    std::{path::PathBuf, sync::Arc, time::Duration},
 };
 
 /// The Solana driver command line arguments.
@@ -38,17 +35,16 @@ pub async fn run(args: Args) {
     }
 
     let shutdown_token = tokio_util::sync::CancellationToken::new();
-    let rpc = SolanaRPC::new_with_timeout_and_commitment(
+    let rpc = Arc::new(SolanaRPC::new_with_timeout_and_commitment(
         &config.rpc.endpoint,
         config.rpc.request_timeout,
         CommitmentConfig::confirmed(),
-    );
+    ));
     let solvers: Vec<solver::Solver> = config.solvers.iter().map(solver::Solver::new).collect();
-    let competition = domain::Competition::new(solvers);
     let api = Api {
         addr: config.http.bind_address,
         rpc,
-        competition,
+        solvers,
     };
     let (listener, _addr) = api.bind().await.expect("failed to bind HTTP server");
     let serve = api.serve(listener, shutdown_token.clone());

--- a/crates/solana-driver/src/run.rs
+++ b/crates/solana-driver/src/run.rs
@@ -1,7 +1,10 @@
 //! Driver entry-point logic.
 
 use {
-    crate::infra::{Api, config, observe as infra_observe, solver},
+    crate::{
+        domain,
+        infra::{Api, config, observe as infra_observe, solver},
+    },
     clap::Parser,
     cow_solana_rpc::{CommitmentConfig, SolanaRPC},
     std::{path::PathBuf, time::Duration},
@@ -41,10 +44,11 @@ pub async fn run(args: Args) {
         CommitmentConfig::confirmed(),
     );
     let solvers: Vec<solver::Solver> = config.solvers.iter().map(solver::Solver::new).collect();
+    let competition = domain::Competition::new(solvers);
     let api = Api {
         addr: config.http.bind_address,
         rpc,
-        solvers,
+        competition,
     };
     let (listener, _addr) = api.bind().await.expect("failed to bind HTTP server");
     let serve = api.serve(listener, shutdown_token.clone());

--- a/crates/solana-driver/tests/api.rs
+++ b/crates/solana-driver/tests/api.rs
@@ -124,6 +124,10 @@ async fn solve_returns_converted_solutions() {
     let engine = spawn_mock_solver_engine(serde_json::json!({
         "solutions": [{
             "id": 42,
+            "prices": {
+                (pubkey(0x33).to_string()): "2000",
+                (pubkey(0x44).to_string()): "1000",
+            },
             "trades": [{
                 "orderUid": uid(),
                 "executedAmount": "1000",
@@ -143,8 +147,8 @@ async fn solve_returns_converted_solutions() {
     assert_eq!(response.status(), reqwest::StatusCode::OK);
 
     let json: serde_json::Value = response.json().await.unwrap();
-    // The sell order's side-matching amount fills `executedSell` while
-    // `executedBuy` is the zero placeholder.
+    // The sell order's side-matching amount fills `executedSell` and the
+    // counterpart leg is derived from the clearing prices.
     let expected = serde_json::json!({
         "solutions": [{
             "solutionId": 42,
@@ -153,7 +157,7 @@ async fn solve_returns_converted_solutions() {
             "orders": {
                 (uid()): {
                     "executedSell": "1000",
-                    "executedBuy": "0",
+                    "executedBuy": "2000",
                 }
             }
         }]

--- a/crates/solana-driver/tests/api.rs
+++ b/crates/solana-driver/tests/api.rs
@@ -143,7 +143,7 @@ async fn solve_returns_converted_solutions() {
     // `executedBuy` is the zero placeholder.
     let expected = serde_json::json!({
         "solutions": [{
-            "solutionId": "42",
+            "solutionId": 42,
             "score": "0",
             "solver": account.to_string(),
             "orders": {

--- a/crates/solana-driver/tests/api.rs
+++ b/crates/solana-driver/tests/api.rs
@@ -185,7 +185,9 @@ async fn settle_rejects_non_positive_auction_id() {
 
     let response = reqwest::Client::new()
         .post(format!("http://{addr}/mock/settle"))
-        .json(&serde_json::json!({ "auctionId": 0, "solutionId": 3, "submissionDeadlineSlot": 125 }))
+        .json(
+            &serde_json::json!({ "auctionId": 0, "solutionId": 3, "submissionDeadlineSlot": 125 }),
+        )
         .send()
         .await
         .unwrap();

--- a/crates/solana-driver/tests/api.rs
+++ b/crates/solana-driver/tests/api.rs
@@ -2,32 +2,92 @@
 
 use {
     cow_solana_rpc::SolanaRPC,
-    solana_driver::infra::api::Api,
-    std::net::SocketAddr,
+    solana_driver::{
+        domain::Competition,
+        infra::{api::Api, config, solver::Solver},
+    },
+    solana_sdk::pubkey::Pubkey,
+    std::{net::SocketAddr, num::NonZero},
     tokio_util::sync::CancellationToken,
 };
 
-fn mock_api() -> Api {
+fn pubkey(byte: u8) -> Pubkey {
+    Pubkey::new_from_array([byte; 32])
+}
+
+/// The autopilot's own literal order uid (32 bytes of `0x11`).
+fn uid() -> String {
+    format!("0x{}", "11".repeat(32))
+}
+
+fn api_with(competition: Competition) -> Api {
     Api {
         addr: "0.0.0.0:0".parse().unwrap(),
         rpc: SolanaRPC::new_mock("succeeds".to_string()),
-        solvers: Vec::new(),
+        competition,
     }
 }
 
 /// Spawn the API server on an ephemeral port and return its bound address.
-async fn spawn_server() -> SocketAddr {
-    let api = mock_api();
+async fn spawn_server(competition: Competition) -> SocketAddr {
+    let api = api_with(competition);
     let (listener, addr) = api.bind().await.unwrap();
-    // A token that is never cancelled keeps the server alive for the test.
+    // The test never cancels this token, so the server stays alive.
     let shutdown = CancellationToken::new();
     tokio::spawn(async move { api.serve(listener, shutdown).await.unwrap() });
     addr
 }
 
+/// A tiny axum server that returns a fixed `/solve` response. It stands in
+/// for a solver engine.
+async fn spawn_mock_solver_engine(response: serde_json::Value) -> SocketAddr {
+    let app = axum::Router::new().route(
+        "/solve",
+        axum::routing::post(move || {
+            let response = response.clone();
+            async move { axum::Json(response) }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    addr
+}
+
+fn solver(addr: SocketAddr, account: Pubkey) -> Solver {
+    Solver::new(&config::Solver {
+        name: "mock".to_owned(),
+        endpoint: format!("http://{addr}").parse().unwrap(),
+        account,
+        max_in_flight: NonZero::new(1).unwrap(),
+    })
+}
+
+/// The autopilot's own literal `/solve` request JSON.
+fn solve_request() -> serde_json::Value {
+    serde_json::json!({
+        "id": "7",
+        "deadlineSlot": "100",
+        "orders": [{
+            "uid": uid(),
+            "owner": pubkey(0x22).to_string(),
+            "sellToken": pubkey(0x33).to_string(),
+            "buyToken": pubkey(0x44).to_string(),
+            "sellTokenAccount": pubkey(0x55).to_string(),
+            "buyTokenAccount": pubkey(0x66).to_string(),
+            "sellAmount": "18446744073709551615",
+            "buyAmount": "2000",
+            "validTo": 42,
+            "kind": "sell",
+            "partiallyFillable": false,
+            "orderPda": pubkey(0x77).to_string(),
+        }]
+    })
+}
+
 #[tokio::test]
 async fn healthz_returns_200() {
-    let addr = spawn_server().await;
+    let addr = spawn_server(Competition::new(Vec::new())).await;
     let response = reqwest::Client::new()
         .get(format!("http://{addr}/healthz"))
         .send()
@@ -38,7 +98,7 @@ async fn healthz_returns_200() {
 
 #[tokio::test]
 async fn shuts_down_cleanly_on_signal() {
-    let api = mock_api();
+    let api = api_with(Competition::new(Vec::new()));
     let (listener, addr) = api.bind().await.unwrap();
     let shutdown_token = CancellationToken::new();
     let serve = api.serve(listener, shutdown_token.clone());
@@ -55,4 +115,189 @@ async fn shuts_down_cleanly_on_signal() {
     // Trigger graceful shutdown and assert the serve future completes cleanly.
     shutdown_token.cancel();
     handle.await.unwrap();
+}
+
+#[tokio::test]
+async fn solve_returns_converted_solutions() {
+    let account = pubkey(0x99);
+    let engine = spawn_mock_solver_engine(serde_json::json!({
+        "solutions": [{
+            "id": 42,
+            "trades": [{
+                "orderUid": uid(),
+                "executedAmount": "1000",
+            }],
+            "interactions": [],
+        }]
+    }))
+    .await;
+    let addr = spawn_server(Competition::new(vec![solver(engine, account)])).await;
+
+    let response = reqwest::Client::new()
+        .post(format!("http://{addr}/solve"))
+        .json(&solve_request())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+    let json: serde_json::Value = response.json().await.unwrap();
+    // The engine's id (42) is reindexed to 0, and the sell order's
+    // side-matching amount fills `executedSell` while `executedBuy` is the
+    // zero placeholder.
+    let expected = serde_json::json!({
+        "solutions": [{
+            "solutionId": "0",
+            "score": "0",
+            "solver": account.to_string(),
+            "orders": {
+                (uid()): {
+                    "executedSell": "1000",
+                    "executedBuy": "0",
+                }
+            }
+        }]
+    });
+    assert_eq!(json, expected);
+}
+
+#[tokio::test]
+async fn solve_reindexes_colliding_engine_ids() {
+    // Two engines both return a solution with the same engine-local id. The
+    // driver reindexes them to driver-unique ids so the autopilot can address
+    // each solution by (auction_id, solution_id) without collision.
+    let account1 = pubkey(0x99);
+    let account2 = pubkey(0x88);
+    let engine1 = spawn_mock_solver_engine(serde_json::json!({
+        "solutions": [{
+            "id": 0,
+            "trades": [{
+                "orderUid": uid(),
+                "executedAmount": "1000",
+            }],
+            "interactions": [],
+        }]
+    }))
+    .await;
+    let engine2 = spawn_mock_solver_engine(serde_json::json!({
+        "solutions": [{
+            "id": 0,
+            "trades": [{
+                "orderUid": uid(),
+                "executedAmount": "500",
+            }],
+            "interactions": [],
+        }]
+    }))
+    .await;
+    let addr = spawn_server(Competition::new(vec![
+        solver(engine1, account1),
+        solver(engine2, account2),
+    ]))
+    .await;
+
+    let response = reqwest::Client::new()
+        .post(format!("http://{addr}/solve"))
+        .json(&solve_request())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+    let json: serde_json::Value = response.json().await.unwrap();
+    let expected = serde_json::json!({
+        "solutions": [
+            {
+                "solutionId": "0",
+                "score": "0",
+                "solver": account1.to_string(),
+                "orders": {
+                    (uid()): {
+                        "executedSell": "1000",
+                        "executedBuy": "0",
+                    }
+                }
+            },
+            {
+                "solutionId": "1",
+                "score": "0",
+                "solver": account2.to_string(),
+                "orders": {
+                    (uid()): {
+                        "executedSell": "500",
+                        "executedBuy": "0",
+                    }
+                }
+            }
+        ]
+    });
+    assert_eq!(json, expected);
+}
+
+#[tokio::test]
+async fn solve_with_engine_down_returns_solver_failed() {
+    // Point the solver at a port with no listener.
+    let dead = solver("127.0.0.1:1".parse().unwrap(), pubkey(0x99));
+    let addr = spawn_server(Competition::new(vec![dead])).await;
+
+    let response = reqwest::Client::new()
+        .post(format!("http://{addr}/solve"))
+        .json(&solve_request())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), reqwest::StatusCode::BAD_REQUEST);
+
+    let json: serde_json::Value = response.json().await.unwrap();
+    assert_eq!(json["kind"], "SolverFailed");
+}
+
+#[tokio::test]
+async fn solve_with_partial_engine_failure_returns_successful_solutions() {
+    // One engine returns a solution, the other is down. The failing engine
+    // must not kill the auction: the driver returns the successful engine's
+    // solution.
+    let account = pubkey(0x99);
+    let engine = spawn_mock_solver_engine(serde_json::json!({
+        "solutions": [{
+            "id": 0,
+            "trades": [{
+                "orderUid": uid(),
+                "executedAmount": "1000",
+            }],
+            "interactions": [],
+        }]
+    }))
+    .await;
+    let dead = solver("127.0.0.1:1".parse().unwrap(), pubkey(0x88));
+    let addr = spawn_server(Competition::new(vec![solver(engine, account), dead])).await;
+
+    let response = reqwest::Client::new()
+        .post(format!("http://{addr}/solve"))
+        .json(&solve_request())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), reqwest::StatusCode::OK);
+
+    let json: serde_json::Value = response.json().await.unwrap();
+    let solutions = json["solutions"].as_array().unwrap();
+    assert_eq!(solutions.len(), 1);
+    assert_eq!(solutions[0]["solutionId"], "0");
+}
+
+#[tokio::test]
+async fn settle_rejects_non_positive_auction_id() {
+    let addr = spawn_server(Competition::new(Vec::new())).await;
+
+    let response = reqwest::Client::new()
+        .post(format!("http://{addr}/settle"))
+        .json(&serde_json::json!({ "auctionId": "0", "solutionId": "3" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), reqwest::StatusCode::BAD_REQUEST);
+
+    let json: serde_json::Value = response.json().await.unwrap();
+    assert_eq!(json["kind"], "InvalidAuctionId");
 }

--- a/crates/solana-driver/tests/api.rs
+++ b/crates/solana-driver/tests/api.rs
@@ -61,10 +61,14 @@ fn solver(addr: SocketAddr, account: Pubkey) -> Solver {
 }
 
 /// The autopilot's own literal `/solve` request JSON.
+///
+/// The deadline is computed relative to now so the request is always
+/// solvable, regardless of when the test runs.
 fn solve_request() -> serde_json::Value {
+    let deadline = chrono::Utc::now() + chrono::Duration::minutes(5);
     serde_json::json!({
         "id": 7,
-        "deadline": "2026-01-01T00:00:00Z",
+        "deadline": deadline.to_rfc3339(),
         "orders": [{
             "uid": uid(),
             "owner": pubkey(0x22).to_string(),

--- a/crates/solana-driver/tests/api.rs
+++ b/crates/solana-driver/tests/api.rs
@@ -2,12 +2,9 @@
 
 use {
     cow_solana_rpc::SolanaRPC,
-    solana_driver::{
-        domain::Competition,
-        infra::{api::Api, config, solver::Solver},
-    },
+    solana_driver::infra::{api::Api, config, solver::Solver},
     solana_sdk::pubkey::Pubkey,
-    std::{net::SocketAddr, num::NonZero},
+    std::{net::SocketAddr, num::NonZero, sync::Arc},
     tokio_util::sync::CancellationToken,
 };
 
@@ -20,17 +17,17 @@ fn uid() -> String {
     format!("0x{}", "11".repeat(32))
 }
 
-fn api_with(competition: Competition) -> Api {
+fn api_with(solvers: Vec<Solver>) -> Api {
     Api {
         addr: "0.0.0.0:0".parse().unwrap(),
-        rpc: SolanaRPC::new_mock("succeeds".to_string()),
-        competition,
+        rpc: Arc::new(SolanaRPC::new_mock("succeeds".to_string())),
+        solvers,
     }
 }
 
 /// Spawn the API server on an ephemeral port and return its bound address.
-async fn spawn_server(competition: Competition) -> SocketAddr {
-    let api = api_with(competition);
+async fn spawn_server(solvers: Vec<Solver>) -> SocketAddr {
+    let api = api_with(solvers);
     let (listener, addr) = api.bind().await.unwrap();
     // The test never cancels this token, so the server stays alive.
     let shutdown = CancellationToken::new();
@@ -87,7 +84,7 @@ fn solve_request() -> serde_json::Value {
 
 #[tokio::test]
 async fn healthz_returns_200() {
-    let addr = spawn_server(Competition::new(Vec::new())).await;
+    let addr = spawn_server(Vec::new()).await;
     let response = reqwest::Client::new()
         .get(format!("http://{addr}/healthz"))
         .send()
@@ -98,7 +95,7 @@ async fn healthz_returns_200() {
 
 #[tokio::test]
 async fn shuts_down_cleanly_on_signal() {
-    let api = api_with(Competition::new(Vec::new()));
+    let api = api_with(Vec::new());
     let (listener, addr) = api.bind().await.unwrap();
     let shutdown_token = CancellationToken::new();
     let serve = api.serve(listener, shutdown_token.clone());
@@ -131,10 +128,10 @@ async fn solve_returns_converted_solutions() {
         }]
     }))
     .await;
-    let addr = spawn_server(Competition::new(vec![solver(engine, account)])).await;
+    let addr = spawn_server(vec![solver(engine, account)]).await;
 
     let response = reqwest::Client::new()
-        .post(format!("http://{addr}/solve"))
+        .post(format!("http://{addr}/mock/solve"))
         .json(&solve_request())
         .send()
         .await
@@ -142,12 +139,11 @@ async fn solve_returns_converted_solutions() {
     assert_eq!(response.status(), reqwest::StatusCode::OK);
 
     let json: serde_json::Value = response.json().await.unwrap();
-    // The engine's id (42) is reindexed to 0, and the sell order's
-    // side-matching amount fills `executedSell` while `executedBuy` is the
-    // zero placeholder.
+    // The sell order's side-matching amount fills `executedSell` while
+    // `executedBuy` is the zero placeholder.
     let expected = serde_json::json!({
         "solutions": [{
-            "solutionId": "0",
+            "solutionId": "42",
             "score": "0",
             "solver": account.to_string(),
             "orders": {
@@ -162,86 +158,13 @@ async fn solve_returns_converted_solutions() {
 }
 
 #[tokio::test]
-async fn solve_reindexes_colliding_engine_ids() {
-    // Two engines both return a solution with the same engine-local id. The
-    // driver reindexes them to driver-unique ids so the autopilot can address
-    // each solution by (auction_id, solution_id) without collision.
-    let account1 = pubkey(0x99);
-    let account2 = pubkey(0x88);
-    let engine1 = spawn_mock_solver_engine(serde_json::json!({
-        "solutions": [{
-            "id": 0,
-            "trades": [{
-                "orderUid": uid(),
-                "executedAmount": "1000",
-            }],
-            "interactions": [],
-        }]
-    }))
-    .await;
-    let engine2 = spawn_mock_solver_engine(serde_json::json!({
-        "solutions": [{
-            "id": 0,
-            "trades": [{
-                "orderUid": uid(),
-                "executedAmount": "500",
-            }],
-            "interactions": [],
-        }]
-    }))
-    .await;
-    let addr = spawn_server(Competition::new(vec![
-        solver(engine1, account1),
-        solver(engine2, account2),
-    ]))
-    .await;
-
-    let response = reqwest::Client::new()
-        .post(format!("http://{addr}/solve"))
-        .json(&solve_request())
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(response.status(), reqwest::StatusCode::OK);
-
-    let json: serde_json::Value = response.json().await.unwrap();
-    let expected = serde_json::json!({
-        "solutions": [
-            {
-                "solutionId": "0",
-                "score": "0",
-                "solver": account1.to_string(),
-                "orders": {
-                    (uid()): {
-                        "executedSell": "1000",
-                        "executedBuy": "0",
-                    }
-                }
-            },
-            {
-                "solutionId": "1",
-                "score": "0",
-                "solver": account2.to_string(),
-                "orders": {
-                    (uid()): {
-                        "executedSell": "500",
-                        "executedBuy": "0",
-                    }
-                }
-            }
-        ]
-    });
-    assert_eq!(json, expected);
-}
-
-#[tokio::test]
 async fn solve_with_engine_down_returns_solver_failed() {
     // Point the solver at a port with no listener.
     let dead = solver("127.0.0.1:1".parse().unwrap(), pubkey(0x99));
-    let addr = spawn_server(Competition::new(vec![dead])).await;
+    let addr = spawn_server(vec![dead]).await;
 
     let response = reqwest::Client::new()
-        .post(format!("http://{addr}/solve"))
+        .post(format!("http://{addr}/mock/solve"))
         .json(&solve_request())
         .send()
         .await
@@ -256,45 +179,12 @@ async fn solve_with_engine_down_returns_solver_failed() {
 }
 
 #[tokio::test]
-async fn solve_with_partial_engine_failure_returns_successful_solutions() {
-    // One engine returns a solution, the other is down. The failing engine
-    // must not kill the auction: the driver returns the successful engine's
-    // solution.
-    let account = pubkey(0x99);
-    let engine = spawn_mock_solver_engine(serde_json::json!({
-        "solutions": [{
-            "id": 0,
-            "trades": [{
-                "orderUid": uid(),
-                "executedAmount": "1000",
-            }],
-            "interactions": [],
-        }]
-    }))
-    .await;
-    let dead = solver("127.0.0.1:1".parse().unwrap(), pubkey(0x88));
-    let addr = spawn_server(Competition::new(vec![solver(engine, account), dead])).await;
-
-    let response = reqwest::Client::new()
-        .post(format!("http://{addr}/solve"))
-        .json(&solve_request())
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(response.status(), reqwest::StatusCode::OK);
-
-    let json: serde_json::Value = response.json().await.unwrap();
-    let solutions = json["solutions"].as_array().unwrap();
-    assert_eq!(solutions.len(), 1);
-    assert_eq!(solutions[0]["solutionId"], "0");
-}
-
-#[tokio::test]
 async fn settle_rejects_non_positive_auction_id() {
-    let addr = spawn_server(Competition::new(Vec::new())).await;
+    let dead = solver("127.0.0.1:1".parse().unwrap(), pubkey(0x99));
+    let addr = spawn_server(vec![dead]).await;
 
     let response = reqwest::Client::new()
-        .post(format!("http://{addr}/settle"))
+        .post(format!("http://{addr}/mock/settle"))
         .json(&serde_json::json!({ "auctionId": "0", "solutionId": "3", "deadlineSlot": "100" }))
         .send()
         .await

--- a/crates/solana-driver/tests/api.rs
+++ b/crates/solana-driver/tests/api.rs
@@ -295,7 +295,7 @@ async fn settle_rejects_non_positive_auction_id() {
 
     let response = reqwest::Client::new()
         .post(format!("http://{addr}/settle"))
-        .json(&serde_json::json!({ "auctionId": "0", "solutionId": "3" }))
+        .json(&serde_json::json!({ "auctionId": "0", "solutionId": "3", "deadlineSlot": "100" }))
         .send()
         .await
         .unwrap();

--- a/crates/solana-driver/tests/api.rs
+++ b/crates/solana-driver/tests/api.rs
@@ -246,7 +246,10 @@ async fn solve_with_engine_down_returns_solver_failed() {
         .send()
         .await
         .unwrap();
-    assert_eq!(response.status(), reqwest::StatusCode::BAD_REQUEST);
+    assert_eq!(
+        response.status(),
+        reqwest::StatusCode::INTERNAL_SERVER_ERROR
+    );
 
     let json: serde_json::Value = response.json().await.unwrap();
     assert_eq!(json["kind"], "SolverFailed");

--- a/crates/solana-driver/tests/jupiter_live.rs
+++ b/crates/solana-driver/tests/jupiter_live.rs
@@ -20,7 +20,7 @@
 
 use {
     solana_driver::{
-        domain::{Auction, Order, Side, order_uid::OrderUid},
+        domain::{Auction, Id, Order, Side, Slot, order_uid::OrderUid},
         infra::{config, solver::Solver},
         util::associated_token_address,
     },
@@ -52,14 +52,22 @@ fn deadline() -> chrono::DateTime<chrono::Utc> {
 /// solver's account, so the domain order carries no destination.
 fn sell_auction() -> Auction {
     Auction {
-        id: 1,
+        id: Id::new(1).unwrap(),
         orders: vec![Order {
             uid: OrderUid([8; 32]),
-            sell_mint: Pubkey::from_str(USDC).unwrap(),
-            buy_mint: Pubkey::from_str(USDT).unwrap(),
-            amount: 10_000_000,
+            owner: Pubkey::default(),
+            sell_token: Pubkey::from_str(USDC).unwrap(),
+            buy_token: Pubkey::from_str(USDT).unwrap(),
+            sell_token_account: Pubkey::default(),
+            buy_token_account: Pubkey::default(),
+            sell_amount: 10_000_000,
+            buy_amount: 0,
+            valid_to: 0,
             side: Side::Sell,
+            partially_fillable: false,
+            order_pda: Pubkey::default(),
         }],
+        deadline_slot: Slot(1),
         deadline: deadline(),
     }
 }

--- a/crates/solana-driver/tests/jupiter_live.rs
+++ b/crates/solana-driver/tests/jupiter_live.rs
@@ -141,7 +141,7 @@ async fn driver_solves_against_live_jupiter_engine() {
     assert_eq!(solution.trades.len(), 1);
     let trade = &solution.trades[0];
     assert_eq!(trade.order_uid, OrderUid([8; 32]));
-    assert_eq!(trade.executed_amount, 10_000_000, "full sell amount filled");
+    assert_eq!(trade.executed_sell, 10_000_000, "full sell amount filled");
 
     // --- interactions ---
     // The swap must arrive as real Solana instructions: every interaction


### PR DESCRIPTION
# Description
Introduces the HTTP interface for receiving `/solve` and `/settle` requests from the autopilot.

The `/settle` endpoint is a stub for now because the actual settlement logic will be presented in a follow-up PR, but all the other aspects of it's API are in place.

@squadgazzz: This PR diff ended up a bit bigger than I expected. Please let me know if you prefer me to split it into smaller ones. _(I'm taking care this doesn't repeat for the follow-up PRs)_

# Changes
- `crates/autopilot-svm`: `SolveRequest`, `Solution`, `SettleRequest` now serialize integer ids as decimal strings, given `u64` can't fit in a JSON number.
- Updated `domain` types: 
  - `Competition` (new type, holds a list of `Solver`s and orchestrates `solve` calls among them.
  - `Auction`: its `id` field, rejects non-positive values
  - `Order` restructured fields to match what we get from the autopilot.
- implemented `api` routing for `solve` and `settle`.
  - Also defined `api`-specific `Error` and `error::Kind` for invalid data (auction ids, solver failures, etc)

## How to test

`cargo test -p solana-driver`

# New TODOs

These are the new TODO comments introduced by this PR.
We're shipping a basic version of the `solana-driver` first and will optimize these areas later.

- In `competition.rs`, the work fan-out is very simple/naive and there's no solution cache.
- The autopilot sends a `deadline_slot` that the driver needs to resolve into an actual timestamp, but for now this PR just uses a hardcoded 15s deadline for every auction. _(The `deadline_slot` field is included in the DTO, just not enforced.)_
- The `solana-solver` engine doesn't yet report the counterpart (buy/sell) amount, so the driver stubs the `score` and counterpart `amount` to `0`. 