### PR TITLE
[EASY] Build and ship the solana service binaries in the release images

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -85,6 +85,7 @@ jobs:
         run: |
           cargo build --release \
             -p autopilot -p driver -p orderbook -p refunder -p solvers -p pool-indexer \
+            -p solana-indexer -p solana-orderbook -p solana-driver -p solana-solvers \
             ${{ steps.features.outputs.cargo_features }}
 
       - uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,13 +20,18 @@ COPY . .
 RUN --mount=type=cache,target=/usr/local/cargo/registry --mount=type=cache,target=/src/target \
     CARGO_PROFILE_RELEASE_DEBUG=1 RUSTFLAGS="${RUSTFLAGS}" cargo build --release \
     -p autopilot -p driver -p orderbook -p refunder -p solvers -p pool-indexer \
+    -p solana-indexer -p solana-orderbook -p solana-driver -p solana-solvers \
     ${CARGO_BUILD_FEATURES} && \
     cp target/release/autopilot / && \
     cp target/release/driver / && \
     cp target/release/orderbook / && \
     cp target/release/refunder / && \
     cp target/release/solvers / && \
-    cp target/release/pool-indexer /
+    cp target/release/pool-indexer / && \
+    cp target/release/solana-indexer / && \
+    cp target/release/solana-orderbook / && \
+    cp target/release/solana-driver / && \
+    cp target/release/solana-solvers /
 
 # Create an intermediate image to extract the binaries
 FROM docker.io/debian:bookworm-slim AS intermediate
@@ -60,6 +65,22 @@ FROM intermediate AS pool-indexer
 COPY --from=cargo-build /pool-indexer /usr/local/bin/pool-indexer
 ENTRYPOINT [ "pool-indexer" ]
 
+FROM intermediate AS solana-indexer
+COPY --from=cargo-build /solana-indexer /usr/local/bin/solana-indexer
+ENTRYPOINT [ "solana-indexer" ]
+
+FROM intermediate AS solana-orderbook
+COPY --from=cargo-build /solana-orderbook /usr/local/bin/solana-orderbook
+ENTRYPOINT [ "solana-orderbook" ]
+
+FROM intermediate AS solana-driver
+COPY --from=cargo-build /solana-driver /usr/local/bin/solana-driver
+ENTRYPOINT [ "solana-driver" ]
+
+FROM intermediate AS solana-solvers
+COPY --from=cargo-build /solana-solvers /usr/local/bin/solana-solvers
+ENTRYPOINT [ "solana-solvers" ]
+
 # Extract Binary
 FROM intermediate
 
@@ -70,5 +91,9 @@ COPY --from=cargo-build /orderbook /usr/local/bin/orderbook
 COPY --from=cargo-build /refunder /usr/local/bin/refunder
 COPY --from=cargo-build /solvers /usr/local/bin/solvers
 COPY --from=cargo-build /pool-indexer /usr/local/bin/pool-indexer
+COPY --from=cargo-build /solana-indexer /usr/local/bin/solana-indexer
+COPY --from=cargo-build /solana-orderbook /usr/local/bin/solana-orderbook
+COPY --from=cargo-build /solana-driver /usr/local/bin/solana-driver
+COPY --from=cargo-build /solana-solvers /usr/local/bin/solana-solvers
 
 ENTRYPOINT ["/usr/bin/tini", "-s", "--"]

--- a/Dockerfile.deploy-ci
+++ b/Dockerfile.deploy-ci
@@ -21,5 +21,9 @@ COPY --from=binaries orderbook /usr/local/bin/orderbook
 COPY --from=binaries refunder /usr/local/bin/refunder
 COPY --from=binaries solvers /usr/local/bin/solvers
 COPY --from=binaries pool-indexer /usr/local/bin/pool-indexer
+COPY --from=binaries solana-indexer /usr/local/bin/solana-indexer
+COPY --from=binaries solana-orderbook /usr/local/bin/solana-orderbook
+COPY --from=binaries solana-driver /usr/local/bin/solana-driver
+COPY --from=binaries solana-solvers /usr/local/bin/solana-solvers
 
 ENTRYPOINT ["/usr/bin/tini", "-s", "--"]


### PR DESCRIPTION
# Description
The release pipeline only builds and ships the EVM binaries, so the devnet deployment has no solana images to pull. This adds the four solana services that have binaries on main (`solana-indexer`, `solana-orderbook`, `solana-driver`, `solana-solvers`) to every image path: the release cargo build in the deploy workflow, the production image (`Dockerfile.deploy-ci`), and the local/playground image with its per-service stages. `autopilot-svm` follows once its binary wiring PR merges.

The migration image needs no change, it already copies the whole `database/` directory including the solana flyway series.

# Changes
- The deploy workflow's release build and both Dockerfiles cover the four solana service binaries

# How to test
CI builds the images on this PR. The deployed combined image gains the four binaries under `/usr/local/bin`, entrypoints unchanged.
