### PR TITLE
[Trivial] Fix clippy 1.98 lints

### DIFF
--- a/crates/driver/src/domain/competition/mod.rs
+++ b/crates/driver/src/domain/competition/mod.rs
@@ -1056,11 +1056,11 @@ impl Competition {
         let tx = settlement.transaction(settlement::Internalization::Enable);
         let gas_needed_for_tx = self.simulator.gas(tx.clone()).await?;
         if gas_needed_for_tx > settlement.gas.limit {
-            return Err(simulator::Error::Revert(RevertError {
+            return Err(simulator::Error::Revert(Box::new(RevertError {
                 err: SimulatorError::GasExceeded(gas_needed_for_tx, settlement.gas.limit),
                 tx: tx.clone(),
                 block: self.eth.current_block().borrow().number.into(),
-            }));
+            })));
         }
         Ok(())
     }

--- a/crates/liquidity-sources/src/balancer_v2/swap/fixed_point/logexpmath.rs
+++ b/crates/liquidity-sources/src/balancer_v2/swap/fixed_point/logexpmath.rs
@@ -141,16 +141,15 @@ fn exp(mut x: I256) -> Result<I256, Error> {
         return Ok((*ONE_18 * *ONE_18) / exp(-x)?);
     }
 
-    let first_an;
-    if x >= constant_x_18(0) {
+    let first_an = if x >= constant_x_18(0) {
         x -= constant_x_18(0);
-        first_an = constant_a_18(0);
+        constant_a_18(0)
     } else if x >= constant_x_18(1) {
         x -= constant_x_18(1);
-        first_an = constant_a_18(1);
+        constant_a_18(1)
     } else {
-        first_an = I256::ONE;
-    }
+        I256::ONE
+    };
 
     x *= I256::try_from(100).expect("100 fits in I256");
 

--- a/crates/simulator/src/lib.rs
+++ b/crates/simulator/src/lib.rs
@@ -183,7 +183,7 @@ pub enum Error {
     /// If a transaction reverted, forward that transaction together with the
     /// error.
     #[error(transparent)]
-    Revert(#[from] RevertError),
+    Revert(#[from] Box<RevertError>),
     /// Any other error that is not related to the underlying transaction
     /// failing.
     #[error(transparent)]
@@ -204,11 +204,11 @@ where
             SimulatorError::GasExceeded(..) => Some(tx.clone()),
         };
         match tx {
-            Some(tx) => Error::Revert(RevertError {
+            Some(tx) => Error::Revert(Box::new(RevertError {
                 err,
                 tx: tx.clone(),
                 block,
-            }),
+            })),
             None => Error::Other(err),
         }
     }


### PR DESCRIPTION
# Description
Fixes new trivial clippy lints that [surfaced in our CI](https://github.com/cowprotocol/services/actions/runs/32398291054/job/96520167656?pr=4759#step:10:1808).

These lints aren't new but after 1.98 (released today) clippy detects cases it previously missed. From their [changelog](https://github.com/rust-lang/rust-clippy/blob/21baba9c10c5d179915cae82e6247bc2337872fb/CHANGELOG.md):
``` 
* [`needless_late_init`] extend to cover grouped assignments, and fix FN for if/match in block expr
* [`result_large_err`] and [`result_unit_err`] fix not triggering on async functions
```

# Changes
- commit 3c3bb3132 fixes the [`result_large_err`](https://rust-lang.github.io/rust-clippy/rust-1.98.0/index.html#result_large_err) in `driver` crate by boxing `RevertError`
- commit e20853d56 fixes the [`needless_late_init`](https://rust-lang.github.io/rust-clippy/rust-1.98.0/index.html#needless_late_init) in the `liquidity-sources` crate.