### PR TITLE
solana-driver: wire solvers signing keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9736,6 +9736,7 @@ dependencies = [
  "serde_with",
  "solana-sdk",
  "solana-solvers",
+ "tempfile",
  "thiserror 1.0.69",
  "tikv-jemallocator",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9736,7 +9736,7 @@ dependencies = [
  "serde_with",
  "solana-sdk",
  "solana-solvers",
- "tempfile",
+ "solana-testlib",
  "thiserror 1.0.69",
  "tikv-jemallocator",
  "tokio",
@@ -11080,6 +11080,14 @@ checksum = "17358d1e9a13e5b9c2264d301102126cf11a47fd394cdf3dec174fe7bc96e1de"
 dependencies = [
  "solana-address 2.6.1",
  "solana-sdk-ids",
+]
+
+[[package]]
+name = "solana-testlib"
+version = "0.1.0"
+dependencies = [
+ "solana-sdk",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,6 +132,7 @@ solana-indexer = { path = "crates/solana-indexer" }
 solana-rpc-client = "4"
 solana-rpc-client-api = "4"
 solana-sdk = "4"
+solana-testlib = { path = "crates/solana-testlib" }
 solver = { path = "crates/solver" }
 solvers = { path = "crates/solvers" }
 solvers-dto = { path = "crates/solvers-dto" }

--- a/crates/solana-driver/Cargo.toml
+++ b/crates/solana-driver/Cargo.toml
@@ -44,6 +44,7 @@ url = { workspace = true, features = ["serde"] }
 [dev-dependencies]
 cow-solana-rpc = { workspace = true, features = ["test-util"] }
 solana-solvers = { path = "../solana-solvers" }
+tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt"] }
 
 [features]

--- a/crates/solana-driver/Cargo.toml
+++ b/crates/solana-driver/Cargo.toml
@@ -44,7 +44,7 @@ url = { workspace = true, features = ["serde"] }
 [dev-dependencies]
 cow-solana-rpc = { workspace = true, features = ["test-util"] }
 solana-solvers = { path = "../solana-solvers" }
-tempfile = { workspace = true }
+solana-testlib = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt"] }
 
 [features]

--- a/crates/solana-driver/example.toml
+++ b/crates/solana-driver/example.toml
@@ -20,4 +20,7 @@ filter = "info,solana_driver=debug"
 name = "baseline"
 endpoint = "http://localhost:8001"
 account = "9VXC6LH9eXMBpXLQnxMYAGkjs59Zon2ACciJwQ6iMzNB"
+# Path to the solver's settlement signer keypair. Its public key must equal
+# `account`. TODO: plaintext keypair paths are temporary; KMS is planned.
+signer-keypair = "/path/to/keypair.json"
 max-in-flight = 1

--- a/crates/solana-driver/src/infra/api/mod.rs
+++ b/crates/solana-driver/src/infra/api/mod.rs
@@ -102,7 +102,7 @@ impl State {
 
 struct Inner {
     /// The shared Solana RPC client.
-    #[expect(dead_code, reason = "used by the deadline and submission follow-ups")]
+    #[expect(dead_code, reason = "slot deadline and submission are not implemented")]
     rpc: Arc<SolanaRPC>,
     /// The competition that runs auctions for this solver engine.
     competition: domain::Competition,

--- a/crates/solana-driver/src/infra/config.rs
+++ b/crates/solana-driver/src/infra/config.rs
@@ -9,7 +9,12 @@ use {
         deserialize_url_with_trailing_slash,
     },
     solana_sdk::pubkey::Pubkey,
-    std::{net::SocketAddr, num::NonZero, path::Path, time::Duration},
+    std::{
+        net::SocketAddr,
+        num::NonZero,
+        path::{Path, PathBuf},
+        time::Duration,
+    },
     tokio::fs,
 };
 
@@ -108,6 +113,13 @@ pub struct Solver {
     /// produced by this engine.
     #[serde(deserialize_with = "deserialize_solana_pubkey_b58")]
     pub account: Pubkey,
+    /// Path to the solver's settlement signer keypair. Its public key must
+    /// equal `account`; the driver fails fast on mismatch at startup.
+    ///
+    /// TODO: plaintext keypair paths are temporary. Secrets must not live in
+    /// plaintext config long-term; KMS-backed signers are planned, mirroring
+    /// the EVM driver's `submission_accounts`.
+    pub signer_keypair: PathBuf,
     /// Maximum number of concurrent solve requests kept in flight per solver.
     pub max_in_flight: NonZero<usize>,
 }
@@ -140,6 +152,10 @@ mod tests {
                 .parse()
                 .unwrap()
         );
+        assert_eq!(
+            config.solvers[0].signer_keypair,
+            Path::new("/path/to/keypair.json")
+        );
         assert_eq!(config.logging.filter, "info,solana_driver=debug");
         assert_eq!(config.logging.stderr_threshold, None);
         assert!(!config.logging.use_json);
@@ -151,11 +167,13 @@ mod tests {
             name = "baseline"
             endpoint = "http://localhost:8001"
             account = "11111111111111111111111111111111"
+            signer-keypair = "/path/to/keypair.json"
             max-in-flight = 1
         "#;
         let solver: Solver = toml::de::from_str(solver_config).unwrap();
         assert_eq!(solver.name, "baseline");
         assert_eq!(solver.account, Pubkey::default());
+        assert_eq!(solver.signer_keypair, Path::new("/path/to/keypair.json"));
         assert_eq!(solver.max_in_flight.get(), 1);
     }
 
@@ -164,6 +182,8 @@ mod tests {
         let solver_config = r#"
             name = "baseline"
             endpoint = "http://localhost:8001"
+            account = "11111111111111111111111111111111"
+            signer-keypair = "/path/to/keypair.json"
             max-in-flight = 0
         "#;
         let err = toml::de::from_str::<Solver>(solver_config)

--- a/crates/solana-driver/src/infra/solver/mod.rs
+++ b/crates/solana-driver/src/infra/solver/mod.rs
@@ -25,7 +25,7 @@ pub mod dto;
 pub struct Solver {
     name: String,
     account: Pubkey,
-    #[expect(dead_code, reason = "used by the settlement path in follow-up PRs")]
+    #[expect(dead_code, reason = "settlement signing is not implemented")]
     signer: Arc<Keypair>,
     client: reqwest::Client,
     base_url: reqwest::Url,

--- a/crates/solana-driver/src/infra/solver/mod.rs
+++ b/crates/solana-driver/src/infra/solver/mod.rs
@@ -51,12 +51,6 @@ impl Solver {
             })?;
         let pubkey = keypair.pubkey();
         if pubkey != config.account {
-            tracing::error!(
-                solver = %config.name,
-                %pubkey,
-                account = %config.account,
-                "signer keypair pubkey does not match solver account",
-            );
             return Err(Error::SignerPubkeyMismatch {
                 solver: config.name.clone(),
                 pubkey,

--- a/crates/solana-driver/src/infra/solver/mod.rs
+++ b/crates/solana-driver/src/infra/solver/mod.rs
@@ -171,25 +171,18 @@ pub enum Error {
 mod tests {
     use {
         super::*,
-        solana_sdk::signer::keypair::{Keypair, read_keypair_file, write_keypair_file},
+        solana_sdk::signer::keypair::read_keypair_file,
+        solana_testlib::temp_keypair,
         std::num::NonZero,
-        tempfile::NamedTempFile,
     };
-
-    /// Write a fresh keypair to a temp file and return its path.
-    fn temp_keypair() -> std::path::PathBuf {
-        let file = NamedTempFile::new().expect("create temp file");
-        let path = file.into_temp_path().keep().expect("keep temp file");
-        write_keypair_file(&Keypair::new(), &path).expect("write keypair");
-        path
-    }
 
     #[tokio::test]
     async fn solve_with_past_deadline_is_rejected() {
         // Build a solver pointing at a port that is never listened on. The
         // deadline check fires before any HTTP request is sent, so this never
         // actually connects to the endpoint.
-        let keypair_path = temp_keypair();
+        let keypair_file = temp_keypair();
+        let keypair_path = keypair_file.path().to_path_buf();
         let solver = Solver::new(&config::Solver {
             name: "test".to_owned(),
             endpoint: "http://127.0.0.1:1".parse().unwrap(),

--- a/crates/solana-driver/src/infra/solver/mod.rs
+++ b/crates/solana-driver/src/infra/solver/mod.rs
@@ -9,7 +9,10 @@ use {
         domain,
         infra::{config, solver::dto::auction::Auction},
     },
-    solana_sdk::pubkey::Pubkey,
+    solana_sdk::{
+        pubkey::Pubkey,
+        signer::{Signer, keypair::Keypair},
+    },
     std::sync::Arc,
     thiserror::Error,
     tokio::sync::Semaphore,
@@ -18,10 +21,12 @@ use {
 pub mod dto;
 
 /// A configured solver engine HTTP client.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Solver {
     name: String,
     account: Pubkey,
+    #[expect(dead_code, reason = "used by the settlement path in follow-up PRs")]
+    signer: Arc<Keypair>,
     client: reqwest::Client,
     base_url: reqwest::Url,
     in_flight: Arc<Semaphore>,
@@ -34,14 +39,38 @@ impl Solver {
     }
 
     /// Build a solver client from its configuration.
-    pub fn new(config: &config::Solver) -> Self {
-        Self {
+    ///
+    /// Loads the signer keypair from `config.signer_keypair` and validates that
+    /// its public key matches `config.account`.
+    pub fn new(config: &config::Solver) -> Result<Self, Error> {
+        let keypair = solana_sdk::signer::keypair::read_keypair_file(&config.signer_keypair)
+            .map_err(|error| Error::SignerKeypair {
+                solver: config.name.clone(),
+                path: config.signer_keypair.clone(),
+                error,
+            })?;
+        let pubkey = keypair.pubkey();
+        if pubkey != config.account {
+            tracing::error!(
+                solver = %config.name,
+                %pubkey,
+                account = %config.account,
+                "signer keypair pubkey does not match solver account",
+            );
+            return Err(Error::SignerPubkeyMismatch {
+                solver: config.name.clone(),
+                pubkey,
+                account: config.account,
+            });
+        }
+        Ok(Self {
             name: config.name.clone(),
             account: config.account,
+            signer: Arc::new(keypair),
             client: reqwest::Client::new(),
             base_url: config.endpoint.clone(),
             in_flight: Arc::new(Semaphore::new(config.max_in_flight.get())),
-        }
+        })
     }
 
     /// POST the auction to this engine's `/solve` endpoint and return the
@@ -123,23 +152,58 @@ pub enum Error {
     /// The auction deadline passed before a solve request could be sent.
     #[error("auction deadline exceeded")]
     DeadlineExceeded,
+    /// The signer keypair could not be loaded from the configured path.
+    #[error("failed to load signer keypair for solver {solver} from {path}: {error}")]
+    SignerKeypair {
+        solver: String,
+        path: std::path::PathBuf,
+        #[source]
+        error: Box<dyn std::error::Error>,
+    },
+    /// The signer keypair's public key does not match the solver's configured
+    /// on-chain identity.
+    #[error(
+        "signer keypair pubkey {pubkey} does not match solver account {account} for solver \
+         {solver}"
+    )]
+    SignerPubkeyMismatch {
+        solver: String,
+        pubkey: Pubkey,
+        account: Pubkey,
+    },
 }
 
 #[cfg(test)]
 mod tests {
-    use {super::*, std::num::NonZero};
+    use {
+        super::*,
+        solana_sdk::signer::keypair::{Keypair, read_keypair_file, write_keypair_file},
+        std::num::NonZero,
+        tempfile::NamedTempFile,
+    };
+
+    /// Write a fresh keypair to a temp file and return its path.
+    fn temp_keypair() -> std::path::PathBuf {
+        let file = NamedTempFile::new().expect("create temp file");
+        let path = file.into_temp_path().keep().expect("keep temp file");
+        write_keypair_file(&Keypair::new(), &path).expect("write keypair");
+        path
+    }
 
     #[tokio::test]
     async fn solve_with_past_deadline_is_rejected() {
         // Build a solver pointing at a port that is never listened on. The
         // deadline check fires before any HTTP request is sent, so this never
         // actually connects to the endpoint.
+        let keypair_path = temp_keypair();
         let solver = Solver::new(&config::Solver {
             name: "test".to_owned(),
             endpoint: "http://127.0.0.1:1".parse().unwrap(),
-            account: Pubkey::default(),
+            account: read_keypair_file(&keypair_path).unwrap().pubkey(),
+            signer_keypair: keypair_path,
             max_in_flight: NonZero::new(1).unwrap(),
-        });
+        })
+        .expect("solver construction should succeed");
         let auction = domain::Auction {
             id: domain::Id::new(1).unwrap(),
             orders: Vec::new(),

--- a/crates/solana-driver/src/run.rs
+++ b/crates/solana-driver/src/run.rs
@@ -40,7 +40,12 @@ pub async fn run(args: Args) {
         config.rpc.request_timeout,
         CommitmentConfig::confirmed(),
     ));
-    let solvers: Vec<solver::Solver> = config.solvers.iter().map(solver::Solver::new).collect();
+    let solvers: Vec<solver::Solver> = config
+        .solvers
+        .iter()
+        .map(solver::Solver::new)
+        .collect::<Result<_, _>>()
+        .expect("failed to load solver signer keypairs");
     let api = Api {
         addr: config.http.bind_address,
         rpc,

--- a/crates/solana-driver/tests/api.rs
+++ b/crates/solana-driver/tests/api.rs
@@ -3,8 +3,14 @@
 use {
     cow_solana_rpc::SolanaRPC,
     solana_driver::infra::{api::Api, config, solver::Solver},
-    solana_sdk::pubkey::Pubkey,
-    std::{net::SocketAddr, num::NonZero, sync::Arc},
+    solana_sdk::{
+        pubkey::Pubkey,
+        signer::{
+            Signer,
+            keypair::{Keypair, read_keypair_file},
+        },
+    },
+    std::{net::SocketAddr, num::NonZero, path::PathBuf, sync::Arc},
     tokio_util::sync::CancellationToken,
 };
 
@@ -15,6 +21,14 @@ fn pubkey(byte: u8) -> Pubkey {
 /// The autopilot's own literal order uid (32 bytes of `0x11`).
 fn uid() -> String {
     format!("0x{}", "11".repeat(32))
+}
+
+/// Write a fresh keypair to a temp file and return its path.
+fn temp_keypair() -> PathBuf {
+    let file = tempfile::NamedTempFile::new().expect("create temp file");
+    let path = file.into_temp_path().keep().expect("keep temp file");
+    solana_sdk::signer::keypair::write_keypair_file(&Keypair::new(), &path).expect("write keypair");
+    path
 }
 
 fn api_with(solvers: Vec<Solver>) -> Api {
@@ -51,13 +65,25 @@ async fn spawn_mock_solver_engine(response: serde_json::Value) -> SocketAddr {
     addr
 }
 
-fn solver(addr: SocketAddr, account: Pubkey) -> Solver {
-    Solver::new(&config::Solver {
+/// A solver client whose on-chain identity is a freshly generated keypair,
+/// so the test can register a matching settlement signer.
+fn solver_with_keypair(addr: SocketAddr) -> (Solver, Pubkey) {
+    let keypair_path = temp_keypair();
+    let account = read_keypair_file(&keypair_path).unwrap().pubkey();
+    let solver = Solver::new(&config::Solver {
         name: "mock".to_owned(),
         endpoint: format!("http://{addr}").parse().unwrap(),
         account,
+        signer_keypair: keypair_path,
         max_in_flight: NonZero::new(1).unwrap(),
     })
+    .expect("solver construction should succeed");
+    (solver, account)
+}
+
+/// A solver client pointing at a dead endpoint (no listener).
+fn dead_solver() -> (Solver, Pubkey) {
+    solver_with_keypair("127.0.0.1:1".parse().unwrap())
 }
 
 /// The autopilot's own literal `/solve` request JSON.
@@ -120,7 +146,6 @@ async fn shuts_down_cleanly_on_signal() {
 
 #[tokio::test]
 async fn solve_returns_converted_solutions() {
-    let account = pubkey(0x99);
     let engine = spawn_mock_solver_engine(serde_json::json!({
         "solutions": [{
             "id": 42,
@@ -136,7 +161,8 @@ async fn solve_returns_converted_solutions() {
         }]
     }))
     .await;
-    let addr = spawn_server(vec![solver(engine, account)]).await;
+    let (solver, account) = solver_with_keypair(engine);
+    let addr = spawn_server(vec![solver]).await;
 
     let response = reqwest::Client::new()
         .post(format!("http://{addr}/mock/solve"))
@@ -168,7 +194,7 @@ async fn solve_returns_converted_solutions() {
 #[tokio::test]
 async fn solve_with_engine_down_returns_solver_failed() {
     // Point the solver at a port with no listener.
-    let dead = solver("127.0.0.1:1".parse().unwrap(), pubkey(0x99));
+    let (dead, _) = dead_solver();
     let addr = spawn_server(vec![dead]).await;
 
     let response = reqwest::Client::new()
@@ -188,7 +214,7 @@ async fn solve_with_engine_down_returns_solver_failed() {
 
 #[tokio::test]
 async fn settle_rejects_non_positive_auction_id() {
-    let dead = solver("127.0.0.1:1".parse().unwrap(), pubkey(0x99));
+    let (dead, _) = dead_solver();
     let addr = spawn_server(vec![dead]).await;
 
     let response = reqwest::Client::new()

--- a/crates/solana-driver/tests/api.rs
+++ b/crates/solana-driver/tests/api.rs
@@ -5,12 +5,10 @@ use {
     solana_driver::infra::{api::Api, config, solver::Solver},
     solana_sdk::{
         pubkey::Pubkey,
-        signer::{
-            Signer,
-            keypair::{Keypair, read_keypair_file},
-        },
+        signer::{Signer, keypair::read_keypair_file},
     },
-    std::{net::SocketAddr, num::NonZero, path::PathBuf, sync::Arc},
+    solana_testlib::temp_keypair,
+    std::{net::SocketAddr, num::NonZero, sync::Arc},
     tokio_util::sync::CancellationToken,
 };
 
@@ -21,14 +19,6 @@ fn pubkey(byte: u8) -> Pubkey {
 /// The autopilot's own literal order uid (32 bytes of `0x11`).
 fn uid() -> String {
     format!("0x{}", "11".repeat(32))
-}
-
-/// Write a fresh keypair to a temp file and return its path.
-fn temp_keypair() -> PathBuf {
-    let file = tempfile::NamedTempFile::new().expect("create temp file");
-    let path = file.into_temp_path().keep().expect("keep temp file");
-    solana_sdk::signer::keypair::write_keypair_file(&Keypair::new(), &path).expect("write keypair");
-    path
 }
 
 fn api_with(solvers: Vec<Solver>) -> Api {
@@ -68,7 +58,8 @@ async fn spawn_mock_solver_engine(response: serde_json::Value) -> SocketAddr {
 /// A solver client whose on-chain identity is a freshly generated keypair,
 /// so the test can register a matching settlement signer.
 fn solver_with_keypair(addr: SocketAddr) -> (Solver, Pubkey) {
-    let keypair_path = temp_keypair();
+    let keypair_file = temp_keypair();
+    let keypair_path = keypair_file.path().to_path_buf();
     let account = read_keypair_file(&keypair_path).unwrap().pubkey();
     let solver = Solver::new(&config::Solver {
         name: "mock".to_owned(),

--- a/crates/solana-driver/tests/jupiter_live.rs
+++ b/crates/solana-driver/tests/jupiter_live.rs
@@ -24,7 +24,13 @@ use {
         infra::{config, solver::Solver},
         util::associated_token_address,
     },
-    solana_sdk::pubkey::Pubkey,
+    solana_sdk::{
+        pubkey::Pubkey,
+        signer::{
+            Signer,
+            keypair::{Keypair, read_keypair_file, write_keypair_file},
+        },
+    },
     solana_solvers::{
         api::Api,
         config::JupiterConfig,
@@ -111,13 +117,21 @@ async fn driver_solves_against_live_jupiter_engine() {
 
     // Any valid pubkey works: Jupiter builds instructions for this account,
     // the swap only runs for real once the driver submits the settlement.
-    let solver_account = Pubkey::new_unique();
+    let keypair_file = tempfile::NamedTempFile::new().expect("create temp file");
+    let keypair_path = keypair_file
+        .into_temp_path()
+        .keep()
+        .expect("keep temp file");
+    write_keypair_file(&Keypair::new(), &keypair_path).expect("write keypair");
+    let solver_account = read_keypair_file(&keypair_path).unwrap().pubkey();
     let solver = Solver::new(&config::Solver {
         name: "jupiter-live".to_string(),
         endpoint: format!("http://{addr}").parse().unwrap(),
         account: solver_account,
+        signer_keypair: keypair_path,
         max_in_flight: std::num::NonZero::new(1).unwrap(),
-    });
+    })
+    .expect("solver construction should succeed");
 
     // `Solver::solve` posts the auction and deserializes the JSON response
     // into `domain::Solution`s; an `Ok` result proves the wire deserialization

--- a/crates/solana-driver/tests/jupiter_live.rs
+++ b/crates/solana-driver/tests/jupiter_live.rs
@@ -26,16 +26,14 @@ use {
     },
     solana_sdk::{
         pubkey::Pubkey,
-        signer::{
-            Signer,
-            keypair::{Keypair, read_keypair_file, write_keypair_file},
-        },
+        signer::{Signer, keypair::read_keypair_file},
     },
     solana_solvers::{
         api::Api,
         config::JupiterConfig,
         dex::{Dex, jupiter::Jupiter},
     },
+    solana_testlib::temp_keypair,
     std::{str::FromStr, sync::Arc},
     tokio_util::sync::CancellationToken,
 };
@@ -117,12 +115,8 @@ async fn driver_solves_against_live_jupiter_engine() {
 
     // Any valid pubkey works: Jupiter builds instructions for this account,
     // the swap only runs for real once the driver submits the settlement.
-    let keypair_file = tempfile::NamedTempFile::new().expect("create temp file");
-    let keypair_path = keypair_file
-        .into_temp_path()
-        .keep()
-        .expect("keep temp file");
-    write_keypair_file(&Keypair::new(), &keypair_path).expect("write keypair");
+    let keypair_file = temp_keypair();
+    let keypair_path = keypair_file.path().to_path_buf();
     let solver_account = read_keypair_file(&keypair_path).unwrap().pubkey();
     let solver = Solver::new(&config::Solver {
         name: "jupiter-live".to_string(),

--- a/crates/solana-testlib/Cargo.toml
+++ b/crates/solana-testlib/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "solana-testlib"
+version = "0.1.0"
+authors = ["Cow Protocol Developers <dev@cow.fi>"]
+edition = "2024"
+license = "GPL-3.0-or-later"
+description = "Shared test helpers for Solana CoW Protocol crates"
+repository = "https://github.com/cowprotocol/services"
+
+[dependencies]
+solana-sdk = { workspace = true }
+tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/solana-testlib/src/lib.rs
+++ b/crates/solana-testlib/src/lib.rs
@@ -1,0 +1,18 @@
+//! Shared test helpers for Solana CoW Protocol crates.
+
+#![forbid(unsafe_code)]
+
+use {
+    solana_sdk::signer::keypair::{Keypair, write_keypair_file},
+    tempfile::NamedTempFile,
+};
+
+/// Write a fresh keypair to a temp file and return the handle.
+///
+/// The file is destroyed when the returned handle is dropped, so callers
+/// must keep it alive for as long as it's needed.
+pub fn temp_keypair() -> NamedTempFile {
+    let file = NamedTempFile::new().expect("create temp file");
+    write_keypair_file(&Keypair::new(), file.path()).expect("write keypair");
+    file
+}


### PR DESCRIPTION
# Description
First PR of a series to enable the `solana-driver` to interact with the Settlement program.


# Changes
- Adds signing keys to the `Solver` struct, loaded from a JSON file whose path is specified in config. 
  - This is a temporary workaround while we don't set up KMS for the `solana-driver`. 
- Solver `account` (address) is enforced to be equal to `signing_key.pubkey()`.
  - This might look redundant, but I think this is a nice way to confirm the provided `account` value. (I'm open to drop the `account` field from the config too.)
  
   
