### PR TITLE
[EASY] Key solana trades by the inner instruction path

### DIFF
--- a/database/sql-solana/V2__solana_order_and_settlement_tables.sql
+++ b/database/sql-solana/V2__solana_order_and_settlement_tables.sql
@@ -82,6 +82,9 @@ CREATE INDEX solana_settlements_auction_id ON solana.settlements (auction_id);
 CREATE TABLE solana.trades (
     tx_signature            bytea NOT NULL,
     instruction_index       integer NOT NULL,
+    -- Instruction path for CPI-emitted trades: '{}' is a top-level
+    -- instruction, '{0,2}' is inner instruction 2 under top-level 0.
+    inner_ix_path           integer[] NOT NULL DEFAULT '{}',
     order_uid               bytea NOT NULL CHECK (length(order_uid) = 32),
     -- Per-order pull from the BeginSettle instruction data, fee included.
     sell_amount             numeric(20,0) NOT NULL,
@@ -89,7 +92,7 @@ CREATE TABLE solana.trades (
     buy_amount              numeric(20,0) NOT NULL,
     -- From the off-chain proposed-solution data.
     fee_amount              numeric(20,0) NOT NULL,
-    PRIMARY KEY (tx_signature, instruction_index, order_uid)
+    PRIMARY KEY (tx_signature, instruction_index, inner_ix_path, order_uid)
 );
 
 CREATE INDEX solana_trades_order_uid ON solana.trades (order_uid);


### PR DESCRIPTION
# Description
The trades key must distinguish CPI-emitted trades: a program invoking `BeginSettle` via CPI produces trades whose top-level `instruction_index` collides. `inner_ix_path` completes the key (`'{}'` for a top-level instruction, the inner path otherwise), matching the DB spec. The solana migrations run only in CI so far, so the shipped file changes in place rather than via a follow-up migration. This is the one shape decision that gets expensive once real rows exist.

# Changes
- `solana.trades` gains `inner_ix_path integer[] NOT NULL DEFAULT '{}'` as part of the primary key

# How to test
Existing Postgres tests. The indexer inserts with an explicit column list and `ON CONFLICT DO NOTHING`, the default covers the new column.
