### PR TITLE
[CIP87-2] Wire penalty cap field through auction, driver and solver engine

### DIFF
--- a/crates/autopilot/src/infra/persistence/dto/order.rs
+++ b/crates/autopilot/src/infra/persistence/dto/order.rs
@@ -42,6 +42,11 @@ pub struct Order {
     #[serde(flatten)]
     pub signature: boundary::Signature,
     pub quote: Option<Quote>,
+    /// Cap on the penalty a solver can incur for winning this order but
+    /// failing to execute it, in native token.
+    #[serde_as(as = "Option<HexOrDecimalU256>")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub penalty_cap_native: Option<U256>,
 }
 
 /// Takes the order by reference so callers that still need the domain order
@@ -84,6 +89,7 @@ pub fn from_domain(order: &domain::Order) -> Order {
         app_data: order.app_data.clone().into(),
         signature: order.signature.clone().into(),
         quote: order.quote.as_ref().map(Quote::from_domain),
+        penalty_cap_native: order.penalty_cap_native.map(Into::into),
     }
 }
 
@@ -121,8 +127,7 @@ pub fn to_domain(order: Order) -> domain::Order {
         app_data: order.app_data.into(),
         signature: order.signature.into(),
         quote: order.quote.map(|q| q.to_domain(order.uid.into())),
-        // Not part of the serialized auction (yet).
-        penalty_cap_native: None,
+        penalty_cap_native: order.penalty_cap_native.map(Into::into),
     }
 }
 

--- a/crates/autopilot/src/infra/solvers/dto/solve.rs
+++ b/crates/autopilot/src/infra/solvers/dto/solve.rs
@@ -522,6 +522,17 @@ mod tests {
         dto::order::to_domain(serde_json::from_value(order_json(uid_byte, executed)).unwrap())
     }
 
+    #[test]
+    fn order_penalty_cap_round_trips() {
+        let mut json = order_json(0x11, 0);
+        json.as_object_mut()
+            .unwrap()
+            .insert("penaltyCapNative".into(), serde_json::json!("1234"));
+        let order = dto::order::to_domain(serde_json::from_value(json.clone()).unwrap());
+        let serialized = serde_json::to_value(dto::order::from_domain(&order)).unwrap();
+        assert_eq!(serialized, json);
+    }
+
     fn test_auction(id: i64, orders: Vec<domain::Order>) -> domain::Auction {
         domain::Auction {
             id,

--- a/crates/driver/openapi.yml
+++ b/crates/driver/openapi.yml
@@ -338,6 +338,12 @@ components:
           allOf:
             - description: A winning quote.
             - $ref: "#/components/schemas/Quote"
+        penaltyCapNative:
+          allOf:
+            - description: |-
+                Cap on the penalty a solver can incur for winning this order
+                but failing to execute it, denominated in the native token.
+            - $ref: "#/components/schemas/TokenAmount"
       required:
         - uid
         - sellToken

--- a/crates/driver/src/domain/competition/order/mod.rs
+++ b/crates/driver/src/domain/competition/order/mod.rs
@@ -49,6 +49,9 @@ pub struct OrderData {
     pub protocol_fees: Vec<FeePolicy>,
     /// The winning quote.
     pub quote: Option<Quote>,
+    /// Cap on the penalty a solver can incur for winning this order but
+    /// failing to execute it, in native token.
+    pub penalty_cap_native: Option<eth::Ether>,
 }
 
 /// An order in the auction.
@@ -500,6 +503,7 @@ mod tests {
                     },
                     protocol_fees: Default::default(),
                     quote: Default::default(),
+                    penalty_cap_native: Default::default(),
                 }),
                 app_data: Default::default(),
                 partial,

--- a/crates/driver/src/domain/competition/solution/mod.rs
+++ b/crates/driver/src/domain/competition/solution/mod.rs
@@ -171,6 +171,7 @@ impl Solution {
                             buy_token_balance: jit.order().buy_token_balance,
                             protocol_fees: vec![],
                             quote: None,
+                            penalty_cap_native: None,
                         }),
                         app_data: jit.order().app_data.into(),
                         partial: jit.order().partially_fillable(),

--- a/crates/driver/src/domain/quote.rs
+++ b/crates/driver/src/domain/quote.rs
@@ -229,6 +229,7 @@ impl Order {
                     },
                     protocol_fees: Default::default(),
                     quote: Default::default(),
+                    penalty_cap_native: Default::default(),
                 }),
                 app_data: Default::default(),
                 partial: competition::order::Partial::No,

--- a/crates/driver/src/infra/api/routes/solve/dto/solve_request.rs
+++ b/crates/driver/src/infra/api/routes/solve/dto/solve_request.rs
@@ -174,6 +174,9 @@ pub(crate) struct Order {
     #[serde_as(as = "serde_ext::Hex")]
     signature: Vec<u8>,
     quote: Option<Quote>,
+    #[serde_as(as = "Option<serde_ext::U256>")]
+    #[serde(default)]
+    penalty_cap_native: Option<eth::U256>,
 }
 
 impl Order {
@@ -277,6 +280,7 @@ impl Order {
                 quote: self
                     .quote
                     .map(|q| q.into_domain(self.sell_token, self.buy_token)),
+                penalty_cap_native: self.penalty_cap_native.map(Into::into),
             }),
             app_data,
             partial,

--- a/crates/driver/src/infra/solver/dto/auction.rs
+++ b/crates/driver/src/infra/solver/dto/auction.rs
@@ -162,6 +162,7 @@ pub fn new(
                             .map(fee_policy_from_domain)
                             .collect(),
                     ),
+                    penalty_cap_native: order.penalty_cap_native.map(Into::into),
                     app_data: AppDataHash(order.app_data.hash().0.into()),
                     flashloan_hint: flashloan_hints.get(&order.uid).map(Into::into),
                     wrappers: wrappers

--- a/crates/e2e/tests/e2e/main.rs
+++ b/crates/e2e/tests/e2e/main.rs
@@ -31,6 +31,7 @@ mod parallel_settlement;
 mod partial_fill;
 mod partially_fillable_balance;
 mod partially_fillable_pool;
+mod penalty_cap;
 mod place_order_with_quote;
 mod pool_indexer;
 mod protocol_fee;

--- a/crates/e2e/tests/e2e/penalty_cap.rs
+++ b/crates/e2e/tests/e2e/penalty_cap.rs
@@ -1,0 +1,87 @@
+use {
+    configs::{
+        autopilot::{Configuration, penalty_cap::PenaltyCapConfig, solver::Solver},
+        test_util::TestDefault,
+    },
+    e2e::setup::*,
+    ethrpc::alloy::CallBuilderExt,
+    model::{
+        order::{OrderCreation, OrderKind},
+        signature::EcdsaSigningScheme,
+    },
+    number::units::EthUnit,
+    shared::web3::Web3,
+};
+
+#[tokio::test]
+#[ignore]
+async fn local_node_penalty_cap() {
+    run_test(penalty_cap).await;
+}
+
+/// Places an order with the penalty cap feature enabled and asserts
+/// that the order gets a penalty cap assigned in the auction.
+async fn penalty_cap(web3: Web3) {
+    let mut onchain = OnchainComponents::deploy(web3).await;
+    let [solver] = onchain.make_solvers(1u64.eth()).await;
+    let [trader] = onchain.make_accounts(1u64.eth()).await;
+    let [token_a, token_b] = onchain
+        .deploy_tokens_with_weth_uni_v2_pools(1_000u64.eth(), 1_000u64.eth())
+        .await;
+
+    token_a.mint(trader.address(), 100u64.eth()).await;
+    token_a
+        .approve(onchain.contracts().allowance, 100u64.eth())
+        .from(trader.address())
+        .send_and_watch()
+        .await
+        .unwrap();
+
+    let services = Services::new(&onchain).await;
+    services
+        .start_protocol_with_args(
+            Configuration {
+                drivers: vec![Solver::test("test_solver", solver.address())],
+                penalty_cap: Some(PenaltyCapConfig {
+                    default_factor: 0.0004.try_into().unwrap(),
+                    absolute_cap_usd: 20.,
+                    // Use WETH as the USD reference token: its native price
+                    // is 1 by definition, so the bound is really 20 ETH here.
+                    // The test only cares about the plumbing.
+                    usd_reference_token: *onchain.contracts().weth.address(),
+                    overrides: vec![],
+                }),
+                ..Configuration::test_no_drivers()
+            },
+            configs::orderbook::Configuration::test_default(),
+            solver,
+        )
+        .await;
+
+    let order = OrderCreation {
+        sell_token: *token_a.address(),
+        sell_amount: 5u64.eth(),
+        buy_token: *token_b.address(),
+        buy_amount: 1u64.eth(),
+        valid_to: model::time::now_in_epoch_seconds() + 300,
+        kind: OrderKind::Sell,
+        ..Default::default()
+    }
+    .sign(
+        EcdsaSigningScheme::Eip712,
+        &onchain.contracts().domain_separator,
+        &trader.signer,
+    );
+    let uid = services.create_order(&order).await.unwrap();
+
+    // The order shows up in the auction with a non-zero penalty cap assigned.
+    wait_for_condition(TIMEOUT, || async {
+        onchain.mint_block().await;
+        let auction = services.get_auction().await.auction;
+        auction.orders.iter().any(|order| {
+            order.uid == uid && order.penalty_cap_native.is_some_and(|cap| !cap.is_zero())
+        })
+    })
+    .await
+    .unwrap();
+}

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -1572,6 +1572,12 @@ components:
             A winning quote.
           allOf:
             - $ref: "#/components/schemas/Quote"
+        penaltyCapNative:
+          description: >
+            Cap on the penalty a solver can incur for winning this order but
+            failing to execute it, denominated in the native token.
+          allOf:
+            - $ref: "#/components/schemas/TokenAmount"
       required:
         - uid
         - sellToken

--- a/crates/orderbook/src/dto/order.rs
+++ b/crates/orderbook/src/dto/order.rs
@@ -41,6 +41,9 @@ pub struct Order {
     #[serde(flatten)]
     pub signature: Signature,
     pub quote: Option<Quote>,
+    #[serde_as(as = "Option<HexOrDecimalU256>")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub penalty_cap_native: Option<alloy::primitives::U256>,
 }
 
 #[serde_as]

--- a/crates/solvers-dto/src/auction.rs
+++ b/crates/solvers-dto/src/auction.rs
@@ -44,6 +44,11 @@ pub struct Order {
     pub full_buy_amount: U256,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fee_policies: Option<Vec<FeePolicy>>,
+    /// Cap on the penalty a solver can incur for winning this order but
+    /// failing to execute it, in native token.
+    #[serde_as(as = "Option<HexOrDecimalU256>")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub penalty_cap_native: Option<U256>,
     pub valid_to: u32,
     pub kind: Kind,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/solvers/openapi.yml
+++ b/crates/solvers/openapi.yml
@@ -371,6 +371,12 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/FeePolicy"
+        penaltyCapNative:
+          allOf:
+            - description: |-
+                Cap on the penalty a solver can incur for winning this order
+                but failing to execute it, denominated in the native token.
+            - $ref: "#/components/schemas/TokenAmount"
         validTo:
           type: integer
         kind:


### PR DESCRIPTION
# Description
Now that the cap is computed, we would like to wire it through the whole stack so that drivers and solver engines are aware.

# Changes
* Pipe penalty cap to drivers and solver engine
* Expose penalty cap on the API
* Document API changes

## How to test
Added an e2e test. For now, the test asserts that the cap is non zero, but when printing it I ensured the value is reasonable (0.000398 ETH, which is ~4bp of the trade amount)

<!--
## Related Issues

Fixes #
-->
