### PR TITLE
Add settle slot headroom metric and more winner time buckets

### DIFF
--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -457,7 +457,15 @@ impl RunLoop {
             OrderEventLabel::Considered,
         );
         tracing::trace!(auction_id = ?auction.id, "orders marked as considered");
-        Metrics::winner_declared(start_block.observed_at.elapsed());
+        let run_loop_time = start_block.observed_at.elapsed();
+        Metrics::winner_declared(run_loop_time);
+        // The headroom is measured against the start block's slot, not against
+        // the moment we noticed it, so the time the block spent reaching us
+        // counts against the budget too.
+        Metrics::settle_slot_headroom(
+            self.eth.chain().block_time_in_ms(),
+            start_block.observation_lag + run_loop_time,
+        );
 
         for (solution_uid, winner) in ranking.enumerated().filter(|(_, bid)| bid.is_winner()) {
             let (driver, solution) = (winner.driver(), winner.solution());
@@ -1158,9 +1166,19 @@ struct Metrics {
     /// Total time between seeing the start block of the auction and declaring
     /// a winning driver.
     #[metric(buckets(
-        0, 1, 2, 3, 4, 5, 6, 7, 7.5, 8, 8.25, 8.5, 8.75, 9, 9.25, 9.5, 9.75, 10
+        0, 1, 2, 3, 4, 5, 5.5, 6, 6.25, 6.5, 6.75, 7, 7.5, 8, 8.25, 8.5, 8.75, 9, 9.25, 9.5, 9.75,
+        10, 12, 13, 14, 15, 17, 20
     ))]
     winner_declared: prometheus::Histogram,
+
+    /// `block_time - (observation_lag + observed_at..settle_dispatched)`: time
+    /// left for the winners to settle against the block after the auction's
+    /// start block. Negative means the run loop already consumed that block.
+    #[metric(buckets(
+        -8, -6, -5, -4.5, -4, -3.5, -3, -2.5, -2, -1.5, -1, -0.5, 0, 0.5, 1, 1.5, 2, 2.5, 3, 3.5,
+        4, 6, 8, 12
+    ))]
+    settle_slot_headroom: prometheus::Histogram,
 
     /// Total time spent in a single run of the run loop.
     #[metric(buckets(0, 3, 6, 9, 12, 15, 18, 21, 24, 27, 30, 33, 36, 39, 42, 45, 48))]
@@ -1262,6 +1280,12 @@ impl Metrics {
 
     fn winner_declared(elapsed: Duration) {
         Self::get().winner_declared.observe(elapsed.as_secs_f64());
+    }
+
+    fn settle_slot_headroom(block_time: Duration, elapsed: Duration) {
+        Self::get()
+            .settle_slot_headroom
+            .observe(block_time.as_secs_f64() - elapsed.as_secs_f64());
     }
 
     fn auction_ready(init_block_timestamp: Instant) {
@@ -1370,6 +1394,7 @@ mod tests {
             gas_price: Default::default(),
             base_fee: Default::default(),
             observed_at: Instant::now(),
+            observation_lag: Default::default(),
         }
     }
 

--- a/crates/ethrpc/src/block_stream.rs
+++ b/crates/ethrpc/src/block_stream.rs
@@ -9,7 +9,7 @@ use {
     futures::StreamExt,
     std::{
         fmt::Debug,
-        time::{Duration, Instant},
+        time::{Duration, Instant, SystemTime, UNIX_EPOCH},
     },
     tokio::sync::watch,
     tokio_stream::wrappers::WatchStream,
@@ -31,6 +31,10 @@ pub struct BlockInfo {
     pub base_fee: u64,
     /// When the system noticed the new block.
     pub observed_at: Instant,
+    /// Chain-side delay before we saw the block: wall clock at observation
+    /// minus the block's `timestamp`. Whole-second timestamps make this an
+    /// upper bound, so aggregate it instead of reading single samples.
+    pub observation_lag: Duration,
 }
 
 impl Default for BlockInfo {
@@ -44,6 +48,7 @@ impl Default for BlockInfo {
             gas_price: Default::default(),
             base_fee: Default::default(),
             observed_at: Instant::now(),
+            observation_lag: Default::default(),
         }
     }
 }
@@ -85,6 +90,12 @@ impl TryFrom<alloy_rpc_types::Header> for BlockInfo {
                 .base_fee_per_gas
                 .ok_or_else(|| anyhow!("no base fee available"))?,
             observed_at: Instant::now(),
+            // `saturating_sub` because a block can carry a timestamp in the
+            // future: test chains mine on demand and real nodes can drift.
+            observation_lag: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .saturating_sub(Duration::from_secs(value.timestamp)),
         })
     }
 }
@@ -337,6 +348,12 @@ pub struct Metrics {
         13.75, 14. // 12s
     ))]
     time_since_last_block: prometheus::Histogram,
+
+    /// Chain-side delay before a new block reaches us: a floor every service
+    /// inherits rather than something a service can optimise.
+    // resolution over the ~0.5-4s mainnet range, coarse above for slow chains
+    #[metric(buckets(0.1, 0.25, 0.5, 0.75, 1., 1.5, 2., 2.5, 3., 3.5, 4., 5., 6., 8., 12.))]
+    block_observation_lag: prometheus::Histogram,
 }
 
 fn update_block_metrics(previous_block: &BlockInfo, new_block: &BlockInfo) {
@@ -359,6 +376,9 @@ fn update_block_metrics(previous_block: &BlockInfo, new_block: &BlockInfo) {
     metrics
         .time_since_last_block
         .observe(previous_block.observed_at.elapsed().as_secs_f64());
+    metrics
+        .block_observation_lag
+        .observe(new_block.observation_lag.as_secs_f64());
 }
 
 /// Awaits and returns the next block that will be pushed into the stream.


### PR DESCRIPTION
# Description
Adds the headroom between a solver receiving signal to settle and the next block (can go negative if it skips the next block)

For reference, here's the existing heatmap:
<img width="2004" height="646" alt="image" src="https://github.com/user-attachments/assets/13984ee1-d3d5-47ac-a662-5b12abce662d" />

We're aiming to get more accurate samples between 7 and 12 seconds.

# Changes

* More intervals
