### PR TITLE
Increase time until /settle bucket granularity

### DIFF
--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -1158,7 +1158,8 @@ struct Metrics {
     /// Total time between seeing the start block of the auction and declaring
     /// a winning driver.
     #[metric(buckets(
-        0, 1, 2, 3, 4, 5, 6, 7, 7.5, 8, 8.25, 8.5, 8.75, 9, 9.25, 9.5, 9.75, 10
+        0, 1, 2, 3, 4, 5, 6, 7, 7.25, 7.5, 7.75, 8, 8.25, 8.5, 8.75, 9, 9.25, 9.5, 9.75, 10, 10.25,
+        10.5, 10.75, 11, 11.25, 11.5, 11.75, 12, 12.5, 13, 15, 17, 20
     ))]
     winner_declared: prometheus::Histogram,
 


### PR DESCRIPTION
# Description
Increases the granularity for the time until /settle bucket.

For reference, here's the existing heatmap:
<img width="2004" height="646" alt="image" src="https://github.com/user-attachments/assets/13984ee1-d3d5-47ac-a662-5b12abce662d" />

We're aiming to get more accurate samples between 7 and 12 seconds.

# Changes

* More intervals
