### PR TITLE
Fix the flaky insufficient-funds e2e test at its source

### DIFF
--- a/crates/autopilot/src/database/order_events.rs
+++ b/crates/autopilot/src/database/order_events.rs
@@ -25,6 +25,10 @@ const INSERT_CHUNK_SIZE: usize = 1000;
 /// label.
 const DEDUP_LOCK: &str = "order_events_dedup";
 
+/// Takes the [`DEDUP_LOCK`] of the bound label.
+const DEDUP_LOCK_QUERY: &str =
+    "SELECT pg_advisory_xact_lock(hashtextextended($1::text || $2::text, 0))";
+
 pub async fn store_order_events(
     ex: &mut PgConnection,
     order_uids: impl IntoIterator<Item = domain::OrderUid>,
@@ -42,7 +46,7 @@ pub async fn store_order_events(
         // only same-label writers to serialize. The lock lives until the
         // outermost transaction commits, and only writers taking it are
         // race-free.
-        sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1::text || $2::text, 0))")
+        sqlx::query(DEDUP_LOCK_QUERY)
             .bind(DEDUP_LOCK)
             .bind(label)
             .execute(&mut *ex)
@@ -131,16 +135,26 @@ mod tests {
         assert_eq!(labels, ["created", "invalid"]);
     }
 
-    /// Writers carrying different labels take different locks, so both append
-    /// whichever order they land in.
+    /// Only same-label writers exclude each other. Holding the `Invalid` lock
+    /// stalls an `Invalid` write while a `Filtered` write runs through, the one
+    /// difference a per-label key makes over a table-wide one: the rows either
+    /// key produces are the same.
     #[tokio::test]
     #[ignore]
-    async fn postgres_concurrent_writes_of_distinct_labels_both_append() {
+    async fn postgres_dedup_lock_is_per_label() {
         let db = Postgres::with_defaults().await.unwrap();
         let mut ex = db.pool.begin().await.unwrap();
         database::clear_DANGER_(&mut ex).await.unwrap();
         ex.commit().await.unwrap();
         let uid = ByteArray([7; 56]);
+
+        let mut holder = db.pool.begin().await.unwrap();
+        sqlx::query(DEDUP_LOCK_QUERY)
+            .bind(DEDUP_LOCK)
+            .bind(OrderEventLabel::Invalid)
+            .execute(&mut *holder)
+            .await
+            .unwrap();
 
         let write = |label| {
             let pool = db.pool.clone();
@@ -150,18 +164,28 @@ mod tests {
                     .await;
             }
         };
-        tokio::join!(
-            write(OrderEventLabel::Invalid),
-            write(OrderEventLabel::Filtered)
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            write(OrderEventLabel::Filtered),
+        )
+        .await
+        .expect("a different label does not wait for the invalid lock");
+        assert!(
+            tokio::time::timeout(
+                std::time::Duration::from_millis(500),
+                write(OrderEventLabel::Invalid)
+            )
+            .await
+            .is_err(),
+            "the same label waits for the lock holder"
         );
 
-        let mut labels: Vec<String> =
-            sqlx::query_scalar("SELECT label::text FROM order_events WHERE order_uid = $1")
-                .bind(uid)
-                .fetch_all(&db.pool)
-                .await
-                .unwrap();
-        labels.sort();
-        assert_eq!(labels, ["filtered", "invalid"]);
+        holder.rollback().await.unwrap();
+        tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            write(OrderEventLabel::Invalid),
+        )
+        .await
+        .expect("the write proceeds once the lock is released");
     }
 }

--- a/crates/autopilot/src/database/order_events.rs
+++ b/crates/autopilot/src/database/order_events.rs
@@ -36,8 +36,9 @@ pub async fn store_order_events(
     let insert = async move {
         let mut ex = ex.begin().await?;
         // The dedup below compares against committed rows only, so writers
-        // that overlap both append. Table-wide rather than per order: these
-        // transactions are small and detached. Only writers taking this lock
+        // that overlap both append. One table-wide lock, held until the
+        // outermost transaction commits: a caller passing a long-running
+        // transaction stalls every other writer. Only writers taking this lock
         // are race-free.
         sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))")
             .bind(DEDUP_LOCK)

--- a/crates/autopilot/src/database/order_events.rs
+++ b/crates/autopilot/src/database/order_events.rs
@@ -21,7 +21,8 @@ impl super::Postgres {
 /// individual queries bounded regardless of how many events are stored at once.
 const INSERT_CHUNK_SIZE: usize = 1000;
 
-/// Advisory-lock name serializing the deduplicating event insert.
+/// Advisory-lock namespace for the deduplicating event insert, one lock per
+/// label.
 const DEDUP_LOCK: &str = "order_events_dedup";
 
 pub async fn store_order_events(
@@ -36,12 +37,14 @@ pub async fn store_order_events(
     let insert = async move {
         let mut ex = ex.begin().await?;
         // The dedup below compares against committed rows only, so writers
-        // that overlap both append. One table-wide lock, held until the
-        // outermost transaction commits: a caller passing a long-running
-        // transaction stalls every other writer. Only writers taking this lock
-        // are race-free.
-        sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))")
+        // that overlap both append. Keyed per label because writers carrying
+        // different labels append in either order for the same result, leaving
+        // only same-label writers to serialize. The lock lives until the
+        // outermost transaction commits, and only writers taking it are
+        // race-free.
+        sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1::text || $2::text, 0))")
             .bind(DEDUP_LOCK)
+            .bind(label)
             .execute(&mut *ex)
             .await?;
         let mut order_uids = order_uids.into_iter().map(|o| ByteArray(o.0));
@@ -126,5 +129,39 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(labels, ["created", "invalid"]);
+    }
+
+    /// Writers carrying different labels take different locks, so both append
+    /// whichever order they land in.
+    #[tokio::test]
+    #[ignore]
+    async fn postgres_concurrent_writes_of_distinct_labels_both_append() {
+        let db = Postgres::with_defaults().await.unwrap();
+        let mut ex = db.pool.begin().await.unwrap();
+        database::clear_DANGER_(&mut ex).await.unwrap();
+        ex.commit().await.unwrap();
+        let uid = ByteArray([7; 56]);
+
+        let write = |label| {
+            let pool = db.pool.clone();
+            async move {
+                let mut ex = pool.acquire().await.unwrap();
+                store_order_events(&mut ex, [domain::OrderUid(uid.0)], label, None, Utc::now())
+                    .await;
+            }
+        };
+        tokio::join!(
+            write(OrderEventLabel::Invalid),
+            write(OrderEventLabel::Filtered)
+        );
+
+        let mut labels: Vec<String> =
+            sqlx::query_scalar("SELECT label::text FROM order_events WHERE order_uid = $1")
+                .bind(uid)
+                .fetch_all(&db.pool)
+                .await
+                .unwrap();
+        labels.sort();
+        assert_eq!(labels, ["filtered", "invalid"]);
     }
 }

--- a/crates/autopilot/src/database/order_events.rs
+++ b/crates/autopilot/src/database/order_events.rs
@@ -135,13 +135,23 @@ mod tests {
         assert_eq!(labels, ["created", "invalid"]);
     }
 
-    /// Only same-label writers exclude each other. Holding the `Invalid` lock
-    /// stalls an `Invalid` write while a `Filtered` write runs through, the one
-    /// difference a per-label key makes over a table-wide one: the rows either
-    /// key produces are the same.
+    /// Only same-label writers exclude each other. While the `Invalid` lock is
+    /// held, a `Filtered` write runs through and an `Invalid` write queues
+    /// behind that exact lock, the one difference a per-label key makes over a
+    /// table-wide one: the rows either key produces are the same.
     #[tokio::test]
     #[ignore]
     async fn postgres_dedup_lock_is_per_label() {
+        /// A writer waiting on the advisory lock another session holds.
+        const QUEUED_ON_HELD_LOCK: &str = r#"
+SELECT EXISTS (
+    SELECT 1
+    FROM pg_locks held
+    JOIN pg_locks waiting USING (locktype, classid, objid, objsubid)
+    WHERE held.locktype = 'advisory' AND held.granted AND NOT waiting.granted
+)
+        "#;
+
         let db = Postgres::with_defaults().await.unwrap();
         let mut ex = db.pool.begin().await.unwrap();
         database::clear_DANGER_(&mut ex).await.unwrap();
@@ -170,22 +180,25 @@ mod tests {
         )
         .await
         .expect("a different label does not wait for the invalid lock");
-        assert!(
-            tokio::time::timeout(
-                std::time::Duration::from_millis(500),
-                write(OrderEventLabel::Invalid)
-            )
-            .await
-            .is_err(),
-            "the same label waits for the lock holder"
-        );
+
+        let blocked = tokio::spawn(write(OrderEventLabel::Invalid));
+        let mut queued = false;
+        for _ in 0..50 {
+            queued = sqlx::query_scalar(QUEUED_ON_HELD_LOCK)
+                .fetch_one(&db.pool)
+                .await
+                .unwrap();
+            if queued {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+        assert!(queued, "the same label waits on the held lock");
 
         holder.rollback().await.unwrap();
-        tokio::time::timeout(
-            std::time::Duration::from_secs(5),
-            write(OrderEventLabel::Invalid),
-        )
-        .await
-        .expect("the write proceeds once the lock is released");
+        tokio::time::timeout(std::time::Duration::from_secs(5), blocked)
+            .await
+            .expect("the write proceeds once the lock is released")
+            .unwrap();
     }
 }

--- a/crates/autopilot/src/database/order_events.rs
+++ b/crates/autopilot/src/database/order_events.rs
@@ -35,12 +35,10 @@ pub async fn store_order_events(
 
     let insert = async move {
         let mut ex = ex.begin().await?;
-        // The insert below skips an event whose label and reason already match
-        // the order's latest event, a comparison that only sees committed rows,
-        // so two overlapping writers would both append. One lock for the whole
-        // table rather than per order: these transactions are small and run
-        // detached. Writers that insert events without taking this lock stay
-        // exposed to the same race.
+        // The dedup below compares against committed rows only, so writers
+        // that overlap both append. Table-wide rather than per order: these
+        // transactions are small and detached. Only writers taking this lock
+        // are race-free.
         sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))")
             .bind(DEDUP_LOCK)
             .execute(&mut *ex)
@@ -84,9 +82,8 @@ mod tests {
         },
     };
 
-    /// Two writers reporting the same label concurrently append one event, not
-    /// two: the deduplicating insert compares against the order's latest event,
-    /// which is only sound while the writes are serialized.
+    /// Unserialized writers would append the same label twice: the dedup
+    /// reads committed rows only.
     #[tokio::test]
     #[ignore]
     async fn postgres_concurrent_writes_append_one_event() {

--- a/crates/autopilot/src/database/order_events.rs
+++ b/crates/autopilot/src/database/order_events.rs
@@ -21,6 +21,9 @@ impl super::Postgres {
 /// individual queries bounded regardless of how many events are stored at once.
 const INSERT_CHUNK_SIZE: usize = 1000;
 
+/// Advisory-lock key serializing the deduplicating event insert.
+const ORDER_EVENTS_WRITE_LOCK: i64 = 0x6f_72_64_65_72_5f_65_76;
+
 pub async fn store_order_events(
     ex: &mut PgConnection,
     order_uids: impl IntoIterator<Item = domain::OrderUid>,
@@ -32,6 +35,13 @@ pub async fn store_order_events(
 
     let insert = async move {
         let mut ex = ex.begin().await?;
+        // The insert below skips an event whose label and reason already match
+        // the order's latest event. That comparison reads uncommitted-invisible
+        // rows, so two overlapping writers would both append. Serialize them.
+        sqlx::query("SELECT pg_advisory_xact_lock($1)")
+            .bind(ORDER_EVENTS_WRITE_LOCK)
+            .execute(&mut *ex)
+            .await?;
         let mut order_uids = order_uids.into_iter().map(|o| ByteArray(o.0));
         let capacity = match order_uids.size_hint().1 {
             Some(hint) => std::cmp::min(hint, INSERT_CHUNK_SIZE),
@@ -57,5 +67,63 @@ pub async fn store_order_events(
             tracing::debug!(?label, count, elapsed = ?start.elapsed(), "stored order events")
         }
         Err(err) => tracing::warn!(?label, ?err, "failed to insert order events"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::database::Postgres,
+        database::{
+            byte_array::ByteArray,
+            order_events::{OrderEvent, OrderEventLabel},
+        },
+    };
+
+    /// Two writers reporting the same label concurrently append one event, not
+    /// two: the deduplicating insert compares against the order's latest event,
+    /// which is only sound while the writes are serialized.
+    #[tokio::test]
+    #[ignore]
+    async fn postgres_concurrent_writes_append_one_event() {
+        let db = Postgres::with_defaults().await.unwrap();
+        let mut ex = db.pool.begin().await.unwrap();
+        database::clear_DANGER_(&mut ex).await.unwrap();
+        let uid = ByteArray([7; 56]);
+        database::order_events::insert_order_event(
+            &mut ex,
+            &OrderEvent {
+                order_uid: uid,
+                timestamp: Utc::now(),
+                label: OrderEventLabel::Created,
+                reason: None,
+            },
+        )
+        .await
+        .unwrap();
+        ex.commit().await.unwrap();
+
+        let write = || async {
+            let mut ex = db.pool.acquire().await.unwrap();
+            store_order_events(
+                &mut ex,
+                [domain::OrderUid(uid.0)],
+                OrderEventLabel::Invalid,
+                Some(OrderFilterReason::InsufficientBalance),
+                Utc::now(),
+            )
+            .await;
+        };
+        tokio::join!(write(), write());
+
+        let labels: Vec<String> = sqlx::query_scalar(
+            "SELECT label::text FROM order_events WHERE order_uid = $1 ORDER BY timestamp",
+        )
+        .bind(uid)
+        .fetch_all(&db.pool)
+        .await
+        .unwrap();
+        assert_eq!(labels, ["created", "invalid"]);
     }
 }

--- a/crates/autopilot/src/database/order_events.rs
+++ b/crates/autopilot/src/database/order_events.rs
@@ -21,8 +21,8 @@ impl super::Postgres {
 /// individual queries bounded regardless of how many events are stored at once.
 const INSERT_CHUNK_SIZE: usize = 1000;
 
-/// Advisory-lock key serializing the deduplicating event insert.
-const ORDER_EVENTS_WRITE_LOCK: i64 = 0x6f_72_64_65_72_5f_65_76;
+/// Advisory-lock name serializing the deduplicating event insert.
+const DEDUP_LOCK: &str = "order_events_dedup";
 
 pub async fn store_order_events(
     ex: &mut PgConnection,
@@ -36,10 +36,13 @@ pub async fn store_order_events(
     let insert = async move {
         let mut ex = ex.begin().await?;
         // The insert below skips an event whose label and reason already match
-        // the order's latest event. That comparison reads uncommitted-invisible
-        // rows, so two overlapping writers would both append. Serialize them.
-        sqlx::query("SELECT pg_advisory_xact_lock($1)")
-            .bind(ORDER_EVENTS_WRITE_LOCK)
+        // the order's latest event, a comparison that only sees committed rows,
+        // so two overlapping writers would both append. One lock for the whole
+        // table rather than per order: these transactions are small and run
+        // detached. Writers that insert events without taking this lock stay
+        // exposed to the same race.
+        sqlx::query("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))")
+            .bind(DEDUP_LOCK)
             .execute(&mut *ex)
             .await?;
         let mut order_uids = order_uids.into_iter().map(|o| ByteArray(o.0));

--- a/crates/e2e/tests/e2e/tracking_insufficient_funds.rs
+++ b/crates/e2e/tests/e2e/tracking_insufficient_funds.rs
@@ -164,7 +164,7 @@ async fn test(web3: Web3) {
         .unwrap();
     let orders_updated = || async {
         onchain.mint_block().await;
-        let events_a = crate::database::events_of_order(services.db(), &uid_b).await;
+        let events_a = crate::database::events_of_order(services.db(), &uid_a).await;
         let events_b = crate::database::events_of_order(services.db(), &uid_b).await;
         events_a.last().map(|o| o.label) == Some(OrderEventLabel::Traded)
             && events_b.last().map(|o| o.label) == Some(OrderEventLabel::Traded)


### PR DESCRIPTION
# Description
`tracking_insufficient_funds::local_node_test` has been failing intermittently in CI, and it looks like that the cause is in the event writer rather than the test.

The writer is supposed to skip an event when it repeats the order's current state: before inserting, it reads the order's latest event and drops the new one if the label and reason are identical. That read only sees committed rows. Two writers running at the same time therefore both read the state from before either of them started, both conclude the event is new, and both insert it.

The autopilot triggers one such write per cache update, each in its own task, so overlapping writes are normal. That is what happened in the failing run: an order was reported invalid twice in a row and both writes landed, leaving `[Created, Invalid, Invalid]`. The test waits for exactly `[Created, Invalid]`, which by then could never appear, so it sat there until it timed out.

Two transactions running the statement concurrently reproduce it. Rows for the order, before and after the fix:

```
before:  created 1, invalid 2
after:   created 1, invalid 1
```

The new Postgres test does the same thing from Rust, and fails with `["created", "invalid", "invalid"]` if the lock is taken out again.

# Changes
- Serialize the deduplicating order event insert with a transaction-scoped advisory lock
- `tracking_insufficient_funds` reads `uid_a` in its last phase, which previously read `uid_b` twice and never asserted anything about the first order

# How to test
New Postgres test, plus the e2e test that was flaking.
