### PR TITLE
don't capture generated code under `contracts` sub-workspace

### DIFF
--- a/contracts/Cargo.toml
+++ b/contracts/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 publish = false
 
 [workspace]
+exclude = ["generated"]
 
 [dependencies]
 alloy-sol-macro-expander = "1.4.1"


### PR DESCRIPTION
# Description
Migrating to generating the `contract` bindings in a separate directory to improve compile times was a breaking change which prevents us from upgrading the `solvers` repository's dependency on the `contracts` package.
The reason appears to be that the new workspace responsible for generating the bindings subsumes them under it. This is not an issue for the services repo because it can freely reference paths when necessary but that's not an option for the `solvers` repository as specifying `git` and `path` in a dependency are mutually exclusive so we have to rely on cargo's default workspace resolution to find all the packages we need.

# Changes
The solution appears to be pretty straight forward. We only need to explicitly exclude the generated code from the new separate cargo workspace. That allows cargo's default dependency resolution to find all the necessary crates which means the `contracts` package defined in the main `Cargo.toml` can actually be referenced correctly again.

## How to test
Pointed a local checkout of the `solvers` repository to this branch and everything compiled again.