### PR TITLE
Unconditionally replace block/tip in next_auction

### DIFF
--- a/crates/autopilot-svm/src/run_loop.rs
+++ b/crates/autopilot-svm/src/run_loop.rs
@@ -198,9 +198,7 @@ impl<C: Cycle> AuctionLoop<C> {
     async fn next_auction(&mut self, tip: &C::Tip) -> Option<C::Auction> {
         let auction = self.provider.cut_auction(tip).await?;
 
-        // Only rerun the competition if the auction or tip changed. The tip
-        // marker is only written when the auction was unchanged, so the
-        // dedupe kicks in one cycle after the auction first repeats.
+        // Only rerun the competition if the auction or tip changed.
         let previous_auction = self.prev_auction.replace(auction.clone());
         let previous_tip = self.prev_tip.replace(tip.clone());
         if previous_auction.as_ref() == Some(&auction) && previous_tip.as_ref() == Some(tip) {

--- a/crates/autopilot-svm/src/run_loop.rs
+++ b/crates/autopilot-svm/src/run_loop.rs
@@ -201,10 +201,9 @@ impl<C: Cycle> AuctionLoop<C> {
         // Only rerun the competition if the auction or tip changed. The tip
         // marker is only written when the auction was unchanged, so the
         // dedupe kicks in one cycle after the auction first repeats.
-        let previous = self.prev_auction.replace(auction.clone());
-        if previous.as_ref() == Some(&auction)
-            && self.prev_tip.replace(tip.clone()).as_ref() == Some(tip)
-        {
+        let previous_auction = self.prev_auction.replace(auction.clone());
+        let previous_tip = self.prev_tip.replace(tip.clone());
+        if previous_auction.as_ref() == Some(&auction) && previous_tip.as_ref() == Some(tip) {
             return None;
         }
 

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -353,14 +353,13 @@ impl RunLoop {
         tracing::trace!(auction_id = ?auction.id, "auction cut");
 
         // Only run the solvers if the auction or block has changed.
-        let previous = prev_auction.replace(auction.clone());
-        if previous.as_ref() == Some(&auction)
-            && prev_block.replace(start_block.hash) == Some(start_block.hash)
-        {
+        let previous_auction = prev_auction.replace(auction.clone());
+        let previous_block = prev_block.replace(start_block.hash);
+        if previous_auction.as_ref() == Some(&auction) && previous_block == Some(start_block.hash) {
             return None;
         }
 
-        observe::log_auction_delta(previous.as_deref(), &auction, &start_block);
+        observe::log_auction_delta(previous_auction.as_deref(), &auction, &start_block);
         self.probes.liveness.auction();
         Metrics::auction_ready(start_block.observed_at);
         Some(auction)

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -235,7 +235,7 @@ impl RunLoop {
             // order, new block). We only update the cache afterwards to update
             // to the most recent state.
             self_arc.wake_notify.notified().await;
-            let start_block = self_arc.wait_until_auction_start(&mut last_block).await;
+            let start_block = self_arc.wait_until_auction_start(&last_block).await;
             self_arc
                 .update_caches(start_block, leader_lock_tracker.is_leader())
                 .await;
@@ -297,7 +297,7 @@ impl RunLoop {
     }
 
     #[instrument(skip_all)]
-    async fn wait_until_auction_start(&self, prev_block: &mut Option<B256>) -> BlockInfo {
+    async fn wait_until_auction_start(&self, prev_block: &Option<B256>) -> BlockInfo {
         let current_block = *self.eth.current_block().borrow();
         let time_since_last_block = current_block.observed_at.elapsed();
         if time_since_last_block > self.config.max_run_loop_delay {


### PR DESCRIPTION
# Description
On busy networks the auction is never the same, as such the conditional short circuits and never replaces the auction.
This leads to the log about missing the deadline never being activated.

# Changes

* Unconditional previous block/tip replacement

## How to test
Me and Martin technically did negative testing, we drove down the delay interval to values that should force the log to show and it didn't, after investigation we found this, hence after deployment the log should start showing sometimes.