### PR TITLE
CI: switch autodeploy back to the rollout strategy

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -145,7 +145,7 @@ jobs:
         if: ${{ github.ref == 'refs/heads/main' }}
         with:
           images: ghcr.io/cowprotocol/services:main
-          strategy: restart # Recreates the deployment
+          strategy: rollout # Rolling restart (kubectl rollout restart), zero downtime
           tag: ${{ secrets.AUTODEPLOY_TAG }}
           url: ${{ secrets.AUTODEPLOY_URL }}
           token: ${{ secrets.AUTODEPLOY_TOKEN }}


### PR DESCRIPTION
# Description

Switches the staging autodeploy from `strategy: restart` back to `strategy: rollout`.

`restart` is implemented in k8s-autodeploy as `kubectl replace --force` — it deletes and recreates every deployment running `services:main`, so every service is fully down for ~60–90s on each merge to main. On 2026-08-25, five merges bounced all ~95 staging deployments five times (confirmed via EKS audit log) and fired false `NoNewBlocks` alerts for ink and arbitrum-one, whose block-gap thresholds are tighter than a pod replacement.

`rollout` (`kubectl rollout restart`) honors the deployments' `RollingUpdate {maxSurge: 1, maxUnavailable: 0}` spec: the old pod keeps serving until the new one is Ready, and new pods still pull `:main` fresh (staging pins `imagePullPolicy: Always`).

## Why the #3695 rationale no longer applies

`restart` was chosen in #3695 because a stalled rollout could fail silently. Since then, `KubeDeploymentRolloutStuck` and `KubeDeploymentReplicasMismatch` alerts fire after 15m in both clusters and route to the deployment's `cow.fi/team` (backend for services). A broken image now alerts loudly *and* leaves the old version serving, instead of leaving the service down.

## Verified end to end

- `rollout` is a valid action input (it's the action's default) and posts to `/images/<image>/rollout`
- The route exists in k8s-autodeploy (predates `restart`), same image filter, runs `kubectl rollout restart` per matching deployment
- The autodeploy SA's Role includes `patch` on deployments; the running staging pod's image contains both routes