### PR TITLE
Fix deadlock on "unlimited" concurrency parameter

### DIFF
--- a/crates/ethrpc/src/alloy/buffering.rs
+++ b/crates/ethrpc/src/alloy/buffering.rs
@@ -187,7 +187,12 @@ where
             CallContext<SerializedRequest, Result<Response, TransportError>>,
         >,
     ) -> JoinHandle<()> {
-        let semaphore = Arc::new(Semaphore::new(config.ethrpc_max_concurrent_requests));
+        let permits = if config.ethrpc_max_concurrent_requests == 0 {
+            Semaphore::MAX_PERMITS
+        } else {
+            config.ethrpc_max_concurrent_requests
+        };
+        let semaphore = Arc::new(Semaphore::new(permits));
         let max_batch_size = config.ethrpc_max_batch_size;
         let batch_delay = config.ethrpc_batch_delay;
 


### PR DESCRIPTION
# Description
Docs state `Use '0' for no limit on concurrency` which in practice leads to a deadlock since a Semaphore with 0 permits never yields a permit.

# Changes

* On 0, use MAX_PERMITS instead

