### PR TITLE
classify `CustomSolverError` as no liquidity

### DIFF
--- a/crates/autopilot/src/infra/api.rs
+++ b/crates/autopilot/src/infra/api.rs
@@ -143,7 +143,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn maps_custom_solver_errors_to_bad_request_with_message() {
+    async fn maps_known_solver_errors_to_bad_request_with_message() {
         assert_bad_request_message(
             PriceEstimationError::TradingOutsideAllowedWindow {
                 message: "outside window".to_string(),
@@ -167,13 +167,16 @@ mod tests {
             "insufficient",
         )
         .await;
-
-        assert_bad_request_message(
-            PriceEstimationError::CustomSolverError {
+    }
+    #[tokio::test]
+    async fn maps_unknown_solver_errors_to_no_liquidity() {
+        let response = error_to_response(PriceEstimationError::CustomSolverError {
                 message: "custom".to_string(),
-            },
-            "custom",
-        )
-        .await;
+            });
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        let body = response.into_body();
+        let body = axum::body::to_bytes(body, usize::MAX).await.unwrap();
+        assert_eq!(std::str::from_utf8(&body).unwrap(), "No liquidity");
     }
 }

--- a/crates/autopilot/src/infra/api.rs
+++ b/crates/autopilot/src/infra/api.rs
@@ -100,7 +100,9 @@ async fn get_native_price(
 
 fn error_to_response(err: PriceEstimationError) -> Response {
     match err {
-        PriceEstimationError::NoLiquidity | PriceEstimationError::EstimatorInternal(_) => {
+        PriceEstimationError::NoLiquidity
+        | PriceEstimationError::EstimatorInternal(_)
+        | PriceEstimationError::CustomSolverError { .. } => {
             (StatusCode::NOT_FOUND, "No liquidity").into_response()
         }
         PriceEstimationError::UnsupportedToken { token: _, reason } => (
@@ -113,8 +115,7 @@ fn error_to_response(err: PriceEstimationError) -> Response {
         }
         PriceEstimationError::TradingOutsideAllowedWindow { message }
         | PriceEstimationError::TokenTemporarilySuspended { message }
-        | PriceEstimationError::InsufficientLiquidity { message }
-        | PriceEstimationError::CustomSolverError { message } => {
+        | PriceEstimationError::InsufficientLiquidity { message } => {
             (StatusCode::BAD_REQUEST, message).into_response()
         }
         PriceEstimationError::UnsupportedOrderType(reason) => (

--- a/crates/autopilot/src/infra/api.rs
+++ b/crates/autopilot/src/infra/api.rs
@@ -171,8 +171,8 @@ mod tests {
     #[tokio::test]
     async fn maps_unknown_solver_errors_to_no_liquidity() {
         let response = error_to_response(PriceEstimationError::CustomSolverError {
-                message: "custom".to_string(),
-            });
+            message: "custom".to_string(),
+        });
 
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
         let body = response.into_body();

--- a/crates/e2e/tests/e2e/quoting.rs
+++ b/crates/e2e/tests/e2e/quoting.rs
@@ -568,31 +568,35 @@ async fn quote_custom_solver_errors(web3: Web3) {
     let cases = vec![
         (
             SolverErrorCode::TradingOutsideAllowedWindow,
+            StatusCode::BAD_REQUEST,
             "TradingOutsideAllowedWindow",
             None,
             "Token can only be traded during specific time windows",
         ),
         (
             SolverErrorCode::TokenTemporarilySuspended,
+            StatusCode::BAD_REQUEST,
             "TokenTemporarilySuspended",
             Some("token is suspended"),
             "token is suspended",
         ),
         (
             SolverErrorCode::InsufficientLiquidity,
+            StatusCode::BAD_REQUEST,
             "InsufficientLiquidity",
             Some("not enough liquidity"),
             "not enough liquidity",
         ),
         (
             SolverErrorCode::Other,
-            "CustomSolverError",
+            StatusCode::NOT_FOUND,
+            "NoLiquidity",
             Some("some solver specific error"),
-            "some solver specific error",
+            "no route found",
         ),
     ];
 
-    for (code, expected_kind, sent_message, expected_message) in cases {
+    for (code, expected_http_code, expected_kind, sent_message, expected_message) in cases {
         mock_solver.configure_response(SolverResponse::Error {
             error: SolverError {
                 code,
@@ -601,7 +605,7 @@ async fn quote_custom_solver_errors(web3: Web3) {
         });
 
         let (status, body) = services.submit_quote(&quote_request).await.unwrap_err();
-        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(status, expected_http_code);
         assert!(
             body.contains(expected_kind),
             "response should include error kind {expected_kind}, got {body}"
@@ -821,13 +825,13 @@ async fn quote_custom_solver_errors_prioritized(web3: Web3) {
     };
 
     let (status, body) = services.submit_quote(&quote_request).await.unwrap_err();
-    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(status, StatusCode::NOT_FOUND);
     assert!(
-        body.contains("CustomSolverError"),
+        body.contains("NoLiquidity"),
         "response should include custom solver error, got {body}"
     );
     assert!(
-        body.contains("priority custom solver error"),
+        body.contains("no route found"),
         "response should include prioritized custom error message, got {body}"
     );
 }

--- a/crates/e2e/tests/e2e/quoting.rs
+++ b/crates/e2e/tests/e2e/quoting.rs
@@ -678,27 +678,31 @@ async fn native_price_custom_solver_errors(web3: Web3) {
     let cases = vec![
         (
             SolverErrorCode::TradingOutsideAllowedWindow,
+            StatusCode::BAD_REQUEST,
             "TradingOutsideAllowedWindow",
             "native window closed",
         ),
         (
             SolverErrorCode::TokenTemporarilySuspended,
+            StatusCode::BAD_REQUEST,
             "TokenTemporarilySuspended",
             "native token suspended",
         ),
         (
             SolverErrorCode::InsufficientLiquidity,
+            StatusCode::BAD_REQUEST,
             "InsufficientLiquidity",
             "native not enough liquidity",
         ),
         (
             SolverErrorCode::Other,
-            "CustomSolverError",
-            "native custom solver reason",
+            StatusCode::NOT_FOUND,
+            "NoLiquidity",
+            "no route found",
         ),
     ];
 
-    for (code, expected_kind, message) in cases {
+    for (code, expected_http_code, expected_kind, message) in cases {
         mock_solver.configure_response(SolverResponse::Error {
             error: SolverError {
                 code,
@@ -710,7 +714,7 @@ async fn native_price_custom_solver_errors(web3: Web3) {
             .get_native_price(sell_token.address())
             .await
             .unwrap_err();
-        assert_eq!(status, StatusCode::BAD_REQUEST);
+        assert_eq!(status, expected_http_code);
         assert!(
             body.contains(expected_kind),
             "response should include error kind {expected_kind}, got {body}"

--- a/crates/orderbook/openapi.yml
+++ b/crates/orderbook/openapi.yml
@@ -1898,7 +1898,7 @@ components:
         Error quoting an order.
 
         Possible `errorType` values per HTTP status:
-        * 400: `AppDataHashMismatch`, `CustomSolverError`, `ExcessiveValidTo`,
+        * 400: `AppDataHashMismatch`, `ExcessiveValidTo`,
           `InsufficientLiquidity`, `InsufficientValidTo`, `InvalidAppData`,
           `InvalidNativeSellToken`, `QuoteNotVerified`, `SameBuyAndSellToken`,
           `SellAmountDoesNotCoverFee`, `TokenTemporarilySuspended`,

--- a/crates/orderbook/src/api.rs
+++ b/crates/orderbook/src/api.rs
@@ -611,7 +611,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn maps_custom_price_estimation_errors_to_bad_request_responses() {
+    async fn maps_known_solver_errors_to_bad_request_responses() {
         let cases = [
             (
                 PriceEstimationError::TradingOutsideAllowedWindow {
@@ -634,13 +634,6 @@ mod tests {
                 "InsufficientLiquidity",
                 "insufficient liquidity",
             ),
-            (
-                PriceEstimationError::CustomSolverError {
-                    message: "custom solver reason".to_string(),
-                },
-                "CustomSolverError",
-                "custom solver reason",
-            ),
         ];
 
         for (err, expected_type, expected_description) in cases {
@@ -655,6 +648,20 @@ mod tests {
             assert_eq!(body.error_type, expected_type);
             assert_eq!(body.description.as_ref(), expected_description);
         }
+    }
+
+    #[tokio::test]
+    async fn maps_unknown_solver_errors_to_no_liquidity_responses() {
+        let response = PriceEstimationErrorWrapper(PriceEstimationError::CustomSolverError {
+            message: "custom solver reason".to_string(),
+        })
+        .into_response();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body: Error = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(body.error_type, "NoLiquidity");
     }
 
     // Tests for Axum extractor type parsing.

--- a/crates/orderbook/src/api.rs
+++ b/crates/orderbook/src/api.rs
@@ -481,7 +481,8 @@ impl IntoResponse for PriceEstimationErrorWrapper {
                 .into_response(),
             PriceEstimationError::NoLiquidity
             | PriceEstimationError::RateLimited
-            | PriceEstimationError::EstimatorInternal(_) => (
+            | PriceEstimationError::EstimatorInternal(_)
+            | PriceEstimationError::CustomSolverError { .. } => (
                 StatusCode::NOT_FOUND,
                 error("NoLiquidity", "no route found"),
             )
@@ -501,9 +502,6 @@ impl IntoResponse for PriceEstimationErrorWrapper {
                 error("InsufficientLiquidity", message),
             )
                 .into_response(),
-            PriceEstimationError::CustomSolverError { message } => {
-                (StatusCode::BAD_REQUEST, error("CustomSolverError", message)).into_response()
-            }
             PriceEstimationError::ProtocolInternal(err) => {
                 tracing::error!(?err, "PriceEstimationError::Other");
                 internal_error_reply()


### PR DESCRIPTION
# Description
Currently `CustomSolverErrors` get converted to internal server errors which are concerning for API consumers.
Since `CustomSolverErrors` are effectively black boxes and can mean anything escalating them to the highest severity is not a great idea.
For example in a current case 1 solver reported such an error with the message `unable to generate a solution for this order` which got escalated to an internal server error.

# Changes
demotes the `CustomSolverError` to `NoLiquidity`

## How to test
moved the `CustomSolverError` case from the existing unit test and asserted that it now gets converted to a NoLiquidity response