### PR TITLE
Add the staging server to the solana orderbook OpenAPI spec

### DIFF
--- a/crates/solana-orderbook/openapi.yml
+++ b/crates/solana-orderbook/openapi.yml
@@ -5,6 +5,9 @@ info:
     Read-only API over the orders and settlements the indexer records from the
     Solana settlement program.
   version: 0.0.1
+servers:
+  - description: Solana (Staging)
+    url: "https://barn.api.cow.fi/solana"
 paths:
   /api/v1/orders/{uid}:
     get:


### PR DESCRIPTION
# Description

Staging only for now, the prod entry follows with the prod deployment.

# Changes
- `servers` entry for staging in `crates/solana-orderbook/openapi.yml`