### PR TITLE
Pin foundry v1.7.1 in CI and the e2e node hardfork after anvil 1.8.0

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -187,6 +187,9 @@ jobs:
           persist-credentials: false
       - run: rustup toolchain install stable --profile minimal
       - uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a # v1.9.0
+        with:
+          # anvil 1.8.0 changed trace/call semantics that the e2e and driver tests rely on
+          version: v1.7.1
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       # Start the build process in the background. The following cargo test command will automatically
       # wait for the build process to be done before proceeding.
@@ -256,6 +259,9 @@ jobs:
           persist-credentials: false
       - run: rustup toolchain install stable --profile minimal
       - uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a # v1.9.0
+        with:
+          # anvil 1.8.0 changed trace/call semantics that the e2e and driver tests rely on
+          version: v1.7.1
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - uses: taiki-e/install-action@4684b8405694ae9dd42c9f39ba901a70ae83f4a3 # v2.82.9
         with:
@@ -325,6 +331,9 @@ jobs:
           persist-credentials: false
       - run: rustup toolchain install stable --profile minimal
       - uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a # v1.9.0
+        with:
+          # anvil 1.8.0 changed trace/call semantics that the e2e and driver tests rely on
+          version: v1.7.1
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       # Start the build process in the background. The following cargo test command will automatically
       # wait for the build process to be done before proceeding.

--- a/crates/e2e/src/nodes/mod.rs
+++ b/crates/e2e/src/nodes/mod.rs
@@ -43,6 +43,11 @@ impl Node {
             "1",
             "--timestamp",
             "1577836800",
+            // Anvil derives the fork schedule from the chain id, and a 2020
+            // genesis on chain 1 sits before London. Pin the fork so EIP-1559
+            // transactions are accepted.
+            "--hardfork",
+            "prague",
         ])
         .await
     }


### PR DESCRIPTION
# Description
`test-local-node` fails since this afternoon at the Multicall3 deployment: `EIP-1559 style fee params … not supported by the current hardfork`. Foundry 1.8.0 came out today and three CI jobs install the latest stable.

Anvil 1.8.0 derives the fork schedule from the chain id (foundry-rs/foundry#14833). Our node is chain 1 with a 2020 genesis timestamp, which lands on Istanbul, so 1559 transactions are rejected. `--hardfork prague` fixes that on both versions. With the fork pinned, the trade tests on 1.8.0 still fail: the bad-token simulation (`trace_callMany`) marks every token unsupported and quotes end in `NoLiquidity`. That needs a separate look, so CI pins foundry v1.7.1 until then, like the forked job already pins v1.0.0.

# Changes
- `--hardfork prague` in the e2e local node arguments
- `foundry-toolchain` pinned to v1.7.1 in `test-local-node`, `test-driver` and `run-flaky-test`

# How to test
CI