### PR TITLE
[EASY] Ship the autopilot-svm binary in the services image

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -86,6 +86,7 @@ jobs:
           cargo build --release \
             -p autopilot -p driver -p orderbook -p refunder -p solvers -p pool-indexer \
             -p solana-indexer -p solana-orderbook -p solana-driver -p solana-solvers \
+            -p autopilot-svm \
             ${{ steps.features.outputs.cargo_features }}
 
       - uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry --mount=type=cache,targe
     CARGO_PROFILE_RELEASE_DEBUG=1 RUSTFLAGS="${RUSTFLAGS}" cargo build --release \
     -p autopilot -p driver -p orderbook -p refunder -p solvers -p pool-indexer \
     -p solana-indexer -p solana-orderbook -p solana-driver -p solana-solvers \
+    -p autopilot-svm \
     ${CARGO_BUILD_FEATURES} && \
     cp target/release/autopilot / && \
     cp target/release/driver / && \
@@ -31,7 +32,8 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry --mount=type=cache,targe
     cp target/release/solana-indexer / && \
     cp target/release/solana-orderbook / && \
     cp target/release/solana-driver / && \
-    cp target/release/solana-solvers /
+    cp target/release/solana-solvers / && \
+    cp target/release/autopilot-svm /
 
 # Create an intermediate image to extract the binaries
 FROM docker.io/debian:bookworm-slim AS intermediate
@@ -81,6 +83,10 @@ FROM intermediate AS solana-solvers
 COPY --from=cargo-build /solana-solvers /usr/local/bin/solana-solvers
 ENTRYPOINT [ "solana-solvers" ]
 
+FROM intermediate AS solana-autopilot
+COPY --from=cargo-build /autopilot-svm /usr/local/bin/autopilot-svm
+ENTRYPOINT [ "autopilot-svm" ]
+
 # Extract Binary
 FROM intermediate
 
@@ -95,5 +101,6 @@ COPY --from=cargo-build /solana-indexer /usr/local/bin/solana-indexer
 COPY --from=cargo-build /solana-orderbook /usr/local/bin/solana-orderbook
 COPY --from=cargo-build /solana-driver /usr/local/bin/solana-driver
 COPY --from=cargo-build /solana-solvers /usr/local/bin/solana-solvers
+COPY --from=cargo-build /autopilot-svm /usr/local/bin/autopilot-svm
 
 ENTRYPOINT ["/usr/bin/tini", "-s", "--"]

--- a/Dockerfile.deploy-ci
+++ b/Dockerfile.deploy-ci
@@ -25,5 +25,6 @@ COPY --from=binaries solana-indexer /usr/local/bin/solana-indexer
 COPY --from=binaries solana-orderbook /usr/local/bin/solana-orderbook
 COPY --from=binaries solana-driver /usr/local/bin/solana-driver
 COPY --from=binaries solana-solvers /usr/local/bin/solana-solvers
+COPY --from=binaries autopilot-svm /usr/local/bin/autopilot-svm
 
 ENTRYPOINT ["/usr/bin/tini", "-s", "--"]


### PR DESCRIPTION
# Description
The solana autopilot pod crashes on start with `exec autopilot-svm failed: No such file or directory`. The `autopilot-svm` binary is never built or copied into the `services` image, so it is not on the pod. The other solana binaries (`solana-indexer`, `solana-orderbook`, `solana-driver`, `solana-solvers`) are, which is why they run.

# Changes
- Build `autopilot-svm` in the deploy cargo step and copy it into `Dockerfile.deploy-ci`, which produces the published `services` image
- Same in the playground `Dockerfile`, plus a `solana-autopilot` stage matching the other solana services

# How to test
CI builds the image. After merge the autopilot pod starts once it pulls the rebuilt `services:main`.
