### PR TITLE
cow-solana-rpc: add latest_blockhash and send_and_confirm_transaction

### DIFF
--- a/crates/cow-solana-rpc/src/lib.rs
+++ b/crates/cow-solana-rpc/src/lib.rs
@@ -5,7 +5,13 @@ use {
     itertools::Itertools,
     solana_rpc_client::nonblocking::rpc_client::RpcClient,
     solana_rpc_client_api::request::MAX_MULTIPLE_ACCOUNTS,
-    solana_sdk::{account::Account, pubkey::Pubkey},
+    solana_sdk::{
+        account::Account,
+        hash::Hash,
+        pubkey::Pubkey,
+        signature::Signature,
+        transaction::VersionedTransaction,
+    },
     std::{collections::HashMap, time::Duration},
     url::Url,
 };
@@ -78,5 +84,29 @@ impl SolanaRPC {
     /// The node's current slot at the client's commitment level.
     pub async fn slot(&self) -> Result<u64, Error> {
         self.inner.get_slot().await
+    }
+
+    /// The latest blockhash and the last block height at which it remains valid
+    /// (so consumers know whether the blockhash is still usable), fetched at
+    /// the client's configured commitment level.
+    ///
+    /// Note: this uses the same commitment level the client was configured
+    /// with. It's important to consider that a `processed` blockhash may come
+    /// from an abandoned fork, a `finalized` blockhash comes at the expense of
+    /// shortening the transaction's ~150-block validity window. `confirmed` is
+    /// usually the safest default.
+    pub async fn latest_blockhash(&self) -> Result<(Hash, u64), Error> {
+        self.inner
+            .get_latest_blockhash_with_commitment(self.inner.commitment())
+            .await
+    }
+
+    /// Send a versioned transaction and wait until it reaches the client's
+    /// configured commitment level.
+    pub async fn send_and_confirm_transaction(
+        &self,
+        transaction: &VersionedTransaction,
+    ) -> Result<Signature, Error> {
+        self.inner.send_and_confirm_transaction(transaction).await
     }
 }

--- a/crates/cow-solana-rpc/src/lib.rs
+++ b/crates/cow-solana-rpc/src/lib.rs
@@ -121,8 +121,7 @@ impl SolanaRPC {
     }
 }
 
-/// A Solana block height. The newtype prevents accidental comparison
-/// against a slot.
+/// A Solana block height.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct BlockHeight(u64);
 
@@ -146,12 +145,12 @@ impl From<BlockHeight> for u64 {
 }
 
 /// The latest confirmed blockhash and the last block height at which
-/// it stays usable. [`SolanaRPC::latest_confirmed_blockhash`] returns
-/// this type.
+/// it stays usable.
 #[derive(Debug)]
 pub struct LatestBlockhash {
     /// The blockhash to sign transactions with.
     pub blockhash: Hash,
-    /// The last block height at which `blockhash` stays usable.
+    /// The last block height at which transactions signed with this
+    /// blockhash as `recent_blockhash` remain valid.
     pub last_valid_block_height: BlockHeight,
 }

--- a/crates/cow-solana-rpc/src/lib.rs
+++ b/crates/cow-solana-rpc/src/lib.rs
@@ -86,27 +86,72 @@ impl SolanaRPC {
         self.inner.get_slot().await
     }
 
-    /// The latest blockhash and the last block height at which it remains valid
-    /// (so consumers know whether the blockhash is still usable), fetched at
-    /// the client's configured commitment level.
+    /// The current block height at the client's commitment level.
+    pub async fn block_height(&self) -> Result<BlockHeight, Error> {
+        Ok(BlockHeight(self.inner.get_block_height().await?))
+    }
+
+    /// The latest confirmed blockhash and the last block height at
+    /// which it stays usable.
     ///
-    /// Note: this uses the same commitment level the client was configured
-    /// with. It's important to consider that a `processed` blockhash may come
-    /// from an abandoned fork, a `finalized` blockhash comes at the expense of
-    /// shortening the transaction's ~150-block validity window. `confirmed` is
-    /// usually the safest default.
-    pub async fn latest_blockhash(&self) -> Result<(Hash, u64), Error> {
-        self.inner
-            .get_latest_blockhash_with_commitment(self.inner.commitment())
-            .await
+    /// The method always fetches the blockhash at `confirmed`,
+    /// regardless of the client's configured commitment level.
+    pub async fn latest_confirmed_blockhash(&self) -> Result<LatestBlockhash, Error> {
+        let (blockhash, last_valid_block_height) = self
+            .inner
+            .get_latest_blockhash_with_commitment(CommitmentConfig::confirmed())
+            .await?;
+        Ok(LatestBlockhash {
+            blockhash,
+            last_valid_block_height: BlockHeight(last_valid_block_height),
+        })
     }
 
     /// Send a versioned transaction and wait until it reaches the client's
     /// configured commitment level.
+    ///
+    /// Each individual RPC request is capped at the client's request timeout,
+    /// but the confirm loop has no overall timeout: it polls until the
+    /// transaction confirms or its blockhash expires.
     pub async fn send_and_confirm_transaction(
         &self,
         transaction: &VersionedTransaction,
     ) -> Result<Signature, Error> {
         self.inner.send_and_confirm_transaction(transaction).await
     }
+}
+
+/// A Solana block height. The newtype prevents accidental comparison
+/// against a slot.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct BlockHeight(u64);
+
+impl BlockHeight {
+    /// The height as a plain number.
+    pub const fn into_inner(self) -> u64 {
+        self.0
+    }
+}
+
+impl From<u64> for BlockHeight {
+    fn from(height: u64) -> Self {
+        Self(height)
+    }
+}
+
+impl From<BlockHeight> for u64 {
+    fn from(height: BlockHeight) -> Self {
+        height.0
+    }
+}
+
+/// The latest confirmed blockhash and the last block height at which
+/// it stays usable. [`SolanaRPC::latest_confirmed_blockhash`] returns
+/// this type.
+#[derive(Debug)]
+pub struct LatestBlockhash {
+    /// The blockhash to sign transactions with.
+    pub blockhash: Hash,
+    /// The last block height at which `blockhash` stays usable.
+    pub last_valid_block_height: BlockHeight,
 }


### PR DESCRIPTION
# Description
Add the two RPC methods the settle path needs: `latest_blockhash` and `send_and_confirm_transaction`.

# Changes
* Add `SolanaRPC::latest_blockhash()` to get the latest blockhash and its last valid block height at the configured commitment level.
* Add `SolanaRPC::send_and_confirm_transaction()` to send a `VersionedTransaction` and wait until it reaches the configured commitment level.
* Import `Hash`, `Signature`, and `VersionedTransaction` from `solana_sdk` to support the new method signatures.
* Document the `latest_blockhash` commitment levels (`processed`, `confirmed`, and `finalized`) in the method rustdoc.
