### PR TITLE
solana-solvers: add `LoggingJson` extractor

### DIFF
--- a/crates/driver/src/infra/api/extract.rs
+++ b/crates/driver/src/infra/api/extract.rs
@@ -1,6 +1,9 @@
 //! Axum extractors that emit a `warn` log when request deserialization
 //! fails, then delegate to the stock extractor's rejection so the HTTP
 //! response shape is unchanged.
+//!
+//! TODO: Factor these extractors out into a shared axum utils crate and
+//! reuse them across all crates instead of duplicating the logic.
 
 use {
     axum::{

--- a/crates/solana-solvers/src/api.rs
+++ b/crates/solana-solvers/src/api.rs
@@ -3,7 +3,7 @@
 //! Serves the `/solve` contract the driver calls.
 
 use {
-    crate::{dex::Dex, domain::solver, dto::auction::Auction},
+    crate::{dex::Dex, domain::solver, dto::auction::Auction, extract::LoggingJson},
     axum::{
         Json,
         Router,
@@ -56,7 +56,10 @@ async fn healthz() -> &'static str {
 }
 
 /// Quote every order in the auction and return the single-order solutions.
-async fn solve(State(dex): State<Arc<Dex>>, Json(auction): Json<Auction>) -> Json<Value> {
+async fn solve(
+    State(dex): State<Arc<Dex>>,
+    LoggingJson(auction): LoggingJson<Auction>,
+) -> Json<Value> {
     let solutions = solver::solve(dex.as_ref(), &auction).await;
     Json(json!({ "solutions": solutions }))
 }

--- a/crates/solana-solvers/src/dex/mod.rs
+++ b/crates/solana-solvers/src/dex/mod.rs
@@ -50,8 +50,7 @@ impl Dex {
     /// The route spends its input from the sell-mint ATA of the solver.
     /// Jupiter has no source-account override. The sell funds must already be
     /// in that ATA. The caller must make sure that the ATA exists before the
-    /// pull instructions of the swap run. Settlement setup creates the ATA
-    /// idempotently.
+    /// pull instructions of the swap run.
     pub async fn swap(&self, order: &Order, user: &Pubkey) -> Result<Swap, jupiter::Error> {
         match self {
             Dex::Jupiter(jupiter) => jupiter.swap(order, user).await,

--- a/crates/solana-solvers/src/dex/mod.rs
+++ b/crates/solana-solvers/src/dex/mod.rs
@@ -45,12 +45,13 @@ pub enum Dex {
 }
 
 impl Dex {
-    /// Quote `order` for settlement signer `user`.
+    /// Build the swap for `order` that the settlement signer `user` executes.
     ///
-    /// The route spends its input from `user`'s ATA for the sell mint.
-    /// Jupiter has no source-account override, so the settlement must pull
-    /// the sell funds into that ATA, creating it if missing, before the
-    /// swap executes.
+    /// The route spends its input from the sell-mint ATA of the solver.
+    /// Jupiter has no source-account override. The sell funds must already be
+    /// in that ATA. The caller must make sure that the ATA exists before the
+    /// pull instructions of the swap run. Settlement setup creates the ATA
+    /// idempotently.
     pub async fn swap(&self, order: &Order, user: &Pubkey) -> Result<Swap, jupiter::Error> {
         match self {
             Dex::Jupiter(jupiter) => jupiter.swap(order, user).await,

--- a/crates/solana-solvers/src/extract.rs
+++ b/crates/solana-solvers/src/extract.rs
@@ -25,7 +25,7 @@ where
             Err(rejection) => {
                 tracing::warn!(
                     err = %rejection,
-                    target = std::any::type_name::<T>(),
+                    type_name = std::any::type_name::<T>(),
                     "failed to deserialize JSON request body",
                 );
                 Err(rejection)

--- a/crates/solana-solvers/src/extract.rs
+++ b/crates/solana-solvers/src/extract.rs
@@ -1,0 +1,35 @@
+//! Axum extractors that log deserialization failures.
+
+use {
+    axum::{
+        body::Body,
+        extract::{FromRequest, Request},
+    },
+    serde::de::DeserializeOwned,
+};
+
+/// JSON extractor that wraps Axum's native one and logs deserialization
+/// errors before returning the same rejection.
+pub struct LoggingJson<T>(pub T);
+
+impl<S, T> FromRequest<S> for LoggingJson<T>
+where
+    S: Send + Sync,
+    T: DeserializeOwned,
+{
+    type Rejection = axum::extract::rejection::JsonRejection;
+
+    async fn from_request(req: Request<Body>, state: &S) -> Result<Self, Self::Rejection> {
+        match axum::Json::<T>::from_request(req, state).await {
+            Ok(axum::Json(value)) => Ok(Self(value)),
+            Err(rejection) => {
+                tracing::warn!(
+                    err = %rejection,
+                    target = std::any::type_name::<T>(),
+                    "failed to deserialize JSON request body",
+                );
+                Err(rejection)
+            }
+        }
+    }
+}

--- a/crates/solana-solvers/src/extract.rs
+++ b/crates/solana-solvers/src/extract.rs
@@ -1,4 +1,8 @@
 //! Axum extractors that log deserialization failures.
+//!
+//! TODO: This duplicates the EVM driver's `LoggingJson` extractor. Factor
+//! the logic out into a shared axum utils crate and reuse it across all
+//! crates.
 
 use {
     axum::{

--- a/crates/solana-solvers/src/lib.rs
+++ b/crates/solana-solvers/src/lib.rs
@@ -9,6 +9,7 @@ pub mod config;
 pub mod dex;
 pub mod domain;
 pub mod dto;
+pub mod extract;
 mod run;
 
 pub use run::start;


### PR DESCRIPTION

# Description
Port the LoggingJson extractor to emit a `tracing::warn` before returning axum's standard 400 rejection.


# Changes
* Add an `extract` module with the `LoggingJson<T>` extractor. 