### PR TITLE
Remove the static/protocol fee type

### DIFF
--- a/crates/driver/src/domain/competition/solution/fee.rs
+++ b/crates/driver/src/domain/competition/solution/fee.rs
@@ -25,14 +25,13 @@
 use {
     super::{
         error::Math,
-        trade::{ClearingPrices, Fee, Fulfillment},
+        trade::{ClearingPrices, Fulfillment},
     },
     crate::domain::competition::{
         PriceLimits,
         order::{self, FeePolicy, Side},
         solution::error::Trade,
     },
-    bigdecimal::Zero,
     eth_domain_types as eth,
     number::u256_ext::U256Ext,
 };
@@ -57,17 +56,12 @@ impl Fulfillment {
         let protocol_fee = self.protocol_fee_in_sell_token(prices, protocol_fee)?;
 
         // Increase the fee by the protocol fee
-        let fee = match self.surplus_fee() {
-            None => {
-                if !protocol_fee.is_zero() {
-                    return Err(Error::ProtocolFeeOnStaticOrder);
-                }
-                Fee::Static
-            }
-            Some(fee) => {
-                Fee::Dynamic((fee.0.checked_add(protocol_fee.0).ok_or(Math::Overflow)?).into())
-            }
-        };
+        let fee = order::SellAmount(
+            self.fee()
+                .0
+                .checked_add(protocol_fee.0)
+                .ok_or(Math::Overflow)?,
+        );
 
         // Reduce the executed amount by the protocol fee. This is because solvers are
         // unaware of the protocol fee that driver introduces and they only account
@@ -130,7 +124,7 @@ impl Fulfillment {
                     uid = ?self.order().uid,
                     ?fee_from_volume,
                     executed = ?self.executed(),
-                    surplus_fee = ?self.surplus_fee(),
+                    fee = ?self.fee(),
                     "calculated protocol fee"
                 );
                 Ok(fee_from_volume)
@@ -160,7 +154,7 @@ impl Fulfillment {
             ?fee_from_volume,
             ?protocol_fee,
             executed = ?self.executed(),
-            surplus_fee = ?self.surplus_fee(),
+            fee = ?self.fee(),
             "calculated protocol fee"
         );
         Ok(protocol_fee)
@@ -298,8 +292,6 @@ pub fn adjust_quote_to_order_limits(order: Order, quote: Quote) -> Result<PriceL
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("orders with non solver determined gas cost fees are not supported")]
-    ProtocolFeeOnStaticOrder,
     #[error(transparent)]
     Math(#[from] Math),
     #[error(transparent)]

--- a/crates/driver/src/domain/competition/solution/mod.rs
+++ b/crates/driver/src/domain/competition/solution/mod.rs
@@ -1,5 +1,5 @@
 use {
-    self::trade::{ClearingPrices, Fee, Fulfillment},
+    self::trade::{ClearingPrices, Fulfillment},
     super::auction,
     crate::{
         boundary,
@@ -176,7 +176,7 @@ impl Solution {
                         partial: jit.order().partially_fillable(),
                     },
                     jit.executed(),
-                    Fee::Dynamic(jit.fee()),
+                    jit.fee(),
                     // JIT orders don't get haircut because they supply private
                     // liquidity which should not prone to negative slippage.
                     eth::U256::ZERO,
@@ -866,8 +866,6 @@ pub mod error {
 
     #[derive(Debug, thiserror::Error)]
     pub enum Trade {
-        #[error("orders with non solver determined gas cost fees are not supported")]
-        ProtocolFeeOnStaticOrder,
         #[error("invalid executed amount")]
         InvalidExecutedAmount,
         #[error(transparent)]

--- a/crates/driver/src/domain/competition/solution/trade.rs
+++ b/crates/driver/src/domain/competition/solution/trade.rs
@@ -116,8 +116,7 @@ pub struct Fulfillment {
     /// order.
     executed: order::TargetAmount,
     /// The fee that is charged to the user for executing the order, in sell
-    /// token. An absent fee in the solver's response is treated as a fee of
-    /// 0.
+    /// token.
     fee: order::SellAmount,
     /// Additional fee for conservative bidding (haircut). Applied on top of
     /// the regular fee to reduce reported surplus without affecting executed

--- a/crates/driver/src/domain/competition/solution/trade.rs
+++ b/crates/driver/src/domain/competition/solution/trade.rs
@@ -115,7 +115,10 @@ pub struct Fulfillment {
     /// order is not partial, the executed amount must equal the amount from the
     /// order.
     executed: order::TargetAmount,
-    fee: Fee,
+    /// The fee that is charged to the user for executing the order, in sell
+    /// token. An absent fee in the solver's response is treated as a fee of
+    /// 0.
+    fee: order::SellAmount,
     /// Additional fee for conservative bidding (haircut). Applied on top of
     /// the regular fee to reduce reported surplus without affecting executed
     /// amounts. Expressed in the order's target token (sell token for sell
@@ -127,7 +130,7 @@ impl Fulfillment {
     pub fn new(
         order: competition::Order,
         executed: order::TargetAmount,
-        fee: Fee,
+        fee: order::SellAmount,
         haircut_fee: eth::U256,
     ) -> Result<Self, error::Trade> {
         // If the order is partial, the total executed amount can be smaller than
@@ -136,10 +139,7 @@ impl Fulfillment {
         let valid_execution = {
             let fee = match order.side {
                 order::Side::Buy => order::TargetAmount::default(),
-                order::Side::Sell => order::TargetAmount(match fee {
-                    Fee::Static => eth::U256::default(),
-                    Fee::Dynamic(fee) => fee.0,
-                }),
+                order::Side::Sell => order::TargetAmount(fee.0),
             };
 
             let executed_with_fee = order::TargetAmount(
@@ -154,14 +154,7 @@ impl Fulfillment {
             }
         };
 
-        // Only accept solver-computed fees if the order requires them, otherwise the
-        // protocol pre-determines the fee and the solver must respect it.
-        let valid_fee = match &fee {
-            Fee::Static => !order.solver_determines_fee(),
-            Fee::Dynamic(_) => order.solver_determines_fee(),
-        };
-
-        if valid_execution && valid_fee {
+        if valid_execution {
             Ok(Self {
                 order,
                 executed,
@@ -190,23 +183,7 @@ impl Fulfillment {
     /// Returns the effectively paid fee from the user's perspective
     /// considering their signed order and the uniform clearing prices
     pub fn fee(&self) -> order::SellAmount {
-        match self.fee {
-            Fee::Static => {
-                // Orders with static fees are no longer used, except for quoting purposes, when
-                // the static fee is set to 0. This is expected to be resolved with https://github.com/cowprotocol/services/issues/2543
-                // Once resolved, this code will be simplified as part of https://github.com/cowprotocol/services/issues/2507
-                order::SellAmount(eth::U256::ZERO)
-            }
-            Fee::Dynamic(fee) => fee,
-        }
-    }
-
-    /// Returns the solver determined fee if it exists.
-    pub fn surplus_fee(&self) -> Option<order::SellAmount> {
-        match self.fee {
-            Fee::Static => None,
-            Fee::Dynamic(fee) => Some(fee),
-        }
+        self.fee
     }
 
     /// Returns the haircut fee for conservative bidding.
@@ -324,14 +301,10 @@ impl Fulfillment {
             }
             Side::Sell => executed,
         };
-        // Sell slightly more `sell_token` to capture the `surplus_fee`
+        // Sell slightly more `sell_token` to capture the fee
         let executed_sell_amount_with_fee = executed_sell_amount
-            .checked_add(
-                // surplus_fee is always expressed in sell token
-                self.surplus_fee()
-                    .map(|fee| fee.0)
-                    .ok_or(error::Trade::ProtocolFeeOnStaticOrder)?,
-            )
+            // the fee is always expressed in sell token
+            .checked_add(self.fee().0)
             .ok_or(Math::Overflow)?;
         let surplus = match self.order().side {
             Side::Buy => {
@@ -376,17 +349,6 @@ impl Fulfillment {
         };
         Ok(surplus.into())
     }
-}
-
-/// A fee that is charged for executing an order.
-#[derive(Clone, Copy, Debug)]
-pub enum Fee {
-    /// A static protocol computed fee.
-    ///
-    /// That is, the fee is known upfront and is signed as part of the order
-    Static,
-    /// A dynamic solver computed surplus fee.
-    Dynamic(order::SellAmount),
 }
 
 /// Uniform clearing prices at which the trade was executed.

--- a/crates/driver/src/infra/notify/mod.rs
+++ b/crates/driver/src/infra/notify/mod.rs
@@ -32,9 +32,9 @@ pub fn scoring_failed(
             notification::Kind::ScoringFailed(ScoreKind::InvalidClearingPrices)
         }
         solution::error::Scoring::Math(_)
-        | solution::error::Scoring::CalculateCustomPrices(
-            solution::error::Trade::Math(_) | solution::error::Trade::ProtocolFeeOnStaticOrder,
-        ) => return,
+        | solution::error::Scoring::CalculateCustomPrices(solution::error::Trade::Math(_)) => {
+            return;
+        }
         solution::error::Scoring::CalculateCustomPrices(
             solution::error::Trade::InvalidExecutedAmount,
         ) => notification::Kind::ScoringFailed(ScoreKind::InvalidExecutedAmount),

--- a/crates/driver/src/infra/solver/dto/solution.rs
+++ b/crates/driver/src/infra/solver/dto/solution.rs
@@ -65,12 +65,10 @@ impl Solutions {
                                 competition::solution::trade::Fulfillment::new(
                                     order,
                                     fulfillment.executed_amount.into(),
-                                    match fulfillment.fee {
-                                        Some(fee) => competition::solution::trade::Fee::Dynamic(
-                                            competition::order::SellAmount(fee),
-                                        ),
-                                        None => competition::solution::trade::Fee::Static,
-                                    },
+                                    // An absent fee is treated as a fee of 0.
+                                    competition::order::SellAmount(
+                                        fulfillment.fee.unwrap_or_default(),
+                                    ),
                                     haircut_fee,
                                 )
                                     .map(competition::solution::Trade::Fulfillment)

--- a/crates/driver/src/infra/solver/dto/solution.rs
+++ b/crates/driver/src/infra/solver/dto/solution.rs
@@ -65,7 +65,8 @@ impl Solutions {
                                 competition::solution::trade::Fulfillment::new(
                                     order,
                                     fulfillment.executed_amount.into(),
-                                    // An absent fee is treated as a fee of 0.
+                                    // An absent fee is treated as a fee of 0. This only happens during quoting 
+                                    // from solvers that don't support computing fees in the sell token.
                                     competition::order::SellAmount(
                                         fulfillment.fee.unwrap_or_default(),
                                     ),
@@ -303,8 +304,8 @@ fn find_order<'a>(
 pub struct JitOrder(solvers_dto::solution::JitOrder);
 
 impl JitOrder {
-    // Deprecated External/Internal arms retained for wire compatibility; solvers no
-    // longer send them in practice.
+    // Deprecated External/Internal arms retained for wire compatibility;
+    // solvers no longer send them in practice.
     #[allow(deprecated)]
     fn raw_order_data(&self) -> OrderData {
         OrderData {
@@ -371,10 +372,10 @@ impl JitOrder {
             self.0.signing_scheme,
             solvers_dto::solution::SigningScheme::Eip1271
         ) {
-            // For EIP-1271 signatures the encoding logic prepends the signer to the raw
-            // signature bytes. This leads to the owner being encoded twice in
-            // the final settlement calldata unless we remove that from the raw
-            // data.
+            // For EIP-1271 signatures the encoding logic prepends the signer to
+            // the raw signature bytes. This leads to the owner
+            // being encoded twice in the final settlement calldata
+            // unless we remove that from the raw data.
             signature.data = Bytes::copy_from_slice(&self.0.signature[20..]);
         }
 

--- a/crates/solvers/src/domain/solution.rs
+++ b/crates/solvers/src/domain/solution.rs
@@ -356,15 +356,6 @@ impl Fulfillment {
         })
     }
 
-    /// Creates a new trade for a fully executed order.
-    pub fn fill(order: order::Order) -> Option<Self> {
-        let executed = match order.side {
-            order::Side::Buy => order.buy.amount,
-            order::Side::Sell => order.sell.amount,
-        };
-        Self::new(order, executed, Default::default())
-    }
-
     /// Get a reference to the traded order.
     pub fn order(&self) -> &order::Order {
         &self.order

--- a/crates/solvers/src/domain/solution.rs
+++ b/crates/solvers/src/domain/solution.rs
@@ -332,7 +332,7 @@ pub struct Fulfillment {
     order: order::Order,
     executed: U256,
     /// The fee that is charged to the user for executing the order, in sell
-    /// token. Zero for orders whose fee the solver does not determine.
+    /// token.
     fee: eth::SellTokenAmount,
 }
 
@@ -384,9 +384,7 @@ impl Fulfillment {
     }
 
     /// Returns the solver computed fee that was charged to the order as an
-    /// asset (token address and amount). Returns `None` for orders whose fee
-    /// the solver does not determine, so that old drivers (which reject fees
-    /// on such orders) keep accepting our responses.
+    /// asset (token address and amount).
     pub fn surplus_fee(&self) -> Option<eth::Asset> {
         self.order.solver_determines_fee().then_some(eth::Asset {
             token: self.order.sell.token,

--- a/crates/solvers/src/domain/solution.rs
+++ b/crates/solvers/src/domain/solution.rs
@@ -139,12 +139,14 @@ impl Single {
             return None;
         }
 
+        // Orders whose fee the solver doesn't determine (market orders, whose
+        // fee was pre-determined by the protocol) are not charged anything.
         let fee = if order.solver_determines_fee() {
-            Fee::Surplus(fee)
+            fee
         } else {
-            Fee::Protocol
+            Default::default()
         };
-        let surplus_fee = fee.surplus().unwrap_or_default();
+        let surplus_fee = fee.0;
 
         // Compute total executed sell and buy amounts accounting for solver
         // fees. That is, the total amount of sell tokens transferred into the
@@ -233,17 +235,20 @@ impl Single {
             // full order fee as well as a solver computed fee. Note that this
             // is fine for now, since there is no way to create limit orders
             // with non-zero fees.
-            Fee::Surplus(eth::SellTokenAmount(
+            eth::SellTokenAmount(
                 sell_token?.ether_value(eth::Ether(
                     swap.0
                         .checked_add(gas_offset.0)?
                         .checked_mul(gas_price.0.0)?,
                 ))?,
-            ))
+            )
         } else {
-            Fee::Protocol
+            // Orders whose fee the solver doesn't determine (market orders,
+            // whose fee was pre-determined by the protocol) are not charged
+            // anything.
+            Default::default()
         };
-        let surplus_fee = fee.surplus().unwrap_or_default();
+        let surplus_fee = fee.0;
 
         // Compute total executed sell and buy amounts accounting for solver
         // fees. That is, the total amount of sell tokens transferred into the
@@ -326,23 +331,18 @@ pub enum Trade {
 pub struct Fulfillment {
     order: order::Order,
     executed: U256,
-    fee: Fee,
+    /// The fee that is charged to the user for executing the order, in sell
+    /// token. Zero for orders whose fee the solver does not determine.
+    fee: eth::SellTokenAmount,
 }
 
 impl Fulfillment {
     /// Creates a new order filled to the specified amount. Returns `None` if
     /// the fill amount is incompatible with the order.
-    pub fn new(order: order::Order, executed: U256, fee: Fee) -> Option<Self> {
-        if matches!(fee, Fee::Surplus(_)) != order.solver_determines_fee() {
-            return None;
-        }
-
+    pub fn new(order: order::Order, executed: U256, fee: eth::SellTokenAmount) -> Option<Self> {
         let (fill, full) = match order.side {
             order::Side::Buy => (order.buy.amount, executed),
-            order::Side::Sell => (
-                order.sell.amount,
-                executed.checked_add(fee.surplus().unwrap_or_default())?,
-            ),
+            order::Side::Sell => (order.sell.amount, executed.checked_add(fee.0)?),
         };
         if (!order.partially_fillable && full != fill) || (order.partially_fillable && full > fill)
         {
@@ -362,7 +362,7 @@ impl Fulfillment {
             order::Side::Buy => order.buy.amount,
             order::Side::Sell => order.sell.amount,
         };
-        Self::new(order, executed, Fee::Protocol)
+        Self::new(order, executed, Default::default())
     }
 
     /// Get a reference to the traded order.
@@ -384,36 +384,14 @@ impl Fulfillment {
     }
 
     /// Returns the solver computed fee that was charged to the order as an
-    /// asset (token address and amount). Returns `None` if the fulfillment
-    /// does not include a solver computed fee.
+    /// asset (token address and amount). Returns `None` for orders whose fee
+    /// the solver does not determine, so that old drivers (which reject fees
+    /// on such orders) keep accepting our responses.
     pub fn surplus_fee(&self) -> Option<eth::Asset> {
-        Some(eth::Asset {
+        self.order.solver_determines_fee().then_some(eth::Asset {
             token: self.order.sell.token,
-            amount: self.fee.surplus()?,
+            amount: self.fee.0,
         })
-    }
-}
-
-/// The fee that is charged to a user for executing an order.
-#[derive(Clone, Copy, Debug)]
-pub enum Fee {
-    /// A protocol computed fee.
-    ///
-    /// That is, the fee is charged from the order's `fee_amount` that is
-    /// included in the auction being solved.
-    Protocol,
-
-    /// An additional surplus fee that is charged by the solver.
-    Surplus(eth::SellTokenAmount),
-}
-
-impl Fee {
-    /// Returns the dynamic component for the fee.
-    pub fn surplus(&self) -> Option<U256> {
-        match self {
-            Fee::Protocol => None,
-            Fee::Surplus(fee) => Some(fee.0),
-        }
     }
 }
 


### PR DESCRIPTION
# Description

Static fees existed for orders whose fee was pre-determined and signed (market orders in the olden days). The distinction carries no behavior anymore: the user signed fixed fee amount is 0 unconditionally (the auction doesn't even transport signed fees), so static fees always evaluate to 0 in every computation. 

Removing the distinction allows simplifying a bunch of our fee types, logic and error types.

Note that this was originally intended as part of #2611 but never finished.

## Backwards compatibility
An absent fee in a solver response is now simply treated as a solver-determined fee of 0. Before, it would be rejected for limit orders (so in practice we don't expect solver engine responses to have an absent fee other than for quote requests (which currently are still send as legacy `class::Market` orders; I'll try cleaning this up as well)

## Changes

* Remove `Fee::Static` and `Fee::Protocol` type and branches
* Rename `surplus_fee` to `fee` where applicable

## How to test
Tests are still working. The only risk is legacy solver engines talking to the new driver. Cf. backwards compatibility section on why this is still safe.