### PR TITLE
Cache failed banned-user lookups

### DIFF
--- a/crates/order-validation/src/banned/cached.rs
+++ b/crates/order-validation/src/banned/cached.rs
@@ -19,31 +19,27 @@ const MAX_CONCURRENT_LOOKUPS: usize = 10;
 const CACHE_EXPIRY: Duration = Duration::from_secs(60 * 60);
 const MAINTENANCE_TIMEOUT: Duration = Duration::from_secs(60);
 
+#[derive(Clone, Copy, PartialEq)]
+enum Verdict {
+    Banned,
+    NotBanned,
+    /// Every lookup failed. Treated as not banned until a maintenance-task
+    /// retry succeeds.
+    Unknown,
+}
+
 #[derive(Clone)]
 struct Entry {
-    is_banned: bool,
+    verdict: Verdict,
     last_updated: Instant,
-    /// The lookup failed and `is_banned` is a fail-open placeholder until
-    /// a maintenance-task retry succeeds.
-    uncertain: bool,
 }
 
 impl Entry {
     /// Creates a new [`Entry`] with `last_updated` set to [`Instant::now`]-
-    fn new(is_banned: bool) -> Self {
+    fn new(verdict: Verdict) -> Self {
         Self {
-            is_banned,
+            verdict,
             last_updated: Instant::now(),
-            uncertain: false,
-        }
-    }
-
-    /// Creates an [`Entry`] for a failed lookup.
-    fn uncertain() -> Self {
-        Self {
-            is_banned: false,
-            last_updated: Instant::now(),
-            uncertain: true,
         }
     }
 }
@@ -94,7 +90,7 @@ impl Cached {
         for address in addresses {
             match self.cache.get(address) {
                 Some(entry) => {
-                    entry.is_banned.then(|| banned.insert(*address));
+                    (entry.verdict == Verdict::Banned).then(|| banned.insert(*address));
                 }
                 None => need_lookup.push(*address),
             }
@@ -107,14 +103,15 @@ impl Cached {
             .await;
 
         for (address, is_banned) in fetched {
-            let entry = match is_banned {
-                Some(is_banned) => Entry::new(is_banned),
-                None => Entry::uncertain(),
+            let verdict = match is_banned {
+                Some(true) => Verdict::Banned,
+                Some(false) => Verdict::NotBanned,
+                None => Verdict::Unknown,
             };
-            if entry.is_banned {
+            if verdict == Verdict::Banned {
                 banned.insert(address);
             }
-            self.cache.insert(address, entry);
+            self.cache.insert(address, Entry::new(verdict));
         }
 
         banned
@@ -135,12 +132,13 @@ impl Cached {
     }
 
     /// Collects cache entries close enough to expiry that the next maintenance
-    /// tick may miss the window, plus uncertain entries awaiting a retry.
+    /// tick may miss the window, plus [`Verdict::Unknown`] entries awaiting
+    /// a retry.
     fn expired(&self, now: Instant) -> Vec<Arc<Address>> {
         self.cache
             .iter()
             .filter_map(|(address, entry)| {
-                let due = entry.uncertain
+                let due = entry.verdict == Verdict::Unknown
                     || now
                         .checked_duration_since(entry.last_updated)
                         .unwrap_or_default()
@@ -154,7 +152,12 @@ impl Cached {
     /// positive confirmation and at least one backend failed.
     async fn refresh(&self, address: Address) -> Option<(Address, Entry)> {
         let is_banned = self.fetch_all(address).await?;
-        Some((address, Entry::new(is_banned)))
+        let verdict = if is_banned {
+            Verdict::Banned
+        } else {
+            Verdict::NotBanned
+        };
+        Some((address, Entry::new(verdict)))
     }
 
     /// Spawns a background task that periodically refreshes near-expiry cache
@@ -257,7 +260,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn uncertain_entries_are_due_for_maintenance_and_recover() {
+    async fn unknown_entries_are_due_for_maintenance_and_recover() {
         let (cached, _calls, failing) = setup(true);
         let address = Address::repeat_byte(1);
         let addresses = HashSet::from([address]);

--- a/crates/order-validation/src/banned/cached.rs
+++ b/crates/order-validation/src/banned/cached.rs
@@ -248,30 +248,24 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn failed_lookup_is_cached_not_refetched_inline() {
-        let (cached, calls, _failing) = setup(true);
-        let addresses = HashSet::from([Address::repeat_byte(1)]);
-
-        assert!(cached.check(&addresses).await.is_empty());
-        assert_eq!(calls.load(Ordering::SeqCst), 1);
-
-        assert!(cached.check(&addresses).await.is_empty());
-        assert_eq!(calls.load(Ordering::SeqCst), 1);
-    }
-
-    #[tokio::test]
-    async fn unknown_entries_are_due_for_maintenance_and_recover() {
-        let (cached, _calls, failing) = setup(true);
+    async fn failed_lookup_is_cached_until_retry_succeeds() {
+        let (cached, calls, failing) = setup(true);
         let address = Address::repeat_byte(1);
         let addresses = HashSet::from([address]);
 
+        // A failed lookup is cached; a second check is served from cache
+        // instead of fetching inline again.
         assert!(cached.check(&addresses).await.is_empty());
-        assert_eq!(cached.expired(Instant::now()).len(), 1);
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+        assert!(cached.check(&addresses).await.is_empty());
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
 
+        // The unknown entry stays due for a background retry until a lookup
+        // succeeds.
+        assert_eq!(cached.expired(Instant::now()).len(), 1);
         failing.store(false, Ordering::SeqCst);
         let (address, entry) = cached.refresh(address).await.unwrap();
         cached.cache.insert(address, entry);
-
         assert!(cached.expired(Instant::now()).is_empty());
     }
 }

--- a/crates/order-validation/src/banned/cached.rs
+++ b/crates/order-validation/src/banned/cached.rs
@@ -23,6 +23,11 @@ const MAINTENANCE_TIMEOUT: Duration = Duration::from_secs(60);
 struct Entry {
     is_banned: bool,
     last_updated: Instant,
+    /// The lookup failed, so `is_banned` is a fail-open placeholder. The
+    /// maintenance task retries uncertain entries on every tick; the read
+    /// path serves them from cache instead of re-paying the backend
+    /// timeout inline on every check.
+    uncertain: bool,
 }
 
 impl Entry {
@@ -31,6 +36,17 @@ impl Entry {
         Self {
             is_banned,
             last_updated: Instant::now(),
+            uncertain: false,
+        }
+    }
+
+    /// Creates an [`Entry`] recording a failed lookup, treated as not banned
+    /// until a retry succeeds.
+    fn uncertain() -> Self {
+        Self {
+            is_banned: false,
+            last_updated: Instant::now(),
+            uncertain: true,
         }
     }
 }
@@ -93,27 +109,23 @@ impl Cached {
             .collect()
             .await;
 
-        let now = Instant::now();
         for (address, is_banned) in fetched {
-            let Some(is_banned) = is_banned else { continue };
-            self.cache.insert(
-                address,
-                Entry {
-                    is_banned,
-                    last_updated: now,
-                },
-            );
-            if is_banned {
+            let entry = match is_banned {
+                Some(is_banned) => Entry::new(is_banned),
+                None => Entry::uncertain(),
+            };
+            if entry.is_banned {
                 banned.insert(address);
             }
+            self.cache.insert(address, entry);
         }
 
         banned
     }
 
-    /// `Some(true)` as soon as any backend confirms a ban — a failure
+    /// `Some(true)` as soon as any backend confirms a ban, since a failure
     /// elsewhere must not mask a positive hit. `None` means no confirmation
-    /// and at least one failure, so the caller skips caching.
+    /// and at least one failure, cached as an uncertain entry.
     async fn fetch_all(&self, address: Address) -> Option<bool> {
         let results = join_all(self.backends.iter().map(|b| fetch_one(b.as_ref(), address))).await;
         if results.iter().any(|r| matches!(r, Some(true))) {
@@ -126,15 +138,16 @@ impl Cached {
     }
 
     /// Collects cache entries close enough to expiry that the next maintenance
-    /// tick may miss the window.
+    /// tick may miss the window, plus uncertain entries awaiting a retry.
     fn expired(&self, now: Instant) -> Vec<Arc<Address>> {
         self.cache
             .iter()
             .filter_map(|(address, entry)| {
-                let due = now
-                    .checked_duration_since(entry.last_updated)
-                    .unwrap_or_default()
-                    >= CACHE_EXPIRY - MAINTENANCE_TIMEOUT;
+                let due = entry.uncertain
+                    || now
+                        .checked_duration_since(entry.last_updated)
+                        .unwrap_or_default()
+                        >= CACHE_EXPIRY - MAINTENANCE_TIMEOUT;
                 due.then_some(address)
             })
             .collect()
@@ -188,5 +201,80 @@ async fn fetch_one(backend: &dyn Backend, address: Address) -> Option<bool> {
             );
             None
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        std::sync::atomic::{AtomicBool, AtomicUsize, Ordering},
+    };
+
+    struct FlakyBackend {
+        calls: Arc<AtomicUsize>,
+        fail: Arc<AtomicBool>,
+    }
+
+    #[async_trait]
+    impl Backend for FlakyBackend {
+        async fn fetch(&self, _: Address) -> Result<bool, BackendError> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            if self.fail.load(Ordering::SeqCst) {
+                Err(BackendError::Hermod(
+                    super::super::hermod::Error::UnexpectedStatus(
+                        reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+                    ),
+                ))
+            } else {
+                Ok(false)
+            }
+        }
+
+        fn name(&self) -> &'static str {
+            "flaky"
+        }
+    }
+
+    fn setup(fail: bool) -> (Arc<Cached>, Arc<AtomicUsize>, Arc<AtomicBool>) {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let failing = Arc::new(AtomicBool::new(fail));
+        let backend = FlakyBackend {
+            calls: calls.clone(),
+            fail: failing.clone(),
+        };
+        let cached = Cached::new(vec![Box::new(backend)], 100).unwrap();
+        (cached, calls, failing)
+    }
+
+    #[tokio::test]
+    async fn failed_lookup_is_cached_not_refetched_inline() {
+        let (cached, calls, _failing) = setup(true);
+        let addresses = HashSet::from([Address::repeat_byte(1)]);
+
+        assert!(cached.check(&addresses).await.is_empty());
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+
+        // The failure is cached as uncertain, so a second check must not
+        // trigger another inline lookup.
+        assert!(cached.check(&addresses).await.is_empty());
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn uncertain_entries_are_due_for_maintenance_and_recover() {
+        let (cached, _calls, failing) = setup(true);
+        let address = Address::repeat_byte(1);
+        let addresses = HashSet::from([address]);
+
+        assert!(cached.check(&addresses).await.is_empty());
+        // The failed lookup is due for a background retry right away.
+        assert_eq!(cached.expired(Instant::now()).len(), 1);
+
+        failing.store(false, Ordering::SeqCst);
+        let (address, entry) = cached.refresh(address).await.unwrap();
+        cached.cache.insert(address, entry);
+
+        assert!(cached.expired(Instant::now()).is_empty());
     }
 }

--- a/crates/order-validation/src/banned/cached.rs
+++ b/crates/order-validation/src/banned/cached.rs
@@ -23,10 +23,8 @@ const MAINTENANCE_TIMEOUT: Duration = Duration::from_secs(60);
 struct Entry {
     is_banned: bool,
     last_updated: Instant,
-    /// The lookup failed, so `is_banned` is a fail-open placeholder. The
-    /// maintenance task retries uncertain entries on every tick; the read
-    /// path serves them from cache instead of re-paying the backend
-    /// timeout inline on every check.
+    /// The lookup failed and `is_banned` is a fail-open placeholder until
+    /// a maintenance-task retry succeeds.
     uncertain: bool,
 }
 
@@ -40,8 +38,7 @@ impl Entry {
         }
     }
 
-    /// Creates an [`Entry`] recording a failed lookup, treated as not banned
-    /// until a retry succeeds.
+    /// Creates an [`Entry`] for a failed lookup.
     fn uncertain() -> Self {
         Self {
             is_banned: false,
@@ -125,7 +122,7 @@ impl Cached {
 
     /// `Some(true)` as soon as any backend confirms a ban, since a failure
     /// elsewhere must not mask a positive hit. `None` means no confirmation
-    /// and at least one failure, cached as an uncertain entry.
+    /// and at least one failure.
     async fn fetch_all(&self, address: Address) -> Option<bool> {
         let results = join_all(self.backends.iter().map(|b| fetch_one(b.as_ref(), address))).await;
         if results.iter().any(|r| matches!(r, Some(true))) {
@@ -255,8 +252,6 @@ mod tests {
         assert!(cached.check(&addresses).await.is_empty());
         assert_eq!(calls.load(Ordering::SeqCst), 1);
 
-        // The failure is cached as uncertain, so a second check must not
-        // trigger another inline lookup.
         assert!(cached.check(&addresses).await.is_empty());
         assert_eq!(calls.load(Ordering::SeqCst), 1);
     }
@@ -268,7 +263,6 @@ mod tests {
         let addresses = HashSet::from([address]);
 
         assert!(cached.check(&addresses).await.is_empty());
-        // The failed lookup is due for a background retry right away.
         assert_eq!(cached.expired(Instant::now()).len(), 1);
 
         failing.store(false, Ordering::SeqCst);


### PR DESCRIPTION
# Description
When a banned-users backend (Hermod or the Chainalysis oracle) fails a lookup, the result is not cached, so the same address is fetched inline again on every check until a lookup succeeds. During the hermod incident on prod (2026-08-31) this turned a trickle of first-time addresses into repeated 5 second stalls of autopilot's `banned_user_filtering` stage: every auction loop re-paid the client timeout for the same few addresses.

Failed lookups are now cached as `Verdict::Unknown`. The read path serves them like any other entry, treated as not banned, and the maintenance task retries them on every tick until a backend answers. So a backend outage costs one timeout per new address instead of one per address per check.

The fail-open window itself is not new. A failed lookup already let the address through, we just retried it inline on the next check. With the retry in the maintenance task it can take up to one tick (60s) after a backend recovers until the address is actually checked again.

# Changes
- Cache failed lookups as `Verdict::Unknown` and retry them in the maintenance task instead of inline on every check
- Replace the `is_banned` + `uncertain` flags on cache entries with a single `Verdict` enum

# How to test
New unit test.