### PR TITLE
Center settle headroom around auction's next block

### DIFF
--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -1314,12 +1314,7 @@ impl Metrics {
             .settle_blocks_elapsed
             .observe(head.saturating_sub(start_block.number) as f64);
 
-        Self::record_settle_time_to_next_block(
-            start_block.number + 1,
-            Utc::now(),
-            Instant::now(),
-            current_block.clone(),
-        );
+        Self::record_settle_time_to_next_block(start_block.number + 1, current_block.clone());
     }
 
     /// Runway to `target`, the block the auction aimed at; negative once it was
@@ -1327,12 +1322,13 @@ impl Metrics {
     /// and `observed_at`, which trails it by the block observation lag.
     fn record_settle_time_to_next_block(
         target: u64,
-        // Two clocks: `block.timestamp` is wall clock, `block.observed_at` is
-        // monotonic, and neither is comparable to the other.
-        sent_at: DateTime<Utc>,
-        sent_at_monotonic: Instant,
         watcher: ethrpc::block_stream::CurrentBlockWatcher,
     ) {
+        // Two clocks: `block.timestamp` is wall clock, `block.observed_at` is
+        // monotonic, and neither is comparable to the other.
+        let sent_at = Utc::now();
+        let sent_at_monotonic = Instant::now();
+
         if watcher.borrow().number > target {
             // The watcher holds only the head, so `target`'s clocks are gone.
             // These calls are `settle_blocks_elapsed` past its `le=1` bucket.

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -1184,11 +1184,13 @@ struct Metrics {
     #[metric(buckets(0, 1, 2, 3, 4, 6, 8, 12, 16, 24, 32, 48, 64))]
     settle_blocks_elapsed: prometheus::Histogram,
 
-    /// Seconds of runway the `/settle` call had: how long until the block after
-    /// the current head arrives. With `settle_blocks_elapsed` it predicts the
-    /// landing block, `start + blocks_elapsed + 1` when the runway suffices.
-    #[metric(buckets(0.5, 0.75, 1, 1.25, 1.5, 1.75, 2, 2.25, 2.5, 2.75, 3, 3.5, 4, 6, 8, 12))]
-    settle_headroom: prometheus::Histogram,
+    /// Seconds from the `/settle` call to the nominal start of the block the
+    /// auction aimed at. Negative once that block was already due.
+    #[metric(buckets(
+        -4, -3, -2, -1.5, -1, -0.75, -0.5, -0.25, 0, 0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2, 2.5,
+        3, 4, 6, 8, 12
+    ))]
+    settle_time_to_next_block: prometheus::Histogram,
 
     /// Tracks the size of the `/solve` request body in bytes. The `kind` label
     /// tells the two bodies apart: `full` is sent to regular drivers, `delta`
@@ -1297,45 +1299,45 @@ impl Metrics {
     }
 
     /// Records where the `/settle` request lands relative to block production:
-    /// how many block windows the run burned, plus the runway left when the
-    /// targeted block is still ahead. Call immediately before the request goes
-    /// out.
+    /// block windows burned, plus the runway to the block the auction aimed at.
+    /// Call immediately before the request goes out.
     fn record_settle_block_metrics(
         start_block: BlockInfo,
         current_block: &ethrpc::block_stream::CurrentBlockWatcher,
     ) {
         let head = current_block.borrow().number;
-        let blocks_elapsed = head.saturating_sub(start_block.number);
         Self::get()
             .settle_blocks_elapsed
-            .observe(blocks_elapsed as f64);
+            .observe(head.saturating_sub(start_block.number) as f64);
 
-        // Anchored on the head rather than on the auction's start block: once a
-        // run overran, the question is whether the request still makes the next
-        // block or loses one more. Both anchors agree when nothing overran.
-        Self::record_time_to_next_block(head + 1, Instant::now(), current_block.clone());
+        Self::record_settle_time_to_next_block(
+            start_block.number + 1,
+            Utc::now(),
+            current_block.clone(),
+        );
     }
 
-    /// Waits in the background for `target` to arrive and records how much
-    /// runway the `/settle` request had. Waiting on an explicit block number
-    /// rather than "the next block" matters: a block landing before this task
-    /// is first polled would otherwise be skipped, overstating the runway by a
-    /// whole block.
-    fn record_time_to_next_block(
+    /// Runway to `target`, the block the auction aimed at; negative once it was
+    /// already due. Referenced to `block.timestamp`, not `observed_at`, which
+    /// trails the nominal start by the block observation lag.
+    fn record_settle_time_to_next_block(
         target: u64,
-        sent_at: Instant,
+        sent_at: DateTime<Utc>,
         watcher: ethrpc::block_stream::CurrentBlockWatcher,
     ) {
+        if watcher.borrow().number > target {
+            // The watcher holds only the head, so `target`'s timestamp is gone.
+            // These calls are `settle_blocks_elapsed` past its `le=1` bucket.
+            return;
+        }
+        let sent_at = sent_at.timestamp_millis() as f64 / 1e3;
         tokio::spawn(async move {
             let mut stream = ethrpc::block_stream::into_stream(watcher);
             while let Some(block) = stream.next().await {
                 if block.number >= target {
-                    Self::get().settle_headroom.observe(
-                        block
-                            .observed_at
-                            .saturating_duration_since(sent_at)
-                            .as_secs_f64(),
-                    );
+                    Self::get()
+                        .settle_time_to_next_block
+                        .observe(block.timestamp as f64 - sent_at);
                     return;
                 }
             }

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -1324,17 +1324,16 @@ impl Metrics {
         target: u64,
         watcher: ethrpc::block_stream::CurrentBlockWatcher,
     ) {
-        // Two clocks: `block.timestamp` is wall clock, `block.observed_at` is
-        // monotonic, and neither is comparable to the other.
-        let sent_at = Utc::now();
-        let sent_at_monotonic = Instant::now();
-
         if watcher.borrow().number > target {
             // The watcher holds only the head, so `target`'s clocks are gone.
             // These calls are `settle_blocks_elapsed` past its `le=1` bucket.
             return;
         }
-        let sent_at = sent_at.timestamp_millis() as f64 / 1e3;
+
+        // Two clocks: `block.timestamp` is wall clock, `block.observed_at` is
+        // monotonic, and neither is comparable to the other.
+        let sent_at_monotonic = Instant::now();
+        let sent_at = Utc::now().timestamp_millis() as f64 / 1e3;
         tokio::spawn(async move {
             let mut stream = ethrpc::block_stream::into_stream(watcher);
             while let Some(block) = stream.next().await {

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -1184,13 +1184,17 @@ struct Metrics {
     #[metric(buckets(0, 1, 2, 3, 4, 6, 8, 12, 16, 24, 32, 48, 64))]
     settle_blocks_elapsed: prometheus::Histogram,
 
-    /// Seconds from the `/settle` call to the nominal start of the block the
-    /// auction aimed at. Negative once that block was already due.
-    #[metric(buckets(
-        -4, -3, -2, -1.5, -1, -0.75, -0.5, -0.25, 0, 0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2, 2.5,
-        3, 4, 6, 8, 12
-    ))]
-    settle_time_to_next_block: prometheus::Histogram,
+    /// Seconds from the `/settle` call to the block the auction aimed at,
+    /// negative once that block was already due. The `reference` label picks
+    /// the clock: `block_timestamp` (nominal start) or `observed_at`.
+    #[metric(
+        labels("reference"),
+        buckets(
+            -4, -3, -2, -1.5, -1, -0.75, -0.5, -0.25, 0, 0.25, 0.5, 0.75, 1, 1.25, 1.5, 1.75, 2,
+            2.5, 3, 4, 6, 8, 12
+        )
+    )]
+    settle_time_to_next_block: prometheus::HistogramVec,
 
     /// Tracks the size of the `/solve` request body in bytes. The `kind` label
     /// tells the two bodies apart: `full` is sent to regular drivers, `delta`
@@ -1313,20 +1317,24 @@ impl Metrics {
         Self::record_settle_time_to_next_block(
             start_block.number + 1,
             Utc::now(),
+            Instant::now(),
             current_block.clone(),
         );
     }
 
     /// Runway to `target`, the block the auction aimed at; negative once it was
-    /// already due. Referenced to `block.timestamp`, not `observed_at`, which
-    /// trails the nominal start by the block observation lag.
+    /// already due. Recorded against both the block's self-reported timestamp
+    /// and `observed_at`, which trails it by the block observation lag.
     fn record_settle_time_to_next_block(
         target: u64,
+        // Two clocks: `block.timestamp` is wall clock, `block.observed_at` is
+        // monotonic, and neither is comparable to the other.
         sent_at: DateTime<Utc>,
+        sent_at_monotonic: Instant,
         watcher: ethrpc::block_stream::CurrentBlockWatcher,
     ) {
         if watcher.borrow().number > target {
-            // The watcher holds only the head, so `target`'s timestamp is gone.
+            // The watcher holds only the head, so `target`'s clocks are gone.
             // These calls are `settle_blocks_elapsed` past its `le=1` bucket.
             return;
         }
@@ -1335,9 +1343,13 @@ impl Metrics {
             let mut stream = ethrpc::block_stream::into_stream(watcher);
             while let Some(block) = stream.next().await {
                 if block.number >= target {
-                    Self::get()
-                        .settle_time_to_next_block
+                    let metric = &Self::get().settle_time_to_next_block;
+                    metric
+                        .with_label_values(&["block_timestamp"])
                         .observe(block.timestamp as f64 - sent_at);
+                    metric
+                        .with_label_values(&["observed_at"])
+                        .observe(signed_secs_between(sent_at_monotonic, block.observed_at));
                     return;
                 }
             }
@@ -1349,6 +1361,14 @@ impl Metrics {
             .solve_request_body_size
             .with_label_values(&[kind])
             .observe(size as f64)
+    }
+}
+
+/// Seconds from `from` to `to`, negative when `to` is the earlier instant.
+fn signed_secs_between(from: Instant, to: Instant) -> f64 {
+    match to.checked_duration_since(from) {
+        Some(forward) => forward.as_secs_f64(),
+        None => -from.duration_since(to).as_secs_f64(),
     }
 }
 
@@ -1445,6 +1465,16 @@ mod tests {
             base_fee: Default::default(),
             observed_at: Instant::now(),
         }
+    }
+
+    #[test]
+    fn signed_secs_between_handles_both_directions() {
+        let earlier = Instant::now();
+        let later = earlier + Duration::from_millis(1500);
+
+        assert_eq!(signed_secs_between(earlier, later), 1.5);
+        assert_eq!(signed_secs_between(later, earlier), -1.5);
+        assert_eq!(signed_secs_between(earlier, earlier), 0.0);
     }
 
     #[test]


### PR DESCRIPTION
# Description
The current `settle_headroom` metric was around the next block and not the next auction block, which would lead to some times being 8s or more ahead. Since we mostly care whether we hit `auction_block + 1` this should give us a more accurate picture.

# Changes

* Rename `settle_headroom` to `settle_time_to_next_block`
* Make it around the auction's next block

## How to test

Deployed to prod and collected the following data (ignore the graph titles).

Heatmap:
<img width="2032" height="642" alt="image" src="https://github.com/user-attachments/assets/ed16f755-6dc1-4a0e-a2eb-c13ec16d3ac7" />

pX:
<img width="2032" height="642" alt="image" src="https://github.com/user-attachments/assets/a7256836-872c-40ff-820c-d14c68c27ce5" />
