### PR TITLE
Remove fetch_latest_prices dependencies on auction_prices

### DIFF
--- a/crates/database/src/auction_prices.rs
+++ b/crates/database/src/auction_prices.rs
@@ -128,6 +128,26 @@ mod tests {
         insert(&mut db, &auction_2).await.unwrap();
         insert(&mut db, &auction_3).await.unwrap();
 
+        // The latest price helpers read from `competition_auctions`, so the
+        // same prices have to be stored there as well.
+        // TODO: unify after migration
+        for prices in [&auction_1, &auction_2, &auction_3] {
+            crate::auction::save(
+                &mut db,
+                crate::auction::Auction {
+                    id: prices[0].auction_id,
+                    block: 0,
+                    deadline: 0,
+                    order_uids: vec![],
+                    price_tokens: prices.iter().map(|price| price.token).collect(),
+                    price_values: prices.iter().map(|price| price.price.clone()).collect(),
+                    surplus_capturing_jit_order_owners: vec![],
+                },
+            )
+            .await
+            .unwrap();
+        }
+
         // check that all auctions are there
         let output = fetch(&mut db, 1).await.unwrap();
         assert_eq!(output, auction_1);

--- a/crates/database/src/auction_prices.rs
+++ b/crates/database/src/auction_prices.rs
@@ -54,10 +54,14 @@ pub async fn fetch(
 #[instrument(skip_all)]
 pub async fn fetch_latest_prices(ex: &mut PgConnection) -> Result<Vec<AuctionPrice>, sqlx::Error> {
     const QUERY: &str = r#"
-SELECT * FROM auction_prices WHERE auction_id = (
-    SELECT MAX(auction_id)
-    FROM auction_prices
-)
+    SELECT
+        c.id,
+        unnest(c.price_tokens) AS price_token,
+        unnest(c.price_values) AS price_value
+    FROM competition_auctions c
+    WHERE c.id = (
+        SELECT MAX(id) FROM competition_auctions
+    )
     "#;
     sqlx::query_as(QUERY).fetch_all(ex).await
 }

--- a/crates/database/src/auction_prices.rs
+++ b/crates/database/src/auction_prices.rs
@@ -55,9 +55,9 @@ pub async fn fetch(
 pub async fn fetch_latest_prices(ex: &mut PgConnection) -> Result<Vec<AuctionPrice>, sqlx::Error> {
     const QUERY: &str = r#"
     SELECT
-        c.id,
-        unnest(c.price_tokens) AS price_token,
-        unnest(c.price_values) AS price_value
+        c.id AS auction_id,
+        unnest(c.price_tokens) AS token,
+        unnest(c.price_values) AS price
     FROM competition_auctions c
     WHERE c.id = (
         SELECT MAX(id) FROM competition_auctions

--- a/database/README.md
+++ b/database/README.md
@@ -53,14 +53,14 @@ Indexes:
 
 Contains all auctions for which a valid solver competition exists.
 
- Column        | Type    | Nullable | Details
----------------|---------|----------|--------
- id            | bigint  | not null | other tables refer to this as `auction\_id`
- block         | bigint  | not null | the block number on top of which the auction was created
- deadline      | bigint  | not null | the block number until which all winning solutions are expected to be settled on-chain.
- order\_uids   | bytea[] | not null | orders that are part of the auction
- price\_tokens | bytea[] | not null | native price tokens
- price\_values | numeric | not null | native price values, mapped one-to-one with `price\_tokens`
+ Column        | Type      | Nullable | Details
+---------------|-----------|----------|--------
+ id            | bigint    | not null | other tables refer to this as `auction\_id`
+ block         | bigint    | not null | the block number on top of which the auction was created
+ deadline      | bigint    | not null | the block number until which all winning solutions are expected to be settled on-chain.
+ order\_uids   | bytea[]   | not null | orders that are part of the auction
+ price\_tokens | bytea[]   | not null | native price tokens
+ price\_values | numeric[] | not null | native price values, mapped one-to-one with `price\_tokens`
  surplus\_capturing\_jit\_order\_owners | bytea[] | not null | surplus capturing jit order owners that are part of the auction
 
 Indexes:


### PR DESCRIPTION
# Description
As part of the goal to remove `auction_prices`, this replaces the dependency from `fetch_latest_prices`

# Changes

* Replace the query in `fetch_latest_prices`

## How to test
Run the following query:

```
WITH a AS (
    SELECT *
    FROM auction_prices
    WHERE auction_id = (
        SELECT MAX(auction_id)
        FROM auction_prices
    )
),
b AS (
    SELECT
        c.id,
        unnest(c.price_tokens) AS price_token,
        unnest(c.price_values) AS price_value
    FROM competition_auctions c
    WHERE c.id = (
        SELECT MAX(id) FROM competition_auctions
    )
    ORDER BY price_token)
SELECT * FROM a
EXCEPT
SELECT * FROM b;
```

`ORDER BY` is required since `EXCEPT` needs a 1:1 match, including order