### PR TITLE
Remove final reads and writes to `auction_prices`

### DIFF
--- a/crates/autopilot/src/database/auction_prices.rs
+++ b/crates/autopilot/src/database/auction_prices.rs
@@ -13,7 +13,7 @@ impl Postgres {
             .with_label_values(&["fetch_latest_prices"])
             .start_timer();
 
-        let mut ex = self.pool.begin().await?;
+        let mut ex = self.pool.acquire().await?;
         Ok(database::auction_prices::fetch_latest_prices(&mut ex)
             .await?
             .into_iter()

--- a/crates/autopilot/src/database/competition.rs
+++ b/crates/autopilot/src/database/competition.rs
@@ -1,12 +1,12 @@
 use {
     crate::domain::competition::Score,
-    alloy::primitives::{Address, U256},
+    alloy::primitives::Address,
     anyhow::Context,
-    database::{auction::AuctionId, auction_prices::AuctionPrice, byte_array::ByteArray},
+    database::{auction::AuctionId, byte_array::ByteArray},
     derive_more::Debug,
     model::solver_competition::SolverCompetitionDB,
     number::conversions::u256_to_big_decimal,
-    std::collections::{BTreeMap, HashMap, HashSet},
+    std::collections::{HashMap, HashSet},
 };
 
 #[derive(Clone, Default, Debug)]
@@ -16,8 +16,6 @@ pub struct Competition {
     /// Addresses to which the CIP20 participation rewards will be payed out.
     /// Usually the same as the solver addresses.
     pub participants: HashSet<Address>,
-    /// External prices for auction.
-    pub prices: BTreeMap<Address, U256>,
     /// Winner receives performance rewards if a settlement is finalized on
     /// chain before this block height.
     pub block_deadline: u64,
@@ -32,7 +30,7 @@ impl super::Postgres {
             .with_label_values(&["save_competition"])
             .start_timer();
 
-        let mut ex = self.pool.begin().await.context("begin")?;
+        let mut ex = self.pool.acquire().await.context("save_competition")?;
 
         let reference_scores: Vec<_> = competition
             .reference_scores
@@ -46,24 +44,6 @@ impl super::Postgres {
 
         database::reference_scores::insert(&mut ex, &reference_scores)
             .await
-            .context("reference_scores::insert")?;
-
-        database::auction_prices::insert(
-            &mut ex,
-            competition
-                .prices
-                .into_iter()
-                .map(|(token, price)| AuctionPrice {
-                    auction_id: competition.auction_id,
-                    token: ByteArray(token.0.0),
-                    price: u256_to_big_decimal(&price),
-                })
-                .collect::<Vec<_>>()
-                .as_slice(),
-        )
-        .await
-        .context("auction_prices::insert")?;
-
-        ex.commit().await.context("commit")
+            .context("reference_scores::insert")
     }
 }

--- a/crates/autopilot/src/run_loop.rs
+++ b/crates/autopilot/src/run_loop.rs
@@ -618,12 +618,6 @@ impl RunLoop {
             auction_id: auction.id,
             reference_scores,
             participants,
-            prices: auction
-                .prices
-                .clone()
-                .into_iter()
-                .map(|(key, value)| (*key, value.get().0))
-                .collect(),
             block_deadline,
             competition_simulation_block,
             competition_table,

--- a/crates/database/src/auction_prices.rs
+++ b/crates/database/src/auction_prices.rs
@@ -1,10 +1,7 @@
-//! This table is deprecated, since it contains duplicated data in the
-//! `competition_auctions` table. But it can't currently be removed, since the
-//! solver team is still using it.
 use {
-    crate::{Address, PgTransaction, auction::AuctionId},
+    crate::{Address, auction::AuctionId},
     bigdecimal::BigDecimal,
-    sqlx::{Connection, PgConnection, QueryBuilder},
+    sqlx::{Connection, PgConnection},
     std::ops::DerefMut,
     tracing::instrument,
 };
@@ -15,40 +12,6 @@ pub struct AuctionPrice {
     pub auction_id: AuctionId,
     pub token: Address,
     pub price: BigDecimal,
-}
-
-#[instrument(skip_all)]
-pub async fn insert(
-    ex: &mut PgTransaction<'_>,
-    prices: &[AuctionPrice],
-) -> Result<(), sqlx::Error> {
-    const BATCH_SIZE: usize = 5000;
-    const QUERY: &str = "INSERT INTO auction_prices (auction_id, token, price) ";
-
-    for chunk in prices.chunks(BATCH_SIZE) {
-        let mut query_builder = QueryBuilder::new(QUERY);
-
-        query_builder.push_values(chunk, |mut builder, price| {
-            builder
-                .push_bind(price.auction_id)
-                .push_bind(price.token)
-                .push_bind(price.price.clone());
-        });
-
-        query_builder.build().execute(ex.deref_mut()).await?;
-    }
-
-    Ok(())
-}
-
-#[instrument(skip_all)]
-pub async fn fetch(
-    ex: &mut PgConnection,
-    auction_id: AuctionId,
-) -> Result<Vec<AuctionPrice>, sqlx::Error> {
-    const QUERY: &str = "SELECT * FROM auction_prices WHERE auction_id = $1";
-    let prices = sqlx::query_as(QUERY).bind(auction_id).fetch_all(ex).await?;
-    Ok(prices)
 }
 
 #[instrument(skip_all)]
@@ -148,13 +111,7 @@ mod tests {
             },
         ];
 
-        insert(&mut db, &auction_1).await.unwrap();
-        insert(&mut db, &auction_2).await.unwrap();
-        insert(&mut db, &auction_3).await.unwrap();
-
-        // The latest price helpers read from `competition_auctions`, so the
-        // same prices have to be stored there as well.
-        // TODO: unify after migration
+        // Prices are stored as the parallel arrays of `competition_auctions`.
         for prices in [&auction_1, &auction_2, &auction_3] {
             crate::auction::save(
                 &mut db,
@@ -174,15 +131,18 @@ mod tests {
         }
 
         // check that all auctions are there
-        let output = fetch(&mut db, 1).await.unwrap();
-        assert_eq!(output, auction_1);
-        let output = fetch(&mut db, 2).await.unwrap();
-        assert_eq!(output, auction_2);
-        let output = fetch(&mut db, 3).await.unwrap();
-        assert_eq!(output, auction_3);
+        for prices in [&auction_1, &auction_2, &auction_3] {
+            let stored = crate::auction::fetch(&mut db, prices[0].auction_id)
+                .await
+                .unwrap()
+                .unwrap();
+            let tokens: Vec<_> = prices.iter().map(|price| price.token).collect();
+            let values: Vec<_> = prices.iter().map(|price| price.price.clone()).collect();
+            assert_eq!(stored.price_tokens, tokens);
+            assert_eq!(stored.price_values, values);
+        }
         // non-existent auction
-        let output = fetch(&mut db, 4).await.unwrap();
-        assert!(output.is_empty());
+        assert!(crate::auction::fetch(&mut db, 4).await.unwrap().is_none());
         // latest prices
         let output = fetch_latest_prices(&mut db).await.unwrap();
         assert_eq!(output, auction_3);

--- a/crates/database/src/lib.rs
+++ b/crates/database/src/lib.rs
@@ -70,7 +70,6 @@ pub const TABLES: &[&str] = &[
 
 /// The names of potentially big volume tables we use in the db.
 pub const LARGE_TABLES: &[&str] = &[
-    "auction_prices",
     "competition_auctions",
     "fee_policies",
     "orders",

--- a/crates/database/src/reference_scores.rs
+++ b/crates/database/src/reference_scores.rs
@@ -1,8 +1,7 @@
 use {
-    crate::{Address, PgTransaction, auction::AuctionId},
+    crate::{Address, auction::AuctionId},
     bigdecimal::BigDecimal,
     sqlx::{PgConnection, QueryBuilder},
-    std::ops::DerefMut,
     tracing::instrument,
 };
 
@@ -14,7 +13,7 @@ pub struct Score {
 }
 
 #[instrument(skip_all)]
-pub async fn insert(ex: &mut PgTransaction<'_>, scores: &[Score]) -> Result<(), sqlx::Error> {
+pub async fn insert(ex: &mut PgConnection, scores: &[Score]) -> Result<(), sqlx::Error> {
     const QUERY: &str = "INSERT INTO reference_scores (auction_id, solver, reference_score) ";
 
     if scores.is_empty() {
@@ -29,7 +28,7 @@ pub async fn insert(ex: &mut PgTransaction<'_>, scores: &[Score]) -> Result<(), 
             .push_bind(score.reference_score.clone());
     });
 
-    query_builder.build().execute(ex.deref_mut()).await?;
+    query_builder.build().execute(ex).await?;
 
     Ok(())
 }

--- a/crates/e2e/tests/e2e/database.rs
+++ b/crates/e2e/tests/e2e/database.rs
@@ -69,7 +69,12 @@ pub async fn auction_prices(
     ex: &mut PgConnection,
     auction_id: i64,
 ) -> anyhow::Result<Vec<database::auction_prices::AuctionPrice>> {
-    const QUERY: &str = "SELECT * FROM auction_prices WHERE auction_id = $1";
+    const QUERY: &str = "
+        SELECT
+            id AS auction_id,
+            unnest(price_tokens) AS token,
+            unnest(price_values) AS price
+        FROM competition_auctions WHERE id = $1";
     Ok(sqlx::query_as(QUERY).bind(auction_id).fetch_all(ex).await?)
 }
 

--- a/crates/orderbook/src/database/auction_prices.rs
+++ b/crates/orderbook/src/database/auction_prices.rs
@@ -13,7 +13,7 @@ impl Postgres {
             .with_label_values(&["fetch_latest_prices"])
             .start_timer();
 
-        let mut ex = self.pool.begin().await?;
+        let mut ex = self.pool.acquire().await?;
         Ok(database::auction_prices::fetch_latest_prices(&mut ex)
             .await?
             .into_iter()


### PR DESCRIPTION
# Description
Remove final reads and writes to `auction_prices`, starts refactoring other pieces of code. Following PRs remove and simplify more, I tried to keep it short here.

# Changes

* Remove the INSERTs to `auction_prices`
* Some `begin()` can now be `acquire` instead since its a single INSERT
* Fixed tests

## How to test
Important reads have been migrated away already, so removing the write is ok.
There's also tests.