### PR TITLE
Drop `auction_prices` table

### DIFF
--- a/database/README.md
+++ b/database/README.md
@@ -24,18 +24,6 @@ Column                | Type        | Nullable | Details
 Indexes:
 - "app\_data\_pkey" PRIMARY KEY, btree (`contract_app_data`)
 
-### auction\_prices
-
-Stores the native price of a token in a given auction. Used for computations related to CIP-20.
-
- Column     | Type    | Nullable | Details
-------------|---------|----------|--------
-auction\_id | bigint  | not null | in which auction this price was provided
-token       | bytea   | not null | address of the token the price refers to
-price       | numeric | not null | the atoms of ETH that can be bought with 1 atom of the token
-
-Indexes:
-- PRIMARY KEY: btree(`auction_uid`, `token`)
 
 ### auctions (and auctions\_id\_seq counter)
 

--- a/database/sql/V124__drop_auction_prices.sql
+++ b/database/sql/V124__drop_auction_prices.sql
@@ -1,0 +1,3 @@
+-- Drop the `auction_prices` table. Its data duplicated the `price_tokens` /
+-- `price_values` arrays of `competition_auctions`, which every reader now uses.
+DROP TABLE IF EXISTS auction_prices;


### PR DESCRIPTION
# Description
Drops the now unused auction prices table, replaced by competition auctions, should save ~370GB (at least)

# Changes

* Drop the `auction_prices` table

