### PR TITLE
solana-indexer: advance the finalized watermark from slot statuses

### DIFF
--- a/crates/solana-indexer/src/indexer/decoder.rs
+++ b/crates/solana-indexer/src/indexer/decoder.rs
@@ -108,6 +108,10 @@ impl Decoder {
                         .await?;
                     continue;
                 }
+                StreamUpdate::Finalized { slot } => {
+                    self.persistence.write_finalized_slot(slot).await?;
+                    continue;
+                }
             };
             self.flush_up_to(&mut pending, slot, &mut flushed_through)
                 .await?;
@@ -163,6 +167,15 @@ impl Decoder {
         for (slot, buffer) in std::mem::replace(pending, keep) {
             self.flush_slot(slot, buffer, true).await?;
             *flushed_through = (*flushed_through).max(Some(slot));
+        }
+        // Everything at or below the cutoff is complete even when nothing was
+        // buffered: advance the watermark on quiet slots too, so the resume
+        // point tracks the stream.
+        if cutoff > 0 && *flushed_through < Some(Slot(cutoff)) {
+            self.persistence
+                .write_last_indexed_slot(Slot(cutoff))
+                .await?;
+            *flushed_through = Some(Slot(cutoff));
         }
         Ok(())
     }

--- a/crates/solana-indexer/src/indexer/decoder.rs
+++ b/crates/solana-indexer/src/indexer/decoder.rs
@@ -85,15 +85,19 @@ impl Decoder {
     /// instructions, and persists the results. Returns when the ingester
     /// drops the sender.
     ///
-    /// Events and dead letters are buffered per slot and flushed once a
-    /// transaction of a later slot arrives: stream resume is slot-granular
-    /// (`from_slot = last_indexed_slot + 1`), so the last indexed slot may
-    /// only name slots whose transactions have all been delivered. Buffering
-    /// also makes it one persistence batch per slot instead of one per
-    /// transaction.
+    /// Events and dead letters are buffered per slot and flushed when the
+    /// slot's confirmed status arrives: the stream delivers a slot's
+    /// transactions before that status, so the status is the completeness
+    /// signal. The watermark (`solana.indexer_state.slot`) advances to every
+    /// confirmed slot, quiet ones included, and only after its buffers
+    /// flushed. A persistence error aborts the decoder and the process: the
+    /// watermark did not advance past anything unflushed, so the restart
+    /// replays it.
     pub async fn run(&mut self) -> Result<(), PersistenceError> {
         let mut pending: BTreeMap<Slot, SlotBuffer> = BTreeMap::new();
-        let mut flushed_through: Option<Slot> = None;
+        // In-memory mirror of the persisted watermark, spares redundant
+        // writes and flags late transactions.
+        let mut watermark: Option<Slot> = None;
         while let Some(update) = self.rx.recv().await {
             let (slot, signature, inner) = match update {
                 StreamUpdate::Tx {
@@ -101,10 +105,8 @@ impl Decoder {
                     signature,
                     inner,
                 } => (slot, signature, inner),
-                // Slot statuses bound the flush latency: the next settlement
-                // transaction can be minutes away.
-                StreamUpdate::Slot { slot } => {
-                    self.flush_up_to(&mut pending, slot, &mut flushed_through)
+                StreamUpdate::Confirmed { slot } => {
+                    self.flush_confirmed(&mut pending, slot, &mut watermark)
                         .await?;
                     continue;
                 }
@@ -113,18 +115,17 @@ impl Decoder {
                     continue;
                 }
             };
-            self.flush_up_to(&mut pending, slot, &mut flushed_through)
-                .await?;
 
-            if let Some(flushed) = flushed_through
-                && slot <= flushed
+            if let Some(watermark) = watermark
+                && slot <= watermark
             {
-                // The events below still persist, and the backward slot write
-                // write is a no-op, but a crash before this batch flushes
-                // would lose the transaction: resume starts past its slot.
+                // The provider broke the transactions-before-status ordering.
+                // The events below still persist (idempotent writes), but a
+                // crash before they flush would lose them: resume starts past
+                // their slot.
                 tracing::warn!(
                     %slot,
-                    flushed_through = %flushed,
+                    %watermark,
                     "transaction arrived for an already flushed slot"
                 );
             }
@@ -141,41 +142,34 @@ impl Decoder {
                 Err(DecodeFailed) => buffer.dead_letters.push(signature),
             }
         }
-        // The stream ended. Only the newest buffer may be missing
-        // transactions, everything below it was already proven complete by
-        // later stream activity.
-        let mut leftover = pending.into_iter().peekable();
-        while let Some((slot, buffer)) = leftover.next() {
-            let complete = leftover.peek().is_some();
-            self.flush_slot(slot, buffer, complete).await?;
+        // The stream ended before these buffers' confirmed statuses arrived,
+        // so they may be missing transactions: flush without advancing the
+        // watermark, the reconnect replays their slots.
+        for (slot, buffer) in pending {
+            self.flush_slot(slot, buffer, false).await?;
         }
         Ok(())
     }
 
-    /// Flushes every buffer at least [`FLUSH_HOLDBACK_SLOTS`] behind the
-    /// observed slot. The hold-back gives late-delivered transactions a
-    /// window to join their slot's still unflushed buffer, keeping them
-    /// crash-safe: resume replays everything past the last indexed slot.
-    async fn flush_up_to(
+    /// Flush every buffer at or below the confirmed slot, then advance the
+    /// watermark to it: the slot's transactions all arrived before its
+    /// status, and quiet slots below it have nothing to wait for.
+    async fn flush_confirmed(
         &self,
         pending: &mut BTreeMap<Slot, SlotBuffer>,
-        observed: Slot,
-        flushed_through: &mut Option<Slot>,
+        confirmed: Slot,
+        watermark: &mut Option<Slot>,
     ) -> Result<(), PersistenceError> {
-        let cutoff = u64::from(observed).saturating_sub(FLUSH_HOLDBACK_SLOTS);
-        let keep = pending.split_off(&Slot(cutoff.saturating_add(1)));
-        for (slot, buffer) in std::mem::replace(pending, keep) {
+        while let Some(entry) = pending.first_entry() {
+            if *entry.key() > confirmed {
+                break;
+            }
+            let (slot, buffer) = entry.remove_entry();
             self.flush_slot(slot, buffer, true).await?;
-            *flushed_through = (*flushed_through).max(Some(slot));
         }
-        // Everything at or below the cutoff is complete even when nothing was
-        // buffered: advance the watermark on quiet slots too, so the resume
-        // point tracks the stream.
-        if cutoff > 0 && *flushed_through < Some(Slot(cutoff)) {
-            self.persistence
-                .write_last_indexed_slot(Slot(cutoff))
-                .await?;
-            *flushed_through = Some(Slot(cutoff));
+        if watermark.is_none_or(|watermark| watermark < confirmed) {
+            self.persistence.write_last_indexed_slot(confirmed).await?;
+            *watermark = Some(confirmed);
         }
         Ok(())
     }
@@ -319,11 +313,6 @@ impl Decoder {
         );
     }
 }
-
-/// Slots stay buffered until the stream reports a slot this far past them.
-/// A transaction delivered up to this many slots late still joins its own
-/// unflushed buffer instead of racing the last-indexed-slot advance.
-const FLUSH_HOLDBACK_SLOTS: u64 = 2;
 
 /// One slot's accumulated output, flushed once the stream moves past the
 /// hold-back window.

--- a/crates/solana-indexer/src/indexer/decoder/tests.rs
+++ b/crates/solana-indexer/src/indexer/decoder/tests.rs
@@ -21,6 +21,7 @@ use {
                 InnerInstruction,
                 InnerInstructions,
                 Message,
+                SlotStatus,
                 SubscribeUpdate,
                 SubscribeUpdateSlot,
                 SubscribeUpdateTransaction,
@@ -313,10 +314,11 @@ fn signature(n: u8) -> Signature {
 }
 
 /// A slot-status message in the proto envelope the ingester reads.
-fn slot_status_update(slot: u64) -> SubscribeUpdate {
+fn slot_status_update(slot: u64, status: SlotStatus) -> SubscribeUpdate {
     SubscribeUpdate {
         update_oneof: Some(UpdateOneof::Slot(SubscribeUpdateSlot {
             slot,
+            status: status as i32,
             ..Default::default()
         })),
         ..Default::default()
@@ -713,21 +715,41 @@ async fn solana_db_ingester_to_decoder_persists_decoded_events() {
         geyser_tx.send(update).await.unwrap();
     }
     // The hold-back keeps both slots buffered: the newest observed slot (43)
-    // is not two past either of them, so nothing may be persisted yet.
+    // is not two past either of them, so no events may be persisted yet. The
+    // watermark still advances to the quiet slots below the hold-back.
     let reader = Postgres::new(pool.clone());
     tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-    assert_eq!(reader.last_indexed_slot().await.unwrap(), None);
+    assert_eq!(reader.last_indexed_slot().await.unwrap(), Some(Slot(41)));
+    let events: i64 = sqlx::query_scalar("SELECT count(*) FROM solana.order_pda")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(events, 0);
 
     // The slot-45 status moves the stream two past 43 and flushes both slots.
-    // Closing the channel ends the ingester (a terminal stream end) and the
-    // decoder drains cleanly behind it, so joining both tasks is the
-    // guarantee that every write below has landed.
-    geyser_tx.send(Ok(slot_status_update(45))).await.unwrap();
+    // The finalized status advances the finalized watermark, and the quiet
+    // slot 50 carries no transactions yet still advances the last indexed
+    // slot to 48 (the hold-back behind it). Closing the channel ends the
+    // ingester (a terminal stream end) and the decoder drains cleanly behind
+    // it, so joining both tasks is the guarantee that every write below has
+    // landed.
+    for update in [
+        slot_status_update(45, SlotStatus::SlotConfirmed),
+        slot_status_update(43, SlotStatus::SlotFinalized),
+        slot_status_update(50, SlotStatus::SlotConfirmed),
+    ] {
+        geyser_tx.send(Ok(update)).await.unwrap();
+    }
     drop(geyser_tx);
     assert!(ingester_task.await.unwrap().is_err());
     assert!(decoder_task.await.unwrap().is_ok());
 
-    assert_eq!(reader.last_indexed_slot().await.unwrap(), Some(Slot(43)));
+    assert_eq!(reader.last_indexed_slot().await.unwrap(), Some(Slot(48)));
+    let finalized: i64 = sqlx::query_scalar("SELECT finalized_slot FROM solana.indexer_state")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(finalized, 43);
 
     // Slot 42 held only the reverted transaction: no dead letter, no rows.
     // The slot-43 transaction with the unknown discriminator is dead-lettered

--- a/crates/solana-indexer/src/indexer/decoder/tests.rs
+++ b/crates/solana-indexer/src/indexer/decoder/tests.rs
@@ -714,25 +714,23 @@ async fn solana_db_ingester_to_decoder_persists_decoded_events() {
     ] {
         geyser_tx.send(update).await.unwrap();
     }
-    // The hold-back keeps both slots buffered: the newest observed slot (43)
-    // is not two past either of them, so no events may be persisted yet. The
-    // watermark still advances to the quiet slots below the hold-back.
+    // No confirmed status arrived yet, so nothing may flush: the buffers
+    // wait and the watermark stays unset.
     let reader = Postgres::new(pool.clone());
     tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-    assert_eq!(reader.last_indexed_slot().await.unwrap(), Some(Slot(41)));
+    assert_eq!(reader.last_indexed_slot().await.unwrap(), None);
     let events: i64 = sqlx::query_scalar("SELECT count(*) FROM solana.order_pda")
         .fetch_one(&pool)
         .await
         .unwrap();
     assert_eq!(events, 0);
 
-    // The slot-45 status moves the stream two past 43 and flushes both slots.
-    // The finalized status advances the finalized watermark, and the quiet
-    // slot 50 carries no transactions yet still advances the last indexed
-    // slot to 48 (the hold-back behind it). Closing the channel ends the
-    // ingester (a terminal stream end) and the decoder drains cleanly behind
-    // it, so joining both tasks is the guarantee that every write below has
-    // landed.
+    // The confirmed 45 status flushes both buffered slots and advances the
+    // watermark to 45. The finalized status advances the finalized
+    // watermark, and the quiet confirmed 50 moves the last indexed slot to
+    // 50 with nothing to flush. Closing the channel ends the ingester (a
+    // terminal stream end) and the decoder drains cleanly behind it, so
+    // joining both tasks is the guarantee that every write below has landed.
     for update in [
         slot_status_update(45, SlotStatus::SlotConfirmed),
         slot_status_update(43, SlotStatus::SlotFinalized),
@@ -744,7 +742,7 @@ async fn solana_db_ingester_to_decoder_persists_decoded_events() {
     assert!(ingester_task.await.unwrap().is_err());
     assert!(decoder_task.await.unwrap().is_ok());
 
-    assert_eq!(reader.last_indexed_slot().await.unwrap(), Some(Slot(48)));
+    assert_eq!(reader.last_indexed_slot().await.unwrap(), Some(Slot(50)));
     let finalized: i64 = sqlx::query_scalar("SELECT finalized_slot FROM solana.indexer_state")
         .fetch_one(&pool)
         .await

--- a/crates/solana-indexer/src/indexer/ingester.rs
+++ b/crates/solana-indexer/src/indexer/ingester.rs
@@ -322,7 +322,7 @@ impl Ingester<GeyserStream> {
 /// matching updates, nothing routes on them today.
 const SETTLEMENT_FILTER: &str = "settlement_txs";
 const SOLFLOW_FILTER: &str = "sol_flow_txs";
-const CHAIN_TIP_FILTER: &str = "chain_tip";
+const SLOT_FILTER: &str = "slot_statuses";
 
 /// Where a fresh subscription starts.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -337,7 +337,7 @@ pub(crate) enum Resume {
 }
 
 /// The wire-level filter shape: the two named transaction filters and the
-/// `chain_tip` slot filter, multiplexed into a single subscription at
+/// slot-status filter, multiplexed into a single subscription at
 /// `confirmed` commitment. `from_slot` is the resume slot passed in by
 /// [`Ingester::serve`] (`last_indexed_slot + 1`, or `None` for the live tip).
 ///
@@ -367,7 +367,7 @@ fn subscribe_request(
     SubscribeRequest {
         transactions: filters,
         slots: [(
-            CHAIN_TIP_FILTER.to_owned(),
+            SLOT_FILTER.to_owned(),
             SubscribeRequestFilterSlots {
                 // Every status transition, so finalized slots arrive next to
                 // confirmed ones. The ingester routes the two it needs and

--- a/crates/solana-indexer/src/indexer/ingester.rs
+++ b/crates/solana-indexer/src/indexer/ingester.rs
@@ -1,6 +1,6 @@
 //! The ingester drains the yellowstone gRPC stream as fast as it delivers,
 //! pushes tagged updates into the channel, and advances the latest-chain-slot
-//! counter on every slot-filter message. It performs no decoding.
+//! counter on every confirmed slot message. It performs no decoding.
 //!
 //! The stream it drains is an `AutoReconnect`-backed
 //! [`GeyserStream`](yellowstone_grpc_client::GeyserStream) from

--- a/crates/solana-indexer/src/indexer/ingester.rs
+++ b/crates/solana-indexer/src/indexer/ingester.rs
@@ -30,6 +30,7 @@ use {
             slot::Slot,
             wire::{
                 CommitmentLevel,
+                SlotStatus,
                 SubscribeRequest,
                 SubscribeRequestFilterSlots,
                 SubscribeRequestFilterTransactions,
@@ -197,21 +198,39 @@ where
         .await
     }
 
-    /// Consume a slot message: advance the in-memory chain-tip counter and
-    /// forward the slot to the decoder so it can flush a finished buffer.
+    /// Consume a slot message, routed by its status. A confirmed slot
+    /// advances the in-memory chain-tip counter and lets the decoder flush a
+    /// finished buffer. A finalized slot advances the finalized watermark.
+    /// Every other status is dropped: flushing on a slot ahead of the
+    /// transaction stream's commitment would declare slots complete whose
+    /// transactions are still in flight.
     async fn handle_slot(
         tx: &Sender<StreamUpdate>,
         latest_chain_slot: &AtomicU64,
         slot: SubscribeUpdateSlot,
     ) -> ControlFlow<()> {
-        latest_chain_slot.fetch_max(slot.slot, Ordering::Relaxed);
-        Self::forward(
-            tx,
-            StreamUpdate::Slot {
-                slot: Slot(slot.slot),
-            },
-        )
-        .await
+        match slot.status() {
+            SlotStatus::SlotConfirmed => {
+                latest_chain_slot.fetch_max(slot.slot, Ordering::Relaxed);
+                Self::forward(
+                    tx,
+                    StreamUpdate::Slot {
+                        slot: Slot(slot.slot),
+                    },
+                )
+                .await
+            }
+            SlotStatus::SlotFinalized => {
+                Self::forward(
+                    tx,
+                    StreamUpdate::Finalized {
+                        slot: Slot(slot.slot),
+                    },
+                )
+                .await
+            }
+            _ => ControlFlow::Continue(()),
+        }
     }
 
     /// Push one update into the decoder channel. A full channel is the intended
@@ -350,8 +369,10 @@ fn subscribe_request(
         slots: [(
             CHAIN_TIP_FILTER.to_owned(),
             SubscribeRequestFilterSlots {
-                // one message per slot at the subscription's commitment level
-                filter_by_commitment: Some(true),
+                // Every status transition, so finalized slots arrive next to
+                // confirmed ones. The ingester routes the two it needs and
+                // drops the rest.
+                filter_by_commitment: Some(false),
                 ..Default::default()
             },
         )]

--- a/crates/solana-indexer/src/indexer/ingester.rs
+++ b/crates/solana-indexer/src/indexer/ingester.rs
@@ -198,12 +198,10 @@ where
         .await
     }
 
-    /// Consume a slot message, routed by its status. A confirmed slot
-    /// advances the in-memory chain-tip counter and lets the decoder flush a
-    /// finished buffer. A finalized slot advances the finalized watermark.
-    /// Every other status is dropped: flushing on a slot ahead of the
-    /// transaction stream's commitment would declare slots complete whose
-    /// transactions are still in flight.
+    /// Route a slot message by status: confirmed advances the tip counter
+    /// and flushes the decoder, finalized advances the finalized watermark,
+    /// and any other status is dropped since its transactions may still be
+    /// in flight.
     async fn handle_slot(
         tx: &Sender<StreamUpdate>,
         latest_chain_slot: &AtomicU64,

--- a/crates/solana-indexer/src/indexer/ingester.rs
+++ b/crates/solana-indexer/src/indexer/ingester.rs
@@ -200,8 +200,8 @@ where
 
     /// Route a slot message by status: confirmed advances the tip counter
     /// and flushes the decoder, finalized advances the finalized watermark,
-    /// and any other status is dropped since its transactions may still be
-    /// in flight.
+    /// and processed is dropped since those slots can still be skipped or
+    /// orphaned.
     async fn handle_slot(
         tx: &Sender<StreamUpdate>,
         latest_chain_slot: &AtomicU64,
@@ -212,7 +212,7 @@ where
                 latest_chain_slot.fetch_max(slot.slot, Ordering::Relaxed);
                 Self::forward(
                     tx,
-                    StreamUpdate::Slot {
+                    StreamUpdate::Confirmed {
                         slot: Slot(slot.slot),
                     },
                 )

--- a/crates/solana-indexer/src/indexer/ingester/tests.rs
+++ b/crates/solana-indexer/src/indexer/ingester/tests.rs
@@ -5,6 +5,7 @@ use {
         channel::StreamUpdate,
         slot::Slot,
         wire::{
+            SlotStatus,
             SubscribeUpdate,
             SubscribeUpdateAccount,
             SubscribeUpdateAccountInfo,
@@ -70,10 +71,11 @@ fn account_update(slot: u64, sig: u8) -> Result<SubscribeUpdate, Status> {
     })
 }
 
-fn slot_update(slot: u64) -> Result<SubscribeUpdate, Status> {
+fn slot_update(slot: u64, status: SlotStatus) -> Result<SubscribeUpdate, Status> {
     Ok(SubscribeUpdate {
         update_oneof: Some(UpdateOneof::Slot(SubscribeUpdateSlot {
             slot,
+            status: status as i32,
             ..Default::default()
         })),
         ..Default::default()
@@ -127,8 +129,11 @@ async fn account_update_is_ignored() {
 }
 
 #[tokio::test]
-async fn slot_update_advances_latest_chain_slot_and_is_forwarded() {
-    let (mut ingester, mut rx, slot) = ingester(stream::iter([slot_update(9_001)]));
+async fn confirmed_slot_advances_latest_chain_slot_and_is_forwarded() {
+    let (mut ingester, mut rx, slot) = ingester(stream::iter([slot_update(
+        9_001,
+        SlotStatus::SlotConfirmed,
+    )]));
 
     assert!(matches!(ingester.run().await, Err(Error::StreamEnded)));
     assert_eq!(slot.load(Ordering::Relaxed), 9_001);
@@ -136,6 +141,37 @@ async fn slot_update_advances_latest_chain_slot_and_is_forwarded() {
         rx.try_recv(),
         Ok(StreamUpdate::Slot { slot: Slot(9_001) })
     ));
+}
+
+/// A finalized slot becomes the finalized-watermark signal. It does not
+/// advance the chain-tip counter: the tip is the confirmed frontier.
+#[tokio::test]
+async fn finalized_slot_is_forwarded_without_moving_the_tip() {
+    let (mut ingester, mut rx, slot) = ingester(stream::iter([slot_update(
+        8_970,
+        SlotStatus::SlotFinalized,
+    )]));
+
+    assert!(matches!(ingester.run().await, Err(Error::StreamEnded)));
+    assert_eq!(slot.load(Ordering::Relaxed), 0);
+    assert!(matches!(
+        rx.try_recv(),
+        Ok(StreamUpdate::Finalized { slot: Slot(8_970) })
+    ));
+}
+
+/// Statuses ahead of the stream's commitment must not drive flushes: a
+/// processed slot is dropped.
+#[tokio::test]
+async fn processed_slot_is_dropped() {
+    let (mut ingester, rx, slot) = ingester(stream::iter([slot_update(
+        9_002,
+        SlotStatus::SlotProcessed,
+    )]));
+
+    assert!(matches!(ingester.run().await, Err(Error::StreamEnded)));
+    assert_eq!(slot.load(Ordering::Relaxed), 0);
+    assert!(rx.is_empty());
 }
 
 #[tokio::test]

--- a/crates/solana-indexer/src/indexer/ingester/tests.rs
+++ b/crates/solana-indexer/src/indexer/ingester/tests.rs
@@ -158,6 +158,7 @@ async fn finalized_slot_is_forwarded_without_moving_the_tip() {
         rx.try_recv(),
         Ok(StreamUpdate::Finalized { slot: Slot(8_970) })
     ));
+    assert!(rx.is_empty());
 }
 
 /// Statuses ahead of the stream's commitment must not drive flushes: a

--- a/crates/solana-indexer/src/indexer/ingester/tests.rs
+++ b/crates/solana-indexer/src/indexer/ingester/tests.rs
@@ -139,7 +139,7 @@ async fn confirmed_slot_advances_latest_chain_slot_and_is_forwarded() {
     assert_eq!(slot.load(Ordering::Relaxed), 9_001);
     assert!(matches!(
         rx.try_recv(),
-        Ok(StreamUpdate::Slot { slot: Slot(9_001) })
+        Ok(StreamUpdate::Confirmed { slot: Slot(9_001) })
     ));
 }
 

--- a/crates/solana-indexer/src/indexer/mod.rs
+++ b/crates/solana-indexer/src/indexer/mod.rs
@@ -1,6 +1,6 @@
 //! Consumer components of the Solana settlement indexer.
 //!
-//! The four components and their roles:
+//! The two components and their roles:
 //!
 //! - [`Ingester`]: subscribes to the Yellowstone gRPC stream and drains it as
 //!   fast as updates arrive, forwarding them to the decoder. It does no

--- a/crates/solana-indexer/src/indexer/mod.rs
+++ b/crates/solana-indexer/src/indexer/mod.rs
@@ -12,12 +12,9 @@
 //!   belonging to the settlement and SolFlow programs, and persists the
 //!   resulting typed events to the store.
 //!
-//! - [`FinalizationWorker`]: rows are first written at the `confirmed`
-//!   commitment level. This worker re-checks them against the chain and
-//!   promotes them to `finalized`, or marks them rolled back if the transaction
-//!   disappeared. It uses a cheap batched RPC call for recent rows and falls
-//!   back to one-call-per-row lookups for rows old enough that the batched
-//!   method no longer reports them.
+//! Rows are written at the `confirmed` commitment level. The stream's
+//! finalized slot statuses advance `solana.indexer_state.finalized_slot`, and
+//! a row counts as final once its slot is at or below that watermark.
 
 pub mod decoder;
 pub mod ingester;

--- a/crates/solana-indexer/src/persistence.rs
+++ b/crates/solana-indexer/src/persistence.rs
@@ -342,6 +342,35 @@ WHERE indexer_state.slot < EXCLUDED.slot
         Ok(tx.commit().await?)
     }
 
+    /// Advance the finalized watermark. Update-only: before the first flush
+    /// there is no state row and nothing indexed to finalize. A backward
+    /// write is a no-op.
+    pub(crate) async fn write_finalized_slot(&self, slot: Slot) -> Result<(), PersistenceError> {
+        sqlx::query(
+            "UPDATE solana.indexer_state SET finalized_slot = GREATEST(finalized_slot, $1)",
+        )
+        .bind(to_db_slot(slot))
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Record the last observed chain tip. Not monotone: a provider
+    /// reconnect can legitimately report an older tip.
+    pub(crate) async fn upsert_chain_tip(&self, slot: Slot) -> Result<(), PersistenceError> {
+        sqlx::query(
+            r#"
+INSERT INTO solana.chain_tip (slot)
+VALUES ($1)
+ON CONFLICT (singleton) DO UPDATE SET slot = EXCLUDED.slot
+            "#,
+        )
+        .bind(to_db_slot(slot))
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
     /// Record a slot as fully indexed. A backward write is a no-op.
     pub(crate) async fn write_last_indexed_slot(&self, slot: Slot) -> Result<(), PersistenceError> {
         Self::upsert_last_indexed_slot(&self.pool, slot).await
@@ -399,6 +428,52 @@ mod tests {
         sqlx::{PgPool, Row},
         std::collections::HashMap,
     };
+
+    /// The finalized watermark only moves forward and needs an existing
+    /// state row: before the first flush the update is a no-op.
+    #[tokio::test]
+    #[ignore = "needs the solana.* schema applied locally, run with --test-threads 1"]
+    async fn solana_db_finalized_watermark_is_monotone_and_update_only() {
+        let pool = pool().await;
+        wipe(&pool).await;
+        let postgres = Postgres::new(pool.clone());
+
+        // No state row yet: the write lands nowhere.
+        postgres.write_finalized_slot(Slot(5)).await.unwrap();
+        let row: Option<i64> =
+            sqlx::query_scalar("SELECT finalized_slot FROM solana.indexer_state")
+                .fetch_optional(&pool)
+                .await
+                .unwrap();
+        assert_eq!(row, None);
+
+        postgres.write_last_indexed_slot(Slot(10)).await.unwrap();
+        postgres.write_finalized_slot(Slot(8)).await.unwrap();
+        postgres.write_finalized_slot(Slot(6)).await.unwrap();
+        let finalized: i64 = sqlx::query_scalar("SELECT finalized_slot FROM solana.indexer_state")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(finalized, 8);
+    }
+
+    /// The chain tip is a plain upsert: a reconnected provider may report an
+    /// older tip and the row follows it.
+    #[tokio::test]
+    #[ignore = "needs the solana.* schema applied locally, run with --test-threads 1"]
+    async fn solana_db_chain_tip_follows_the_last_write() {
+        let pool = pool().await;
+        wipe(&pool).await;
+        let postgres = Postgres::new(pool.clone());
+
+        postgres.upsert_chain_tip(Slot(100)).await.unwrap();
+        postgres.upsert_chain_tip(Slot(90)).await.unwrap();
+        let tip: i64 = sqlx::query_scalar("SELECT slot FROM solana.chain_tip")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(tip, 90);
+    }
 
     /// The `solana.orders` columns a seeded test order writes.
     struct SeedOrder {

--- a/crates/solana-indexer/src/persistence.rs
+++ b/crates/solana-indexer/src/persistence.rs
@@ -355,22 +355,6 @@ WHERE indexer_state.slot < EXCLUDED.slot
         Ok(())
     }
 
-    /// Record the last observed chain tip. Not monotone: a provider
-    /// reconnect can legitimately report an older tip.
-    pub(crate) async fn upsert_chain_tip(&self, slot: Slot) -> Result<(), PersistenceError> {
-        sqlx::query(
-            r#"
-INSERT INTO solana.chain_tip (slot)
-VALUES ($1)
-ON CONFLICT (singleton) DO UPDATE SET slot = EXCLUDED.slot
-            "#,
-        )
-        .bind(to_db_slot(slot))
-        .execute(&self.pool)
-        .await?;
-        Ok(())
-    }
-
     /// Record a slot as fully indexed. A backward write is a no-op.
     pub(crate) async fn write_last_indexed_slot(&self, slot: Slot) -> Result<(), PersistenceError> {
         Self::upsert_last_indexed_slot(&self.pool, slot).await
@@ -455,24 +439,6 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(finalized, 8);
-    }
-
-    /// The chain tip is a plain upsert: a reconnected provider may report an
-    /// older tip and the row follows it.
-    #[tokio::test]
-    #[ignore = "needs the solana.* schema applied locally, run with --test-threads 1"]
-    async fn solana_db_chain_tip_follows_the_last_write() {
-        let pool = pool().await;
-        wipe(&pool).await;
-        let postgres = Postgres::new(pool.clone());
-
-        postgres.upsert_chain_tip(Slot(100)).await.unwrap();
-        postgres.upsert_chain_tip(Slot(90)).await.unwrap();
-        let tip: i64 = sqlx::query_scalar("SELECT slot FROM solana.chain_tip")
-            .fetch_one(&pool)
-            .await
-            .unwrap();
-        assert_eq!(tip, 90);
     }
 
     /// The `solana.orders` columns a seeded test order writes.

--- a/crates/solana-indexer/src/run.rs
+++ b/crates/solana-indexer/src/run.rs
@@ -9,6 +9,7 @@ use {
             ingester::{Error, INGEST_TO_DECODER_CAPACITY, Ingester, Resume},
         },
         persistence::Postgres,
+        types::slot::Slot,
         yellowstone,
     },
     clap::Parser,
@@ -18,7 +19,10 @@ use {
     std::{
         net::SocketAddr,
         path::PathBuf,
-        sync::{Arc, atomic::AtomicU64},
+        sync::{
+            Arc,
+            atomic::{AtomicU64, Ordering},
+        },
         time::Duration,
     },
     tokio::{sync::mpsc, task::JoinHandle},
@@ -27,6 +31,9 @@ use {
 
 /// Wait between attempts to bring the stream back up.
 const STREAM_RETRY: Duration = Duration::from_secs(5);
+
+/// How often the observed chain tip is written to the database.
+const CHAIN_TIP_INTERVAL: Duration = Duration::from_secs(1);
 
 /// The Solana indexer command line arguments.
 #[derive(Debug, Parser)]
@@ -84,6 +91,30 @@ async fn run(config: Config, start_slot: Option<u64>) {
     let mut decoder_task = tokio::spawn(async move { decoder.run().await });
 
     let latest_chain_slot = Arc::new(AtomicU64::default());
+
+    // Samples the ingester's chain-tip counter: the tip stays fresh under
+    // decoder backpressure and the stream's hot path never writes to the
+    // database.
+    let chain_tip_loop = {
+        let persistence = persistence.clone();
+        let latest_chain_slot = latest_chain_slot.clone();
+        async move {
+            let mut written = 0;
+            loop {
+                tokio::time::sleep(CHAIN_TIP_INTERVAL).await;
+                let tip = latest_chain_slot.load(Ordering::Relaxed);
+                if tip <= written {
+                    continue;
+                }
+                match persistence.upsert_chain_tip(Slot(tip)).await {
+                    Ok(()) => written = tip,
+                    Err(err) => tracing::warn!(?err, "chain tip write failed"),
+                }
+            }
+        }
+    };
+    tokio::spawn(chain_tip_loop);
+
     let stream_loop = async {
         let mut resume = start_slot.map_or(Resume::Watermark, Resume::From);
         loop {

--- a/crates/solana-indexer/src/run.rs
+++ b/crates/solana-indexer/src/run.rs
@@ -9,7 +9,6 @@ use {
             ingester::{Error, INGEST_TO_DECODER_CAPACITY, Ingester, Resume},
         },
         persistence::Postgres,
-        types::slot::Slot,
         yellowstone,
     },
     clap::Parser,
@@ -19,10 +18,7 @@ use {
     std::{
         net::SocketAddr,
         path::PathBuf,
-        sync::{
-            Arc,
-            atomic::{AtomicU64, Ordering},
-        },
+        sync::{Arc, atomic::AtomicU64},
         time::Duration,
     },
     tokio::{sync::mpsc, task::JoinHandle},
@@ -31,9 +27,6 @@ use {
 
 /// Wait between attempts to bring the stream back up.
 const STREAM_RETRY: Duration = Duration::from_secs(5);
-
-/// How often the observed chain tip is written to the database.
-const CHAIN_TIP_INTERVAL: Duration = Duration::from_secs(1);
 
 /// The Solana indexer command line arguments.
 #[derive(Debug, Parser)]
@@ -91,30 +84,6 @@ async fn run(config: Config, start_slot: Option<u64>) {
     let mut decoder_task = tokio::spawn(async move { decoder.run().await });
 
     let latest_chain_slot = Arc::new(AtomicU64::default());
-
-    // Samples the ingester's chain-tip counter: the tip stays fresh under
-    // decoder backpressure and the stream's hot path never writes to the
-    // database.
-    let chain_tip_loop = {
-        let persistence = persistence.clone();
-        let latest_chain_slot = latest_chain_slot.clone();
-        async move {
-            let mut written = 0;
-            loop {
-                tokio::time::sleep(CHAIN_TIP_INTERVAL).await;
-                let tip = latest_chain_slot.load(Ordering::Relaxed);
-                if tip <= written {
-                    continue;
-                }
-                match persistence.upsert_chain_tip(Slot(tip)).await {
-                    Ok(()) => written = tip,
-                    Err(err) => tracing::warn!(?err, "chain tip write failed"),
-                }
-            }
-        }
-    };
-    tokio::spawn(chain_tip_loop);
-
     let stream_loop = async {
         let mut resume = start_slot.map_or(Resume::Watermark, Resume::From);
         loop {

--- a/crates/solana-indexer/src/types/channel.rs
+++ b/crates/solana-indexer/src/types/channel.rs
@@ -19,13 +19,19 @@ pub(crate) enum StreamUpdate {
         /// Wire message body.
         inner: Box<SubscribeUpdateTransactionInfo>,
     },
-    /// A slot-status message. Lets the decoder flush a buffered slot without
-    /// waiting for the next tracked transaction, which can be arbitrarily far
-    /// away. Only slots at the transaction stream's commitment may be
-    /// forwarded, an earlier-commitment slot would flush a buffer whose
-    /// transactions are still in flight.
+    /// A confirmed slot-status message. Lets the decoder flush a buffered
+    /// slot without waiting for the next tracked transaction, which can be
+    /// arbitrarily far away. Only slots at the transaction stream's
+    /// commitment may be forwarded, an earlier-commitment slot would flush a
+    /// buffer whose transactions are still in flight.
     Slot {
         /// The slot the status message reports.
+        slot: Slot,
+    },
+    /// A finalized slot-status message. Advances the finalized watermark:
+    /// rows at or below it can no longer roll back.
+    Finalized {
+        /// The slot the status message reports finalized.
         slot: Slot,
     },
 }

--- a/crates/solana-indexer/src/types/channel.rs
+++ b/crates/solana-indexer/src/types/channel.rs
@@ -19,13 +19,11 @@ pub(crate) enum StreamUpdate {
         /// Wire message body.
         inner: Box<SubscribeUpdateTransactionInfo>,
     },
-    /// A confirmed slot-status message. Lets the decoder flush a buffered
-    /// slot without waiting for the next tracked transaction, which can be
-    /// arbitrarily far away. Only slots at the transaction stream's
-    /// commitment may be forwarded, an earlier-commitment slot would flush a
-    /// buffer whose transactions are still in flight.
-    Slot {
-        /// The slot the status message reports.
+    /// A confirmed slot-status message. The stream delivers a slot's
+    /// transactions before its confirmed status, so this message means every
+    /// buffered transaction at or below the slot is complete and can flush.
+    Confirmed {
+        /// The slot the status message reports confirmed.
         slot: Slot,
     },
     /// A finalized slot-status message. Advances the finalized watermark:

--- a/database/sql-solana/V2__drop_chain_tip.sql
+++ b/database/sql-solana/V2__drop_chain_tip.sql
@@ -1,0 +1,4 @@
+-- The chain tip duplicated the last-indexed watermark: quiet slots advance
+-- solana.indexer_state.slot every confirmed slot, so freshness checks read
+-- that row and this table had no reader left.
+DROP TABLE solana.chain_tip;


### PR DESCRIPTION
# Description
The yellowstone subscription only delivered confirmed slot statuses, so the indexer never saw finality: `solana.indexer_state.finalized_slot` and `solana.chain_tip` had no writer, and the last-indexed watermark only advanced when a settlement flushed. Since we eventually need to support resume/backfill and reorgs functionality for older slots, this needs to be changed.

This is the first half of [BE-203](https://linear.app/cowswap/issue/BE-203). The rollback cascade for rows above the finalized watermark follows in its own PR.

`solana.chain_tip` existed to answer "is the indexer keeping up with the chain". The watermark could not answer that alone, since it only moved on settlements, so the planned monitoring needed a second row that tracked the chain to compare against. With this PR, the watermark moves on every confirmed slot, so "keeping up" is simply "the watermark keeps moving", and one row answers the question. That leaves `chain_tip` with no reader and no purpose, so it goes away.

# Changes
- The slot filter subscribes to every status transition. The ingester forwards confirmed statuses (flush signal and tip counter) and finalized ones (watermark), and drops the rest: a status ahead of the transaction stream's commitment must not flush a buffer whose transactions are still in flight.
- `finalized_slot` advances from finalized statuses, monotone and update-only.
- The last-indexed watermark advances on quiet slots up to the flush hold-back, so the resume point tracks the stream instead of the last settlement.
- `solana.chain_tip` is dropped (V2 migration), see above: the quiet-slot watermark replaces it as the freshness signal.

# How to test
New unit tests and ignored postgres tests, including the pipeline test driving finalized and quiet-slot statuses end to end.

# Related issues
[BE-203](https://linear.app/cowswap/issue/BE-203)


