### PR TITLE
(fast1) Thread solution_id through price-estimation

### DIFF
--- a/crates/price-estimation/src/lib.rs
+++ b/crates/price-estimation/src/lib.rs
@@ -203,6 +203,9 @@ pub struct Estimate {
     /// Whether the quoting solver supports fast-path (out-of-competition)
     /// execution for this order.
     pub supports_fast_path: bool,
+    /// Solver-assigned solution id when the underlying quote response
+    /// carried one. Threaded end-to-end into `QuoteResponse.solution_id`.
+    pub solution_id: Option<u64>,
     /// Data associated with this estimation.
     #[debug(ignore)]
     pub execution: QuoteExecution,

--- a/crates/price-estimation/src/native/mod.rs
+++ b/crates/price-estimation/src/native/mod.rs
@@ -157,6 +157,7 @@ mod tests {
                     solver: Address::repeat_byte(1),
                     verified: false,
                     supports_fast_path: false,
+                    solution_id: None,
                     execution: Default::default(),
                 })
             }

--- a/crates/price-estimation/src/sanitized.rs
+++ b/crates/price-estimation/src/sanitized.rs
@@ -126,6 +126,7 @@ impl SanitizedPriceEstimator {
                 solver: Default::default(),
                 verified: true,
                 supports_fast_path: false,
+                solution_id: None,
                 execution: Default::default(),
             };
             tracing::debug!(?query, ?estimation, "generate trivial price estimation");
@@ -141,6 +142,7 @@ impl SanitizedPriceEstimator {
                 solver: Default::default(),
                 verified: true,
                 supports_fast_path: false,
+                solution_id: None,
                 execution: Default::default(),
             };
             tracing::debug!(?query, ?estimation, "generate trivial unwrap estimation");
@@ -156,6 +158,7 @@ impl SanitizedPriceEstimator {
                 solver: Default::default(),
                 verified: true,
                 supports_fast_path: false,
+                solution_id: None,
                 execution: Default::default(),
             };
             tracing::debug!(?query, ?estimation, "generate trivial wrap estimation");
@@ -224,6 +227,7 @@ mod tests {
                     solver: Default::default(),
                     verified: false,
                     supports_fast_path: false,
+                    solution_id: None,
                     execution: Default::default(),
                 }),
             ),
@@ -250,6 +254,7 @@ mod tests {
                     solver: Default::default(),
                     verified: false,
                     supports_fast_path: false,
+                    solution_id: None,
                     execution: Default::default(),
                 }),
             ),
@@ -293,6 +298,7 @@ mod tests {
                     solver: Default::default(),
                     verified: false,
                     supports_fast_path: false,
+                    solution_id: None,
                     execution: Default::default(),
                 }),
             ),
@@ -316,6 +322,7 @@ mod tests {
                     solver: Default::default(),
                     verified: true,
                     supports_fast_path: false,
+                    solution_id: None,
                     execution: Default::default(),
                 }),
             ),
@@ -338,6 +345,7 @@ mod tests {
                     solver: Default::default(),
                     verified: true,
                     supports_fast_path: false,
+                    solution_id: None,
                     execution: Default::default(),
                 }),
             ),
@@ -361,6 +369,7 @@ mod tests {
                     solver: Default::default(),
                     verified: true,
                     supports_fast_path: false,
+                    solution_id: None,
                     execution: Default::default(),
                 }),
             ),
@@ -384,6 +393,7 @@ mod tests {
                     solver: Default::default(),
                     verified: true,
                     supports_fast_path: false,
+                    solution_id: None,
                     execution: Default::default(),
                 }),
             ),
@@ -457,6 +467,7 @@ mod tests {
                         solver: Default::default(),
                         verified: false,
                         supports_fast_path: false,
+                        solution_id: None,
                         execution: Default::default(),
                     })
                 }
@@ -474,6 +485,7 @@ mod tests {
                         solver: Default::default(),
                         verified: false,
                         supports_fast_path: false,
+                        solution_id: None,
                         execution: Default::default(),
                     })
                 }
@@ -491,6 +503,7 @@ mod tests {
                         solver: Default::default(),
                         verified: false,
                         supports_fast_path: false,
+                        solution_id: None,
                         execution: Default::default(),
                     })
                 }
@@ -508,6 +521,7 @@ mod tests {
                         solver: Default::default(),
                         verified: false,
                         supports_fast_path: false,
+                        solution_id: None,
                         execution: Default::default(),
                     })
                 }
@@ -555,6 +569,7 @@ mod tests {
                     solver: Default::default(),
                     verified: true,
                     supports_fast_path: false,
+                    solution_id: None,
                     execution: Default::default(),
                 }),
             ),
@@ -576,6 +591,7 @@ mod tests {
                     solver: Default::default(),
                     verified: true,
                     supports_fast_path: false,
+                    solution_id: None,
                     execution: Default::default(),
                 }),
             ),
@@ -602,6 +618,7 @@ mod tests {
                         solver: Default::default(),
                         verified: true,
                         supports_fast_path: false,
+                        solution_id: None,
                         execution: Default::default(),
                     })
                 }
@@ -619,6 +636,7 @@ mod tests {
                         solver: Default::default(),
                         verified: true,
                         supports_fast_path: false,
+                        solution_id: None,
                         execution: Default::default(),
                     })
                 }

--- a/crates/price-estimation/src/trade_finding/external.rs
+++ b/crates/price-estimation/src/trade_finding/external.rs
@@ -184,6 +184,7 @@ impl From<dto::LegacyQuote> for LegacyTrade {
             solver: quote.solver,
             tx_origin: quote.tx_origin,
             supports_fast_path: quote.supports_fast_path,
+            solution_id: quote.solution_id,
         }
     }
 }
@@ -215,6 +216,7 @@ impl From<dto::Quote> for Trade {
             tx_origin: quote.tx_origin,
             jit_orders: quote.jit_orders,
             supports_fast_path: quote.supports_fast_path,
+            solution_id: quote.solution_id,
         }
     }
 }
@@ -363,6 +365,7 @@ impl TradeFinding for ExternalTradeFinder {
             gas_estimate,
             solver: trade.solver(),
             supports_fast_path: trade.supports_fast_path(),
+            solution_id: trade.solution_id(),
             execution: QuoteExecution {
                 interactions: map_interactions_data(trade.interactions()),
                 pre_interactions: map_interactions_data(trade.pre_interactions()),
@@ -402,7 +405,12 @@ pub mod dto {
         pub amount: U256,
         pub kind: OrderKind,
         pub deadline: chrono::DateTime<chrono::Utc>,
-        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+        // Renamed to match the driver's `enableFastPath` field name.
+        #[serde(
+            rename = "enableFastPath",
+            default,
+            skip_serializing_if = "std::ops::Not::not"
+        )]
         pub fast_path: bool,
         #[serde(skip_serializing_if = "Option::is_none")]
         pub auction_id: Option<i64>,
@@ -429,6 +437,11 @@ pub mod dto {
         pub tx_origin: Option<Address>,
         #[serde(default)]
         pub supports_fast_path: bool,
+        /// Solver-assigned solution id for this quote. Threaded through to
+        /// `QuoteResponse.solution_id` and, ultimately, into
+        /// `proposed_solutions.id` when a fast-path quote is persisted.
+        #[serde(default)]
+        pub solution_id: Option<u64>,
     }
 
     #[serde_as]
@@ -448,6 +461,11 @@ pub mod dto {
         pub jit_orders: Vec<JitOrder>,
         #[serde(default)]
         pub supports_fast_path: bool,
+        /// Solver-assigned solution id for this quote. Threaded through to
+        /// `QuoteResponse.solution_id` and, ultimately, into
+        /// `proposed_solutions.id` when a fast-path quote is persisted.
+        #[serde(default)]
+        pub solution_id: Option<u64>,
     }
 
     #[serde_as]

--- a/crates/price-estimation/src/trade_finding/mod.rs
+++ b/crates/price-estimation/src/trade_finding/mod.rs
@@ -37,6 +37,9 @@ pub struct Quote {
     pub solver: Address,
     /// Whether the quoting solver supports fast-path execution.
     pub supports_fast_path: bool,
+    /// Solver-assigned solution id, when the underlying quote response
+    /// carries one.
+    pub solution_id: Option<u64>,
     #[debug(ignore)]
     pub execution: QuoteExecution,
 }
@@ -87,6 +90,13 @@ impl TradeKind {
         match self {
             TradeKind::Legacy(trade) => trade.tx_origin,
             TradeKind::Regular(trade) => trade.tx_origin,
+        }
+    }
+
+    pub fn solution_id(&self) -> Option<u64> {
+        match self {
+            TradeKind::Legacy(trade) => trade.solution_id,
+            TradeKind::Regular(trade) => trade.solution_id,
         }
     }
 
@@ -148,6 +158,9 @@ pub struct LegacyTrade {
     pub tx_origin: Option<Address>,
     /// Whether the quoting solver supports fast-path execution.
     pub supports_fast_path: bool,
+    /// Solver-assigned solution id for this trade, if the response carried
+    /// one.
+    pub solution_id: Option<u64>,
 }
 
 /// A trade with JIT orders.
@@ -169,6 +182,9 @@ pub struct Trade {
     pub jit_orders: Vec<dto::JitOrder>,
     /// Whether the quoting solver supports fast-path execution.
     pub supports_fast_path: bool,
+    /// Solver-assigned solution id for this trade, if the response carried
+    /// one.
+    pub solution_id: Option<u64>,
 }
 
 impl Trade {

--- a/crates/price-estimation/src/trade_finding/trade_estimator.rs
+++ b/crates/price-estimation/src/trade_finding/trade_estimator.rs
@@ -90,6 +90,7 @@ impl Inner {
             solver: quote.solver,
             verified: false,
             supports_fast_path: quote.supports_fast_path,
+            solution_id: quote.solution_id,
             execution: quote.execution,
         })
     }

--- a/crates/price-estimation/src/trade_verifier.rs
+++ b/crates/price-estimation/src/trade_verifier.rs
@@ -130,6 +130,7 @@ impl TradeVerifier {
                     solver: trade.solver(),
                     verified: false,
                     supports_fast_path: trade.supports_fast_path(),
+                    solution_id: trade.solution_id(),
                     execution: QuoteExecution {
                         interactions: map_interactions_data(trade.interactions()),
                         pre_interactions: map_interactions_data(trade.pre_interactions()),
@@ -837,6 +838,7 @@ fn ensure_quote_accuracy(
         solver: trade.solver(),
         verified: true,
         supports_fast_path: trade.supports_fast_path(),
+        solution_id: trade.solution_id(),
         execution: QuoteExecution {
             interactions: map_interactions_data(trade.interactions()),
             pre_interactions: map_interactions_data(trade.pre_interactions()),

--- a/crates/shared/src/order_quoting.rs
+++ b/crates/shared/src/order_quoting.rs
@@ -261,6 +261,10 @@ pub struct QuoteResponse {
     pub verified: bool,
     pub supports_fast_path: bool,
     pub metadata: QuoteMetadata,
+    /// Solver-assigned solution id, when the underlying solver quote
+    /// response carries one. Populated into `proposed_solutions.id` when
+    /// the quote is persisted as fast-path competition data.
+    pub solution_id: Option<u64>,
 }
 
 impl QuoteCompetition {
@@ -929,6 +933,7 @@ fn assemble_quote_data(
                 jit_orders: estimate.execution.jit_orders,
             }
             .into(),
+            solution_id: estimate.solution_id,
         }
     };
 
@@ -1131,6 +1136,7 @@ mod tests {
                             solver: Address::repeat_byte(1),
                             verified: false,
                             supports_fast_path: false,
+                            solution_id: None,
                             execution: Default::default(),
                         },
                         [],
@@ -1176,6 +1182,7 @@ mod tests {
                     verified: false,
                     supports_fast_path: false,
                     metadata: Default::default(),
+                    solution_id: None,
                 },
                 [],
                 QuoteCompetitionMetadata {
@@ -1291,6 +1298,7 @@ mod tests {
                             solver: Address::repeat_byte(1),
                             verified: false,
                             supports_fast_path: false,
+                            solution_id: None,
                             execution: Default::default(),
                         },
                         [],
@@ -1336,6 +1344,7 @@ mod tests {
                     verified: false,
                     supports_fast_path: false,
                     metadata: Default::default(),
+                    solution_id: None,
                 },
                 [],
                 QuoteCompetitionMetadata {
@@ -1446,6 +1455,7 @@ mod tests {
                             solver: Address::repeat_byte(1),
                             verified: false,
                             supports_fast_path: false,
+                            solution_id: None,
                             execution: Default::default(),
                         },
                         [],
@@ -1491,6 +1501,7 @@ mod tests {
                     verified: false,
                     supports_fast_path: false,
                     metadata: Default::default(),
+                    solution_id: None,
                 },
                 [],
                 QuoteCompetitionMetadata {
@@ -1584,6 +1595,7 @@ mod tests {
                         solver: Address::repeat_byte(1),
                         verified: false,
                         supports_fast_path: false,
+                        solution_id: None,
                         execution: Default::default(),
                     },
                     [],
@@ -1662,6 +1674,7 @@ mod tests {
                         solver: Address::repeat_byte(1),
                         verified: false,
                         supports_fast_path: false,
+                        solution_id: None,
                         execution: Default::default(),
                     },
                     [],
@@ -2150,6 +2163,7 @@ mod tests {
             solver: Address::repeat_byte(7),
             verified: true,
             supports_fast_path: false,
+            solution_id: None,
             execution: Default::default(),
         };
 
@@ -2208,6 +2222,7 @@ mod tests {
             solver: Address::repeat_byte(7),
             verified: false,
             supports_fast_path: false,
+            solution_id: None,
             execution: Default::default(),
         };
 
@@ -2313,6 +2328,7 @@ mod tests {
                     solver: Address::repeat_byte(1),
                     verified: false,
                     supports_fast_path: false,
+                    solution_id: None,
                     execution: Default::default(),
                 }),
                 Ok(price_estimation::Estimate {
@@ -2321,6 +2337,7 @@ mod tests {
                     solver: Address::repeat_byte(2),
                     verified: false,
                     supports_fast_path: false,
+                    solution_id: None,
                     execution: Default::default(),
                 }),
             ])
@@ -2369,6 +2386,7 @@ mod tests {
                     solver: Address::repeat_byte(1),
                     verified: false,
                     supports_fast_path: false,
+                    solution_id: None,
                     execution: Default::default(),
                 }),
                 // zero gas - must be dropped silently
@@ -2378,6 +2396,7 @@ mod tests {
                     solver: Address::repeat_byte(2),
                     verified: false,
                     supports_fast_path: false,
+                    solution_id: None,
                     execution: Default::default(),
                 }),
                 // zero out_amount - must be dropped silently
@@ -2387,6 +2406,7 @@ mod tests {
                     solver: Address::repeat_byte(3),
                     verified: false,
                     supports_fast_path: false,
+                    solution_id: None,
                     execution: Default::default(),
                 }),
             ])
@@ -2474,6 +2494,7 @@ mod tests {
                 solver: Address::repeat_byte(1),
                 verified: false,
                 supports_fast_path: false,
+                solution_id: None,
                 execution: Default::default(),
             })])
             .boxed()
@@ -2523,6 +2544,7 @@ mod tests {
                 solver: Address::repeat_byte(1),
                 verified: false,
                 supports_fast_path: false,
+                solution_id: None,
                 execution: Default::default(),
             }
         }


### PR DESCRIPTION
# Description
Fast path quotes are supposed to be treated as firm commitments. In order to store the solutions properly in the DB and have the autopilot reference a specific solution in the `/settle` call we need to receive a solution ID from the driver and thread it through the program.

# Changes
add `solution_id` to quote response DTO and thread the data through the program
also uses `serde(rename)` for the currently misaligned flag indicating whether fast path orders are supported with the quote - this will be cleaned up later

## How to test
e2e tests coming up at the end of the PR stack