### PR TITLE
Fix the cargo-audit CI job (prebuilt install)

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -63,10 +63,10 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - run: rustup toolchain install stable --profile minimal
-      - uses: rustsec/audit-check@69366f33c96575abad1ee0dba8212993eecbe998 # v2.0.0
+      - uses: taiki-e/install-action@4684b8405694ae9dd42c9f39ba901a70ae83f4a3 # v2.82.9
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          tool: cargo-audit
+      - run: cargo audit
 
   nitpicker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Description
`cargo-audit` fails on every open PR. The `rustsec/audit-check` action runs `cargo install cargo-audit` without `--locked`, which resolves `tinyvec 1.13.0`, and that release fails to compile (`cannot find macro vec`). The tool never builds, so the failure is unrelated to any PR's own code.

Install cargo-audit as a prebuilt binary through `taiki-e/install-action` (already used here for nextest), skipping the source build entirely. `cargo audit` then runs against our `Cargo.lock` and respects the existing `.cargo/audit.toml` ignores. Verified locally: exits 0, only the already-allowed warnings.

# Changes
- The `cargo-audit` job installs the prebuilt binary and runs `cargo audit`, replacing the `rustsec/audit-check` action

# How to test
CI. The cargo-audit job passes.
