### PR TITLE
Migrate solana settlement crates to v0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3739,9 +3739,9 @@ dependencies = [
 
 [[package]]
 name = "cow-settlement-client"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93949beec804859f528c0aa3d5944793f76ca007d2930eff88e9705a2fb03c3c"
+checksum = "f89153d6546523201a157c5aa32637e4edad914a0515852b81475c2ee3ad3f3f"
 dependencies = [
  "cow-settlement-interface",
  "solana-program-error",
@@ -3749,9 +3749,9 @@ dependencies = [
 
 [[package]]
 name = "cow-settlement-interface"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f74c11504033ef2f52571c0a3854c45308ee9017a31ff7b8c482448f15ac225f"
+checksum = "c496d37e96c63caf31367d532eaa88acf0b4dcfc29b644c81c061e3c5f09da91"
 dependencies = [
  "arrayref",
  "derive_more 1.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,8 +56,8 @@ console-subscriber = "0.5.0"
 const_format = "0.2.32"
 const-hex = "1.17.0"
 contracts = { path = "contracts/generated/contracts-facade" }
-cow-settlement-client = "0.2"
-cow-settlement-interface = "0.2"
+cow-settlement-client = "0.3"
+cow-settlement-interface = "0.3"
 cow-solana-rpc = { path = "crates/cow-solana-rpc" }
 dashmap = "6.1.0"
 database = { path = "crates/database" }

--- a/crates/solana-driver/src/domain/settlement.rs
+++ b/crates/solana-driver/src/domain/settlement.rs
@@ -347,10 +347,12 @@ impl From<&Order> for OrderIntent {
             sell_amount: order.sell_amount,
             buy_amount: order.buy_amount,
             valid_to: order.valid_to,
-            // Off-chain, Ed25519-signed orders only. On-chain-created orders
-            // would carry this from the wire.
+            // Every auction order exists as a PDA the owner created with
+            // `CreateOrder`, and the program only accepts that instruction
+            // for intents carrying this flag. An off-chain Ed25519 intent
+            // flow would carry the flag on the wire instead.
             flags: Flags {
-                created_on_chain: false,
+                created_on_chain: true,
                 kind: match order.side {
                     Side::Sell => OrderKind::Sell,
                     Side::Buy => OrderKind::Buy,

--- a/crates/solana-driver/src/domain/settlement.rs
+++ b/crates/solana-driver/src/domain/settlement.rs
@@ -19,7 +19,7 @@ use {
         Pull,
     },
     cow_settlement_interface::{
-        data::intent::{OrderIntent, OrderKind},
+        data::intent::{Flags, OrderIntent, OrderKind},
         pda::{buffer::find_buffer_pda, order::find_order_pda},
     },
     solana_compute_budget_interface::ComputeBudgetInstruction,
@@ -174,7 +174,6 @@ impl ResolvedSettlement {
                     },
                     FinalizedIntent {
                         intent: &data.intent,
-                        mint: data.buy_mint,
                         amount: data.buy_amount,
                     },
                 )
@@ -224,6 +223,7 @@ impl ResolvedSettlement {
         instructions.push(
             BeginSettle {
                 program_id: self.settlement.program_id,
+                solver: payer,
                 finalize_ix_index,
                 auction_id: self.settlement.auction_id.get(),
                 orders: &initialized_intents,
@@ -341,15 +341,22 @@ impl From<&Order> for OrderIntent {
         OrderIntent {
             owner: order.owner,
             buy_token_account: order.buy_token_account,
+            buy_mint: order.buy_token,
             sell_token_account: order.sell_token_account,
+            sell_mint: order.sell_token,
             sell_amount: order.sell_amount,
             buy_amount: order.buy_amount,
             valid_to: order.valid_to,
-            kind: match order.side {
-                Side::Sell => OrderKind::Sell,
-                Side::Buy => OrderKind::Buy,
+            // Off-chain, Ed25519-signed orders only. On-chain-created orders
+            // would carry this from the wire.
+            flags: Flags {
+                created_on_chain: false,
+                kind: match order.side {
+                    Side::Sell => OrderKind::Sell,
+                    Side::Buy => OrderKind::Buy,
+                },
+                partially_fillable: order.partially_fillable,
             },
-            partially_fillable: order.partially_fillable,
             app_data: order.app_data,
         }
     }
@@ -477,7 +484,6 @@ fn executed_amounts(order: &Order, solution: &Solution) -> Result<ExecutedAmount
 struct SettlementOrder {
     intent: OrderIntent,
     pulls: Vec<Pull>,
-    buy_mint: Pubkey,
     buy_amount: u64,
 }
 
@@ -495,7 +501,6 @@ impl SettlementOrder {
                 destination: associated_token_address(payer, &order.sell_token),
                 amount: amounts.sell,
             }],
-            buy_mint: order.buy_token,
             buy_amount: amounts.buy,
         }
     }

--- a/crates/solana-driver/tests/api.rs
+++ b/crates/solana-driver/tests/api.rs
@@ -30,7 +30,7 @@ fn test_order_intent() -> OrderIntent {
         // Far future so the settle path's order-expiry check passes.
         valid_to: u32::MAX,
         flags: Flags {
-            created_on_chain: false,
+            created_on_chain: true,
             kind: OrderKind::Sell,
             partially_fillable: false,
         },

--- a/crates/solana-driver/tests/api.rs
+++ b/crates/solana-driver/tests/api.rs
@@ -2,7 +2,7 @@
 
 use {
     cow_settlement_interface::{
-        data::intent::{OrderIntent, OrderKind},
+        data::intent::{Flags, OrderIntent, OrderKind},
         pda::order::find_order_pda,
     },
     cow_solana_rpc::{Mocks, RpcRequest, SolanaRPC},
@@ -22,13 +22,18 @@ fn test_order_intent() -> OrderIntent {
     OrderIntent {
         owner: pubkey(0x22),
         buy_token_account: pubkey(0x66),
+        buy_mint: pubkey(0x77),
         sell_token_account: pubkey(0x55),
+        sell_mint: pubkey(0x88),
         sell_amount: 1_000,
         buy_amount: 2_000,
         // Far future so the settle path's order-expiry check passes.
         valid_to: u32::MAX,
-        kind: OrderKind::Sell,
-        partially_fillable: false,
+        flags: Flags {
+            created_on_chain: false,
+            kind: OrderKind::Sell,
+            partially_fillable: false,
+        },
         app_data: [0; 32],
     }
 }

--- a/crates/solana-driver/tests/settle_devnet.rs
+++ b/crates/solana-driver/tests/settle_devnet.rs
@@ -211,7 +211,7 @@ async fn create_order_on_chain(
         buy_amount: SELL_AMOUNT, // 1:1 swap.
         valid_to,
         flags: Flags {
-            created_on_chain: false,
+            created_on_chain: true,
             kind: OrderKind::Sell,
             partially_fillable: false,
         },

--- a/crates/solana-driver/tests/settle_devnet.rs
+++ b/crates/solana-driver/tests/settle_devnet.rs
@@ -21,7 +21,7 @@ use {
         cow_settlement_interface::{
             ID as PROGRAM_ID,
             Pubkey,
-            data::intent::{OrderIntent, OrderKind},
+            data::intent::{Flags, OrderIntent, OrderKind},
             pda::{buffer::find_buffer_pda, order::find_order_pda, state::find_state_pda},
         },
         instructions::CreateOrder,
@@ -204,12 +204,17 @@ async fn create_order_on_chain(
     let intent = OrderIntent {
         owner: payer_pk,
         sell_token_account: sell_ata,
+        sell_mint,
         buy_token_account: buy_ata,
+        buy_mint,
         sell_amount: SELL_AMOUNT,
         buy_amount: SELL_AMOUNT, // 1:1 swap.
         valid_to,
-        kind: OrderKind::Sell,
-        partially_fillable: false,
+        flags: Flags {
+            created_on_chain: false,
+            kind: OrderKind::Sell,
+            partially_fillable: false,
+        },
         app_data: [0; 32],
     };
 

--- a/crates/solana-driver/tests/settle_mainnet.rs
+++ b/crates/solana-driver/tests/settle_mainnet.rs
@@ -342,7 +342,7 @@ async fn create_order_on_chain(rpc: &RpcClient, user: &dyn Signer, pair: &Pair) 
         buy_amount: 0,
         valid_to,
         flags: Flags {
-            created_on_chain: false,
+            created_on_chain: true,
             kind: OrderKind::Sell,
             partially_fillable: false,
         },

--- a/crates/solana-driver/tests/settle_mainnet.rs
+++ b/crates/solana-driver/tests/settle_mainnet.rs
@@ -41,7 +41,7 @@ use {
         cow_settlement_interface::{
             ID as PROGRAM_ID,
             Pubkey,
-            data::intent::{OrderIntent, OrderKind},
+            data::intent::{Flags, OrderIntent, OrderKind},
             pda::{buffer::find_buffer_pda, order::find_order_pda, state::find_state_pda},
         },
         instructions::CreateOrder,
@@ -335,12 +335,17 @@ async fn create_order_on_chain(rpc: &RpcClient, user: &dyn Signer, pair: &Pair) 
     let intent = OrderIntent {
         owner: user_pubkey,
         sell_token_account,
+        sell_mint: pair.sell.mint,
         buy_token_account,
+        buy_mint: pair.buy.mint,
         sell_amount: SELL_AMOUNT,
         buy_amount: 0,
         valid_to,
-        kind: OrderKind::Sell,
-        partially_fillable: false,
+        flags: Flags {
+            created_on_chain: false,
+            kind: OrderKind::Sell,
+            partially_fillable: false,
+        },
         app_data: [0; 32],
     };
 

--- a/crates/solana-indexer/Cargo.toml
+++ b/crates/solana-indexer/Cargo.toml
@@ -21,7 +21,7 @@ bigdecimal = { workspace = true }
 bytes = { workspace = true }
 clap = { workspace = true }
 configs = { workspace = true }
-cow-settlement-interface = "0.2.0"
+cow-settlement-interface = "0.3.0"
 cow-solana-rpc = { workspace = true }
 database = { workspace = true }
 derive_more = { workspace = true }
@@ -45,7 +45,7 @@ yellowstone-grpc-client = { workspace = true }
 yellowstone-grpc-proto = { workspace = true }
 
 [dev-dependencies]
-cow-settlement-client = "0.2.0"
+cow-settlement-client = "0.3.0"
 cow-solana-rpc = { workspace = true, features = ["test-util"] }
 serde_json = { workspace = true }
 

--- a/crates/solana-indexer/Cargo.toml
+++ b/crates/solana-indexer/Cargo.toml
@@ -21,7 +21,7 @@ bigdecimal = { workspace = true }
 bytes = { workspace = true }
 clap = { workspace = true }
 configs = { workspace = true }
-cow-settlement-interface = "0.3.0"
+cow-settlement-interface = { workspace = true }
 cow-solana-rpc = { workspace = true }
 database = { workspace = true }
 derive_more = { workspace = true }
@@ -45,7 +45,7 @@ yellowstone-grpc-client = { workspace = true }
 yellowstone-grpc-proto = { workspace = true }
 
 [dev-dependencies]
-cow-settlement-client = "0.3.0"
+cow-settlement-client = { workspace = true }
 cow-solana-rpc = { workspace = true, features = ["test-util"] }
 serde_json = { workspace = true }
 

--- a/crates/solana-indexer/src/indexer/decoder.rs
+++ b/crates/solana-indexer/src/indexer/decoder.rs
@@ -371,12 +371,15 @@ fn decode_settlement(
             SettlementInstruction::BeginSettle | SettlementInstruction::FinalizeSettle => {
                 Ok(Vec::new())
             }
-            // No domain event: `Initialize` bootstraps the program state and
-            // `ReclaimBuffer` recovers rent without touching order state.
+            // No domain event: `Initialize` bootstraps program state,
+            // `ReclaimBuffer` recovers rent, and `TransferAuthority`/`AddSolver`
+            // manage program governance, none touching order state.
             // TODO: map `ReclaimOrder` to `OrderClosed`.
             SettlementInstruction::Initialize
             | SettlementInstruction::ReclaimOrder
-            | SettlementInstruction::ReclaimBuffer => Ok(Vec::new()),
+            | SettlementInstruction::ReclaimBuffer
+            | SettlementInstruction::TransferAuthority
+            | SettlementInstruction::AddSolver => Ok(Vec::new()),
         };
         match decoded {
             Ok(decoded_events) => events.extend(decoded_events),
@@ -428,11 +431,11 @@ fn decode_order_created(
         sell_amount: intent.sell_amount,
         buy_amount: intent.buy_amount,
         valid_to: intent.valid_to,
-        kind: match intent.kind {
+        kind: match intent.flags.kind {
             InterfaceOrderKind::Sell => OrderKind::Sell,
             InterfaceOrderKind::Buy => OrderKind::Buy,
         },
-        partially_fillable: intent.partially_fillable,
+        partially_fillable: intent.flags.partially_fillable,
         app_data: intent.app_data,
     })))
 }

--- a/crates/solana-indexer/src/indexer/decoder.rs
+++ b/crates/solana-indexer/src/indexer/decoder.rs
@@ -472,12 +472,6 @@ fn decode_settlements_finalized(
     ctx: &TxContext,
     decode_failed: &mut bool,
 ) -> Vec<SettlementEvent> {
-    // The solver is the transaction fee payer: the first account key, which
-    // Solana guarantees is the signer that submitted the transaction.
-    let Some(&solver) = ctx.account_keys.first() else {
-        return Vec::new();
-    };
-
     let mut events = Vec::new();
     'process_instructions: for begin in instructions {
         let Ok((SettlementInstruction::BeginSettle, _)) = recover_discriminator(&begin.data) else {
@@ -593,7 +587,9 @@ fn decode_settlements_finalized(
 
         events.push(SettlementEvent::SettlementFinalized(FinalizedSettlement {
             auction_id: begin_input.auction_id,
-            solver,
+            // The signer `BeginSettle` names, which the program requires to
+            // be registered. The transaction fee payer may be someone else.
+            solver: *begin_input.solver_account,
             tx_signature: ctx.signature,
             slot: ctx.slot,
             instruction_index: begin.instruction_index,

--- a/crates/solana-indexer/src/indexer/decoder/tests.rs
+++ b/crates/solana-indexer/src/indexer/decoder/tests.rs
@@ -356,7 +356,7 @@ fn create_order_tx() -> (SubscribeUpdateTransactionInfo, CreatedOrder) {
         buy_amount: 2_000,
         valid_to: 42,
         flags: Flags {
-            created_on_chain: false,
+            created_on_chain: true,
             kind: IntentOrderKind::Sell,
             partially_fillable: false,
         },
@@ -580,7 +580,7 @@ fn begin_and_finalize_settle_decode_to_settlement_finalized() {
         buy_amount: 1_234,
         valid_to: 42,
         flags: Flags {
-            created_on_chain: false,
+            created_on_chain: true,
             kind: IntentOrderKind::Sell,
             partially_fillable: false,
         },

--- a/crates/solana-indexer/src/indexer/decoder/tests.rs
+++ b/crates/solana-indexer/src/indexer/decoder/tests.rs
@@ -36,7 +36,7 @@ use {
     cow_settlement_interface::{
         Pubkey as InterfacePubkey,
         SettlementInstruction,
-        data::intent::{OrderIntent, OrderKind as IntentOrderKind},
+        data::intent::{Flags, OrderIntent, OrderKind as IntentOrderKind},
         pda::order::find_order_pda,
     },
     cow_solana_rpc::{Mocks, RpcRequest, SolanaRPC},
@@ -350,11 +350,16 @@ fn create_order_tx() -> (SubscribeUpdateTransactionInfo, CreatedOrder) {
         owner: InterfacePubkey::new_from_array([0x11; 32]),
         buy_token_account: InterfacePubkey::new_from_array([0x22; 32]),
         sell_token_account: InterfacePubkey::new_from_array([0x33; 32]),
+        buy_mint: InterfacePubkey::new_from_array([0x55; 32]),
+        sell_mint: InterfacePubkey::new_from_array([0x66; 32]),
         sell_amount: 1_000,
         buy_amount: 2_000,
         valid_to: 42,
-        kind: IntentOrderKind::Sell,
-        partially_fillable: false,
+        flags: Flags {
+            created_on_chain: false,
+            kind: IntentOrderKind::Sell,
+            partially_fillable: false,
+        },
         app_data: [0x44; 32],
     };
     let instruction = cow_settlement_client::instructions::CreateOrder {
@@ -569,17 +574,23 @@ fn begin_and_finalize_settle_decode_to_settlement_finalized() {
         owner: InterfacePubkey::new_from_array([0x11; 32]),
         buy_token_account: InterfacePubkey::new_from_array([0x22; 32]),
         sell_token_account: InterfacePubkey::new_from_array([0x33; 32]),
+        buy_mint: InterfacePubkey::new_from_array([0x55; 32]),
+        sell_mint: InterfacePubkey::new_from_array([0x66; 32]),
         sell_amount: 1_000,
         buy_amount: 1_234,
         valid_to: 42,
-        kind: IntentOrderKind::Sell,
-        partially_fillable: false,
+        flags: Flags {
+            created_on_chain: false,
+            kind: IntentOrderKind::Sell,
+            partially_fillable: false,
+        },
         app_data: [0x44; 32],
     };
     let order_pda = find_order_pda(&settlement, &intent.uid()).0;
 
     let begin = cow_settlement_client::instructions::BeginSettle {
         program_id: settlement,
+        solver,
         finalize_ix_index: 1,
         auction_id: 4242,
         orders: &[cow_settlement_client::instructions::InitializedIntent {
@@ -602,7 +613,6 @@ fn begin_and_finalize_settle_decode_to_settlement_finalized() {
         begin_ix_index: 0,
         orders: &[cow_settlement_client::instructions::FinalizedIntent {
             intent: &intent,
-            mint: pubkey(30),
             amount: 1_234,
         }],
     }

--- a/crates/solana-indexer/src/indexer/decoder/tests.rs
+++ b/crates/solana-indexer/src/indexer/decoder/tests.rs
@@ -565,11 +565,12 @@ fn unpaired_begin_settle_sets_failure_flag() {
 /// - the buy-side amount comes from the `FinalizeSettle` entry paired to its
 ///   order by position (order `i` is paid by entry `i`),
 /// - the trade names the canonical order PDA the builder derives,
-/// - the solver is the fee payer.
+/// - the solver is the signer `BeginSettle` names, not the fee payer.
 #[test]
 fn begin_and_finalize_settle_decode_to_settlement_finalized() {
     let (settlement, solflow) = (pubkey(1), pubkey(2));
     let solver = pubkey(10);
+    let fee_payer = pubkey(9);
     let intent = OrderIntent {
         owner: InterfacePubkey::new_from_array([0x11; 32]),
         buy_token_account: InterfacePubkey::new_from_array([0x22; 32]),
@@ -617,7 +618,7 @@ fn begin_and_finalize_settle_decode_to_settlement_finalized() {
         }],
     }
     .into();
-    let tx = tx_from_instructions(solver, &[begin, finalize]);
+    let tx = tx_from_instructions(fee_payer, &[begin, finalize]);
 
     let ctx = TxContext {
         slot: Slot(5),


### PR DESCRIPTION
# Description
The v0.3 settlement program's order intent has a new layout, so the driver and indexer have to speak v0.3 to decode and settle those orders.

# Changes
- Bumped `cow-settlement-interface` and `cow-settlement-client` from 0.2 to 0.3
- The driver order intent now carries `buy_mint` and `sell_mint` and folds `kind`, `partial-fill`, and `on-chain-creation` into a `flags` byte
- `BeginSettle` now takes the `solver`, and `FinalizeSettle` drops the redundant per-order `mint`
- The indexer decoder reads the intent flags and ignores the two new instructions, `TransferAuthority` and `AddSolver`
- Intents are flagged `created_on_chain`: the program rejects a `CreateOrder` whose intent lacks it, and every auction order is such a PDA. The driver hardcodes the flag when rebuilding intents, which holds until an off-chain Ed25519 intent flow exists, then the flag has to travel with the order
- The default settlement program id follows the interface crate, so it now points at v0.3

# How to test
Existing tests + staging

