### PR TITLE
[TRIVIAL] Log dropped quotes in the solana solve loop

### DIFF
--- a/crates/solana-solvers/src/domain/solver/mod.rs
+++ b/crates/solana-solvers/src/domain/solver/mod.rs
@@ -43,7 +43,16 @@ pub async fn solve<Q: Quote>(quoter: &Q, auction: &Auction) -> Vec<Solution> {
     let candidates = auction.orders.iter().enumerate().map(|(index, order)| {
         let dex_order = order.to_dex_order();
         async move {
-            let swap = quoter.quote(&dex_order, &auction.taker).await.ok()?;
+            let swap = quoter
+                .quote(&dex_order, &auction.taker)
+                .await
+                .inspect_err(|err| match err {
+                    dex::jupiter::Error::NotFound | dex::jupiter::Error::OrderNotSupported => {
+                        tracing::debug!(order = %order.uid, %err, "no swap for order")
+                    }
+                    _ => tracing::warn!(order = %order.uid, %err, "quote failed"),
+                })
+                .ok()?;
             Solution::new(index as u64, order.uid, &dex_order, swap).ok()
         }
     });


### PR DESCRIPTION
# Description
The solana Jupiter solver dropped every failed quote silently. The solve loop discarded the error with `.ok()?`, so a disabled buy order, a routing miss, and a real Jupiter API or network failure all looked identical and left no trace. In production that would hide a Jupiter outage behind the same empty result as a routine no-route. The EVM dex solver already logs these, this brings the solana solver in line.

# Changes
- Log each dropped quote in the solve loop: debug for routine no-route and unsupported orders, warn for API, transport, and rate-limit failures

# How to test
Existing tests. On staging, a quote the solver cannot route now logs at the jupiter solver instead of vanishing.
