### PR TITLE
[EASY] Default the driver settlement program id to the interface crate

### DIFF
--- a/crates/solana-driver/src/infra/config.rs
+++ b/crates/solana-driver/src/infra/config.rs
@@ -71,12 +71,20 @@ impl Config {
     }
 }
 
+fn default_settlement_program_id() -> Pubkey {
+    cow_settlement_interface::ID
+}
+
 /// Solana chain configuration.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct Chain {
-    /// On-chain program id of the settlement contract.
-    #[serde(deserialize_with = "deserialize_solana_pubkey_b58")]
+    /// On-chain program id of the settlement contract. Defaults to the
+    /// official deployment the interface crate exports.
+    #[serde(
+        default = "default_settlement_program_id",
+        deserialize_with = "deserialize_solana_pubkey_b58"
+    )]
     pub settlement_program_id: Pubkey,
 }
 
@@ -173,5 +181,11 @@ mod tests {
             err.to_string().contains("expected a nonzero usize"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn chain_defaults_to_interface_program_id() {
+        let chain: Chain = toml::de::from_str("").unwrap();
+        assert_eq!(chain.settlement_program_id, cow_settlement_interface::ID);
     }
 }


### PR DESCRIPTION
# Description
The driver takes its settlement program id from config, while the indexer defaults to the id the interface crate declares. This gives the driver the same default, so the program id has one source of truth: the crate. Bumping the crate version moves it everywhere, and the infra can stop configuring it (follow-up).

# Changes
- Default the driver's settlement-program-id to `cow_settlement_interface::ID` when config omits it, matching the indexer

# How to test
New unit test. Existing tests.
