### PR TITLE
Index order mints from the intent, not an RPC lookup

### DIFF
--- a/crates/solana-indexer/src/indexer/decoder.rs
+++ b/crates/solana-indexer/src/indexer/decoder.rs
@@ -38,9 +38,8 @@ use {
         },
         recover_discriminator,
     },
-    cow_solana_rpc::SolanaRPC,
-    solana_sdk::{account::Account, pubkey::Pubkey},
-    std::collections::{BTreeMap, HashMap},
+    solana_sdk::pubkey::Pubkey,
+    std::collections::BTreeMap,
     tokio::sync::mpsc::Receiver,
 };
 
@@ -48,9 +47,6 @@ use {
 pub(crate) struct Decoder {
     /// Persistence layer.
     pub persistence: Postgres,
-
-    /// Account lookups for data the stream does not carry.
-    pub rpc: SolanaRPC,
 
     /// Incoming `StreamUpdate` from the ingester.
     pub rx: Receiver<StreamUpdate>,
@@ -67,14 +63,12 @@ impl Decoder {
     /// Construct a new decoder. The caller owns the channel capacity decision.
     pub fn new(
         persistence: Postgres,
-        rpc: SolanaRPC,
         rx: Receiver<StreamUpdate>,
         settlement_program: Pubkey,
         solflow_program: Option<Pubkey>,
     ) -> Self {
         Self {
             persistence,
-            rpc,
             rx,
             settlement_program,
             solflow_program,
@@ -196,41 +190,11 @@ impl Decoder {
                     .await?;
             }
         } else {
-            let mints = self.resolve_mints(&buffer.events).await?;
             self.persistence
-                .persist_events(buffer.events, &mints, last_indexed)
+                .persist_events(buffer.events, last_indexed)
                 .await?;
         }
         Ok(())
-    }
-
-    /// Resolve the token accounts named by the batch's created orders to
-    /// their mints. The intent carries token accounts, the orders table
-    /// stores mints.
-    async fn resolve_mints(
-        &self,
-        events: &[DecodedEvent],
-    ) -> Result<HashMap<Pubkey, Pubkey>, PersistenceError> {
-        let accounts: Vec<Pubkey> = events
-            .iter()
-            .filter_map(|event| match event {
-                DecodedEvent::Settlement(SettlementEvent::OrderCreated(order)) => {
-                    Some([order.sell_token_account, order.buy_token_account])
-                }
-                _ => None,
-            })
-            .flatten()
-            .collect();
-        if accounts.is_empty() {
-            return Ok(HashMap::new());
-        }
-        Ok(self
-            .rpc
-            .multiple_accounts(accounts)
-            .await?
-            .iter()
-            .filter_map(|(key, account)| Some((*key, token_account_mint(account)?)))
-            .collect())
     }
 
     /// Decode one transaction's tracked instructions into domain events.
@@ -427,7 +391,9 @@ fn decode_order_created(
         created_by: *input.created_by,
         order_pda: *input.order_pda,
         sell_token_account: to_sdk_pubkey(intent.sell_token_account),
+        sell_mint: to_sdk_pubkey(intent.sell_mint),
         buy_token_account: to_sdk_pubkey(intent.buy_token_account),
+        buy_mint: to_sdk_pubkey(intent.buy_mint),
         sell_amount: intent.sell_amount,
         buy_amount: intent.buy_amount,
         valid_to: intent.valid_to,
@@ -597,26 +563,6 @@ fn decode_settlements_finalized(
         }));
     }
     events
-}
-
-/// The classic and 2022 SPL token programs, the only owners whose account
-/// layout `token_account_mint` trusts.
-const TOKEN_PROGRAMS: [Pubkey; 2] = [spl_token_interface::ID, spl_token_2022_interface::ID];
-
-/// Size of a classic SPL token account, the lower bound for Token-2022,
-/// whose extensions append past it.
-const TOKEN_ACCOUNT_MIN_LEN: usize = 165;
-
-/// The mint an SPL token account holds, the first 32 bytes of its data.
-/// `None` for accounts that are not token accounts, so a garbage account
-/// named by an intent cannot smuggle a fake mint into the orders table.
-fn token_account_mint(account: &Account) -> Option<Pubkey> {
-    if !TOKEN_PROGRAMS.contains(&account.owner) || account.data.len() < TOKEN_ACCOUNT_MIN_LEN {
-        return None;
-    }
-    Some(Pubkey::new_from_array(
-        account.data.get(..32)?.try_into().ok()?,
-    ))
 }
 
 /// Resolve an instruction's account-list indices to their pubkeys, in order, so

--- a/crates/solana-indexer/src/indexer/decoder/tests.rs
+++ b/crates/solana-indexer/src/indexer/decoder/tests.rs
@@ -711,6 +711,6 @@ async fn solana_db_ingester_to_decoder_persists_decoded_events() {
             .fetch_one(&pool)
             .await
             .unwrap();
-    assert_eq!(sell_token, vec![0xA1; 32]);
-    assert_eq!(buy_token, vec![0xA2; 32]);
+    assert_eq!(sell_token, expected.sell_mint.to_bytes().to_vec());
+    assert_eq!(buy_token, expected.buy_mint.to_bytes().to_vec());
 }

--- a/crates/solana-indexer/src/indexer/decoder/tests.rs
+++ b/crates/solana-indexer/src/indexer/decoder/tests.rs
@@ -39,7 +39,6 @@ use {
         data::intent::{Flags, OrderIntent, OrderKind as IntentOrderKind},
         pda::order::find_order_pda,
     },
-    cow_solana_rpc::{Mocks, RpcRequest, SolanaRPC},
     futures::StreamExt,
     solana_sdk::pubkey::Pubkey,
     std::sync::{Arc, atomic::AtomicU64},
@@ -377,7 +376,9 @@ fn create_order_tx() -> (SubscribeUpdateTransactionInfo, CreatedOrder) {
         created_by,
         order_pda: find_order_pda(&settlement, &intent.uid()).0,
         sell_token_account: Pubkey::new_from_array([0x33; 32]),
+        sell_mint: Pubkey::new_from_array([0x66; 32]),
         buy_token_account: Pubkey::new_from_array([0x22; 32]),
+        buy_mint: Pubkey::new_from_array([0x55; 32]),
         sell_amount: 1_000,
         buy_amount: 2_000,
         valid_to: 42,
@@ -388,68 +389,12 @@ fn create_order_tx() -> (SubscribeUpdateTransactionInfo, CreatedOrder) {
     (tx, expected)
 }
 
-#[test]
-fn token_account_mint_trusts_only_token_program_accounts() {
-    let account = |owner: Pubkey, data: Vec<u8>| solana_sdk::account::Account {
-        lamports: 1,
-        data,
-        owner,
-        executable: false,
-        rent_epoch: 0,
-    };
-    let token_program = super::TOKEN_PROGRAMS[0];
-    assert_eq!(
-        super::token_account_mint(&account(token_program, vec![0xAA; 165])),
-        Some(Pubkey::new_from_array([0xAA; 32]))
-    );
-    // A mint account: right owner, too short to be a token account.
-    assert_eq!(
-        super::token_account_mint(&account(token_program, vec![0xAA; 82])),
-        None
-    );
-    // Right size, arbitrary owner.
-    assert_eq!(
-        super::token_account_mint(&account(pubkey(1), vec![0xAA; 165])),
-        None
-    );
-}
-
-/// A canned `getMultipleAccounts` response, in request order: the sell token
-/// account holds mint `[0xA1; 32]`, the buy token account mint `[0xA2; 32]`
-/// (the first 32 bytes of the base64 data).
-fn mock_rpc_with_token_accounts() -> SolanaRPC {
-    let account = |data: &str| {
-        serde_json::json!({
-            "lamports": 1u64,
-            "data": [data, "base64"],
-            "owner": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
-            "executable": false,
-            "rentEpoch": 0u64,
-            "space": 165u64
-        })
-    };
-    let sell = account("oaGhoaGhoaGhoaGhoaGhoaGhoaGhoaGhoaGhoaGhoaEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
-    let buy = account("oqKioqKioqKioqKioqKioqKioqKioqKioqKioqKioqIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
-    let response = serde_json::json!({
-        "context": { "slot": 1u64, "apiVersion": "2.0.0" },
-        "value": [sell, buy],
-    });
-    let mocks = Mocks::from([(RpcRequest::GetMultipleAccounts, response)]);
-    SolanaRPC::new_mock_with_mocks(mocks)
-}
-
 /// A decoder over a lazy pool that never connects: `decode` is pure, tests
 /// of it stay database-free.
 fn pure_decoder(settlement: Pubkey, solflow: Pubkey) -> Decoder {
     let pool = sqlx::PgPool::connect_lazy("postgresql://").unwrap();
     let (_sender, rx) = tokio::sync::mpsc::channel(1);
-    Decoder::new(
-        Postgres::new(pool),
-        SolanaRPC::new_mock_with_mocks(Default::default()),
-        rx,
-        settlement,
-        Some(solflow),
-    )
+    Decoder::new(Postgres::new(pool), rx, settlement, Some(solflow))
 }
 
 /// `decode` wraps settlement events as `DecodedEvent::Settlement` for `run`
@@ -708,7 +653,6 @@ async fn solana_db_ingester_to_decoder_persists_decoded_events() {
     let mut ingester = Ingester::new(geyser_stream, sender, Arc::new(AtomicU64::new(0)));
     let mut decoder = Decoder::new(
         Postgres::new(pool.clone()),
-        mock_rpc_with_token_accounts(),
         receiver,
         settlement,
         Some(solflow),

--- a/crates/solana-indexer/src/persistence.rs
+++ b/crates/solana-indexer/src/persistence.rs
@@ -16,9 +16,7 @@ use {
     },
     bigdecimal::BigDecimal,
     database::solana::OrderEventLabel,
-    solana_sdk::pubkey::Pubkey,
     sqlx::{PgPool, PgTransaction},
-    std::collections::HashMap,
 };
 
 /// Slots stay far below `i64::MAX`, the conversion to the database's
@@ -48,8 +46,6 @@ fn from_db_uid(uid: Vec<u8>) -> [u8; 32] {
 enum DeadLetterReason {
     /// The transaction failed to decode.
     DecoderError,
-    /// A created order's token accounts did not resolve to mints.
-    UnresolvedMints,
     /// A settlement trade named an order PDA with no orders row.
     UnresolvedOrders,
 }
@@ -58,7 +54,6 @@ impl DeadLetterReason {
     fn as_str(&self) -> &'static str {
         match self {
             Self::DecoderError => "decoder_error",
-            Self::UnresolvedMints => "unresolved_mints",
             Self::UnresolvedOrders => "unresolved_orders",
         }
     }
@@ -87,12 +82,10 @@ impl Postgres {
     async fn apply(
         tx: &mut PgTransaction<'_>,
         event: DecodedEvent,
-        mints: &HashMap<Pubkey, Pubkey>,
-        slot: Slot,
     ) -> Result<(), PersistenceError> {
         match event {
             DecodedEvent::Settlement(SettlementEvent::OrderCreated(order)) => {
-                Self::apply_order_created(tx, &order, mints, slot).await
+                Self::apply_order_created(tx, &order).await
             }
             DecodedEvent::Settlement(SettlementEvent::SettlementFinalized(settlement)) => {
                 Self::apply_settlement_finalized(tx, settlement).await
@@ -111,8 +104,6 @@ impl Postgres {
     async fn apply_order_created(
         tx: &mut PgTransaction<'_>,
         order: &CreatedOrder,
-        mints: &HashMap<Pubkey, Pubkey>,
-        slot: Slot,
     ) -> Result<(), PersistenceError> {
         sqlx::query(
             r#"
@@ -125,26 +116,6 @@ ON CONFLICT (order_uid) DO NOTHING
         .bind(order.created_by.to_bytes())
         .execute(&mut **tx)
         .await?;
-        // Without both mints the intent row cannot be written. The
-        // transaction is dead-lettered so the replay machinery re-delivers
-        // it, until then the order stays out of the solvable set.
-        let (Some(sell_token), Some(buy_token)) = (
-            mints.get(&order.sell_token_account),
-            mints.get(&order.buy_token_account),
-        ) else {
-            tracing::warn!(
-                order_uid = %order.order_uid,
-                "unresolved token account mints, order dead-lettered"
-            );
-            Self::insert_dead_letter(
-                &mut **tx,
-                order.signature,
-                slot,
-                DeadLetterReason::UnresolvedMints,
-            )
-            .await?;
-            return Ok(());
-        };
         // creation_timestamp is the indexing time, the stream carries no
         // block time.
         let inserted = sqlx::query(
@@ -158,8 +129,8 @@ ON CONFLICT (uid) DO NOTHING
         )
         .bind(order.order_uid.0)
         .bind(order.owner.to_bytes())
-        .bind(sell_token.to_bytes())
-        .bind(buy_token.to_bytes())
+        .bind(order.sell_mint.to_bytes())
+        .bind(order.buy_mint.to_bytes())
         .bind(order.sell_token_account.to_bytes())
         .bind(order.buy_token_account.to_bytes())
         .bind(BigDecimal::from(order.sell_amount))
@@ -326,17 +297,15 @@ WHERE indexer_state.slot < EXCLUDED.slot
     }
 
     /// Save one slot's decoded events and advance the last indexed slot in
-    /// one transaction. `mints` maps the batch's token accounts to their
-    /// mints.
+    /// one transaction.
     pub(crate) async fn persist_events(
         &self,
         events: Vec<DecodedEvent>,
-        mints: &HashMap<Pubkey, Pubkey>,
         last_indexed_slot: Slot,
     ) -> Result<(), PersistenceError> {
         let mut tx = self.pool.begin().await?;
         for event in events {
-            Self::apply(&mut tx, event, mints, last_indexed_slot).await?;
+            Self::apply(&mut tx, event).await?;
         }
         Self::upsert_last_indexed_slot(&mut *tx, last_indexed_slot).await?;
         Ok(tx.commit().await?)
@@ -397,7 +366,6 @@ mod tests {
         bigdecimal::BigDecimal,
         solana_sdk::pubkey::Pubkey,
         sqlx::{PgPool, Row},
-        std::collections::HashMap,
     };
 
     /// The `solana.orders` columns a seeded test order writes.
@@ -454,7 +422,9 @@ VALUES ($1, $2, $2, $2, $2, $2, $3, $4, $5, $6, false, $2, now(), $7)
             created_by: Pubkey::new_from_array([0xBB; 32]),
             order_pda: Pubkey::new_from_array([0xDD; 32]),
             sell_token_account: Pubkey::new_from_array([4; 32]),
+            sell_mint: Pubkey::new_from_array([8; 32]),
             buy_token_account: Pubkey::new_from_array([5; 32]),
+            buy_mint: Pubkey::new_from_array([9; 32]),
             sell_amount: 1_000,
             buy_amount: 2_000,
             valid_to: 42,
@@ -462,44 +432,6 @@ VALUES ($1, $2, $2, $2, $2, $2, $3, $4, $5, $6, false, $2, now(), $7)
             partially_fillable: false,
             app_data: [0; 32],
         }
-    }
-
-    #[tokio::test]
-    #[ignore = "needs the solana.* schema applied locally, run with --test-threads 1"]
-    async fn solana_db_unresolved_mints_skip_the_orders_row() {
-        let pool = pool().await;
-        wipe(&pool).await;
-        let postgres = Postgres::new(pool.clone());
-
-        let uid = [0x77; 32];
-        let events = vec![DecodedEvent::Settlement(SettlementEvent::OrderCreated(
-            Box::new(created_order(uid)),
-        ))];
-        postgres
-            .persist_events(events, &HashMap::new(), Slot(30))
-            .await
-            .unwrap();
-
-        let pda: i64 =
-            sqlx::query_scalar("SELECT count(*) FROM solana.order_pda WHERE order_uid = $1")
-                .bind(uid)
-                .fetch_one(&pool)
-                .await
-                .unwrap();
-        assert_eq!(pda, 1);
-        let orders: i64 = sqlx::query_scalar("SELECT count(*) FROM solana.orders WHERE uid = $1")
-            .bind(uid)
-            .fetch_one(&pool)
-            .await
-            .unwrap();
-        assert_eq!(orders, 0);
-        let reason: String =
-            sqlx::query_scalar("SELECT reason FROM solana.dead_letter WHERE tx_signature = $1")
-                .bind(Signature::from([6; 64]).as_ref())
-                .fetch_one(&pool)
-                .await
-                .unwrap();
-        assert_eq!(reason, "unresolved_mints");
     }
 
     #[tokio::test]
@@ -583,26 +515,12 @@ VALUES ($1, $2, $2, $2, $2, $2, $3, $4, $5, $6, false, $2, now(), $7)
             })),
         ];
 
-        let mints = HashMap::from([
-            (
-                Pubkey::new_from_array([4; 32]),
-                Pubkey::new_from_array([0xA1; 32]),
-            ),
-            (
-                Pubkey::new_from_array([5; 32]),
-                Pubkey::new_from_array([0xA2; 32]),
-            ),
-        ]);
-
         // Twice: the second run must change nothing, replay is idempotent.
         postgres
-            .persist_events(events.clone(), &mints, Slot(20))
+            .persist_events(events.clone(), Slot(20))
             .await
             .unwrap();
-        postgres
-            .persist_events(events, &mints, Slot(20))
-            .await
-            .unwrap();
+        postgres.persist_events(events, Slot(20)).await.unwrap();
 
         let created = sqlx::query(
             "SELECT sell_token, buy_token, sell_amount FROM solana.orders WHERE uid = $1",
@@ -682,10 +600,7 @@ VALUES ($1, $2, $2, $2, $2, $2, $3, $4, $5, $6, false, $2, now(), $7)
                 }],
             }),
         )];
-        postgres
-            .persist_events(events, &HashMap::new(), Slot(20))
-            .await
-            .unwrap();
+        postgres.persist_events(events, Slot(20)).await.unwrap();
 
         // The settlement row lands, the unresolvable trade is replaced by a
         // replay marker.

--- a/crates/solana-indexer/src/persistence.rs
+++ b/crates/solana-indexer/src/persistence.rs
@@ -529,8 +529,8 @@ VALUES ($1, $2, $2, $2, $2, $2, $3, $4, $5, $6, false, $2, now(), $7)
         .fetch_one(&pool)
         .await
         .unwrap();
-        assert_eq!(created.get::<Vec<u8>, _>("sell_token"), vec![0xA1; 32]);
-        assert_eq!(created.get::<Vec<u8>, _>("buy_token"), vec![0xA2; 32]);
+        assert_eq!(created.get::<Vec<u8>, _>("sell_token"), vec![8; 32]);
+        assert_eq!(created.get::<Vec<u8>, _>("buy_token"), vec![9; 32]);
 
         let pda = sqlx::query(
             "SELECT created_by, amount_withdrawn, amount_received FROM solana.order_pda WHERE \

--- a/crates/solana-indexer/src/run.rs
+++ b/crates/solana-indexer/src/run.rs
@@ -12,7 +12,6 @@ use {
         yellowstone,
     },
     clap::Parser,
-    cow_solana_rpc::{CommitmentConfig, SolanaRPC},
     observe::metrics::{DEFAULT_METRICS_PORT, LivenessChecking, serve_metrics},
     sqlx::{PgPool, postgres::PgPoolOptions},
     std::{
@@ -64,23 +63,11 @@ async fn run(config: Config, start_slot: Option<u64>) {
         .expect("database connection");
     let mut metrics = serve_probes(pool.clone());
     let persistence = Postgres::new(pool);
-    // Confirmed commitment, matching the stream subscription.
-    let rpc = SolanaRPC::new_with_timeout_and_commitment(
-        &config.rpc.endpoint,
-        config.rpc.request_timeout,
-        CommitmentConfig::confirmed(),
-    );
 
     let (tx, rx) = mpsc::channel(INGEST_TO_DECODER_CAPACITY);
     let settlement_program = config.chain.settlement_program_id;
     let solflow_program = config.chain.solflow_program_id;
-    let mut decoder = Decoder::new(
-        persistence.clone(),
-        rpc,
-        rx,
-        settlement_program,
-        solflow_program,
-    );
+    let mut decoder = Decoder::new(persistence.clone(), rx, settlement_program, solflow_program);
     let mut decoder_task = tokio::spawn(async move { decoder.run().await });
 
     let latest_chain_slot = Arc::new(AtomicU64::default());

--- a/crates/solana-indexer/src/types/events.rs
+++ b/crates/solana-indexer/src/types/events.rs
@@ -47,11 +47,14 @@ pub(crate) struct CreatedOrder {
     pub created_by: Pubkey,
     /// Canonical order PDA address.
     pub order_pda: Pubkey,
-    /// Account the sell amount is pulled from. The intent names token
-    /// accounts, not mints: mints require an account lookup.
+    /// Account the sell amount is pulled from.
     pub sell_token_account: Pubkey,
+    /// Mint of the sell token, carried by the intent.
+    pub sell_mint: Pubkey,
     /// Account the buy amount is pushed to.
     pub buy_token_account: Pubkey,
+    /// Mint of the buy token, carried by the intent.
+    pub buy_mint: Pubkey,
     /// Amount sold, in the sell token's native units.
     pub sell_amount: u64,
     /// Amount bought, in the buy token's native units.


### PR DESCRIPTION
# Description
The indexer can't process v0.3 orders. To record an order's two mints, it fetched the order's token accounts over RPC and read the mint off each. The buy account usually does not exist yet at index time (it is created at settlement), so the fetch came back empty and the order landed in the `dead_letter` table as "unresolved mints". v0.3 intents carry both mints inline, so the indexer now reads them straight from the decoded intent and skips the RPC lookup.

# Changes
- Carry `sell_mint` and `buy_mint` on the created-order event, taken from the decoded intent
- Persist the order's mints from those fields and drop the RPC mint resolution and its dead-letter path
- Drop the now-unused RPC client from the decoder

The indexer config keeps its `rpc` endpoint. Nothing reads it after this change, but the upcoming backfill and recovery work needs RPC to fetch transactions older than the stream's ~150-slot replay window.

# How to test
Staging.