### PR TITLE
[TRIVIAL] Support Ink in BitGet solver

### DIFF
--- a/crates/solvers/src/infra/dex/bitget/dto.rs
+++ b/crates/solvers/src/infra/dex/bitget/dto.rs
@@ -21,6 +21,8 @@ pub enum ChainName {
     Polygon,
     #[serde(rename = "arbitrum")]
     ArbitrumOne,
+    #[serde(rename = "ink")]
+    Ink,
 }
 
 impl ChainName {
@@ -31,6 +33,7 @@ impl ChainName {
             eth::ChainId::Base => Self::Base,
             eth::ChainId::Polygon => Self::Polygon,
             eth::ChainId::ArbitrumOne => Self::ArbitrumOne,
+            eth::ChainId::Ink => Self::Ink,
             _ => panic!("unsupported Bitget chain: {chain_id:?}"),
         }
     }


### PR DESCRIPTION
Based on the information from the Bitget team, they now operate on Ink. The relevant infra PR was merged before this one.