### PR TITLE
Make the solana autopilot cycle interval configurable

### DIFF
--- a/crates/autopilot-svm/example.toml
+++ b/crates/autopilot-svm/example.toml
@@ -5,6 +5,8 @@ metrics-port = 9586
 # The pod fails the liveness probe when no auction cycle completed in this
 # time.
 max-auction-age = "5m"
+# Minimum time between auction cycles. Zero runs a cycle every new slot.
+min-auction-interval = "2s"
 
 [database]
 # The Postgres database the indexer writes to. A value like "%DB_WRITE_URL"

--- a/crates/autopilot-svm/src/infra/config.rs
+++ b/crates/autopilot-svm/src/infra/config.rs
@@ -52,6 +52,9 @@ pub struct Config {
     /// check.
     #[serde(with = "humantime_serde", default = "default_max_auction_age")]
     pub max_auction_age: Duration,
+    /// Minimum time between auction cycles. Zero runs a cycle every new slot.
+    #[serde(with = "humantime_serde", default = "default_min_auction_interval")]
+    pub min_auction_interval: Duration,
     /// The driver endpoints participating in every auction.
     #[serde(deserialize_with = "deserialize_nonempty_vec")]
     pub drivers: Vec<Driver>,
@@ -79,6 +82,10 @@ const fn default_metrics_port() -> u16 {
 
 const fn default_max_auction_age() -> Duration {
     Duration::from_mins(5)
+}
+
+const fn default_min_auction_interval() -> Duration {
+    Duration::ZERO
 }
 
 /// JSON-RPC client configuration.
@@ -154,6 +161,7 @@ mod tests {
         assert_eq!(config.competition.solve_deadline, Duration::from_secs(6));
         assert_eq!(config.competition.submission_deadline_slots.get(), 25);
         assert_eq!(config.max_auction_age, Duration::from_secs(5 * 60));
+        assert_eq!(config.min_auction_interval, Duration::from_secs(2));
         assert_eq!(config.drivers.len(), 1);
         assert_eq!(config.drivers[0].name, "baseline");
         assert_eq!(config.logging.filter, "info,autopilot_svm=debug");

--- a/crates/autopilot-svm/src/infra/trigger.rs
+++ b/crates/autopilot-svm/src/infra/trigger.rs
@@ -6,7 +6,7 @@ use {
     cow_solana_rpc::SolanaRPC,
     std::{
         sync::atomic::{AtomicU64, Ordering},
-        time::Duration,
+        time::{Duration, Instant},
     },
 };
 
@@ -18,13 +18,19 @@ const POLL_INTERVAL: Duration = Duration::from_millis(200);
 pub struct SlotTrigger {
     rpc: SolanaRPC,
     tip: AtomicU64,
+    /// Minimum time between cycles. Zero yields one cycle per new slot.
+    min_interval: Duration,
+    /// When the last cycle fired, to hold `min_interval` before the next one.
+    last_fired: Option<Instant>,
 }
 
 impl SlotTrigger {
-    pub fn new(rpc: SolanaRPC) -> Self {
+    pub fn new(rpc: SolanaRPC, min_interval: Duration) -> Self {
         Self {
             rpc,
             tip: AtomicU64::new(0),
+            min_interval,
+            last_fired: None,
         }
     }
 }
@@ -32,11 +38,20 @@ impl SlotTrigger {
 #[async_trait]
 impl CycleTrigger<SolanaCycle> for SlotTrigger {
     async fn next_cycle(&mut self) -> u64 {
+        // Hold at least `min_interval` since the last cycle, then poll for the
+        // freshest slot.
+        if let Some(last) = self.last_fired {
+            let since = last.elapsed();
+            if since < self.min_interval {
+                tokio::time::sleep(self.min_interval - since).await;
+            }
+        }
         loop {
             match self.rpc.slot().await {
                 Ok(slot) => {
                     let previous = self.tip.fetch_max(slot, Ordering::Relaxed);
                     if slot > previous {
+                        self.last_fired = Some(Instant::now());
                         return slot;
                     }
                 }

--- a/crates/autopilot-svm/src/run.rs
+++ b/crates/autopilot-svm/src/run.rs
@@ -106,7 +106,7 @@ async fn run(config: Config) {
         .collect();
 
     let auction_loop = AuctionLoop::new(
-        Box::new(SlotTrigger::new(rpc)),
+        Box::new(SlotTrigger::new(rpc, config.min_auction_interval)),
         Box::new(DbAuctionProvider::new(pool.clone())),
         Box::new(DriverCompetition::new(
             drivers.clone(),


### PR DESCRIPTION
# Description
The solana autopilot cuts a new auction every slot (~400ms), so a single standing order is re-solved a few times a second. That overruns the Jupiter solver's API budget on staging, where every quote comes back rate limited and nothing settles. This adds a knob to pace the loop.

# Changes
- Add `min_auction_interval` to the autopilot config, default zero, which keeps the current one-cycle-per-slot behavior
- `SlotTrigger` holds at least that interval between cycles before cutting the next auction

# How to test
Existing tests, plus a parse assertion in the example-config test. On staging, set `min-auction-interval` and watch the auction cadence in the logs drop to that rate.
