### PR TITLE
[TRIVIAL] autopilot-svm: log landed tx signatures as base58

### DIFF
--- a/crates/autopilot-svm/src/infra/observation.rs
+++ b/crates/autopilot-svm/src/infra/observation.rs
@@ -14,7 +14,7 @@ use {
     crate::infra::{db, listen::NotifyHandler},
     anyhow::Result,
     async_trait::async_trait,
-    chain_types::solana::Pubkey,
+    chain_types::solana::{Pubkey, Signature},
     sqlx::PgPool,
 };
 
@@ -79,7 +79,7 @@ impl SettlementWindows {
                 auction_id,
                 slot = landed.end_slot,
                 solver = %Pubkey(landed.solver.0),
-                tx_signature = %const_hex::encode(landed.submitted_signature.0),
+                tx_signature = %Signature(landed.submitted_signature.0),
                 "settlement observed on chain"
             );
         }


### PR DESCRIPTION
# Description
The autopilot logged landed settlement signatures as hex while the driver logs them as base58, making it hard to correlate the same transaction across the two components' logs.

# Changes
* autopilot-svm: render `tx_signature` via `chain_types::solana::Signature` (base58 Display) instead of `const_hex::encode` in the "settlement observed on chain" log
