### PR TITLE
Add [rwa] to config to de-duplicate RWA lists from solvers

### DIFF
--- a/crates/driver/example.toml
+++ b/crates/driver/example.toml
@@ -15,6 +15,7 @@ fake-header-one = "FAKE-HEADER-VALUE"  # For instance an authorization token whi
 [solver.token-supported]  # Keys are token addresses or [token-groups] names
 ondo = false
 xstocks = false
+"0x0000000000000000000000000000000000000002" = true  # An address overrides the groups containing it
 
 # [[solver]] # And so on, specify as many solvers as needed
 # name = "othersolver"

--- a/crates/driver/example.toml
+++ b/crates/driver/example.toml
@@ -12,7 +12,7 @@ response-size-limit-max-bytes = 30000000
 [solver.request-headers]
 fake-header-one = "FAKE-HEADER-VALUE"  # For instance an authorization token which must be provided on each request
 
-[solver.token-supported]  # Keys are token addresses or [rwa] group names
+[solver.token-supported]  # Keys are token addresses or [token-groups] names
 ondo = false
 xstocks = false
 
@@ -24,7 +24,7 @@ xstocks = false
 
 # Groups of tokens that solvers refer to by name in `token-supported`. Listing
 # them once per driver keeps the solver sections small.
-[rwa]
+[token-groups]
 ondo = ["0x0000000000000000000000000000000000000001"]
 xstocks = ["0x0000000000000000000000000000000000000002"]
 

--- a/crates/driver/example.toml
+++ b/crates/driver/example.toml
@@ -8,6 +8,7 @@ relative-slippage = "0.1"  # Percentage in the [0, 1] range
 account = "0x0000000000000000000000000000000000000000000000000000000000000001"  # The private key of the solver
 merge-solutions = true  # Multiple solutions proposed by the solver may be combined into one by the driver
 response-size-limit-max-bytes = 30000000
+# rwa-support = ["ondo"]  # Names of the [rwa] groups this solver supports; tokens of the other groups are marked unsupported
 
 [solver.request-headers]
 fake-header-one = "FAKE-HEADER-VALUE"  # For instance an authorization token which must be provided on each request
@@ -17,6 +18,12 @@ fake-header-one = "FAKE-HEADER-VALUE"  # For instance an authorization token whi
 # endpoint = "http://localhost:1235"
 # relative-slippage = "0.1"
 # account = "0x0000000000000000000000000000000000000000000000000000000000000002"
+
+# Groups of tokens that solvers opt into as a whole via `rwa-support`. Listing
+# them once per driver keeps the solver sections small.
+[rwa]
+ondo = ["0x0000000000000000000000000000000000000001"]
+xstocks = ["0x0000000000000000000000000000000000000002"]
 
 [submission]
 gas-price-cap = "1000000000000"

--- a/crates/driver/example.toml
+++ b/crates/driver/example.toml
@@ -8,10 +8,13 @@ relative-slippage = "0.1"  # Percentage in the [0, 1] range
 account = "0x0000000000000000000000000000000000000000000000000000000000000001"  # The private key of the solver
 merge-solutions = true  # Multiple solutions proposed by the solver may be combined into one by the driver
 response-size-limit-max-bytes = 30000000
-# rwa-support = ["ondo"]  # Names of the [rwa] groups this solver supports; tokens of the other groups are marked unsupported
 
 [solver.request-headers]
 fake-header-one = "FAKE-HEADER-VALUE"  # For instance an authorization token which must be provided on each request
+
+[solver.token-supported]  # Keys are token addresses or [rwa] group names
+ondo = false
+xstocks = false
 
 # [[solver]] # And so on, specify as many solvers as needed
 # name = "othersolver"
@@ -19,7 +22,7 @@ fake-header-one = "FAKE-HEADER-VALUE"  # For instance an authorization token whi
 # relative-slippage = "0.1"
 # account = "0x0000000000000000000000000000000000000000000000000000000000000002"
 
-# Groups of tokens that solvers opt into as a whole via `rwa-support`. Listing
+# Groups of tokens that solvers refer to by name in `token-supported`. Listing
 # them once per driver keeps the solver sections small.
 [rwa]
 ondo = ["0x0000000000000000000000000000000000000001"]

--- a/crates/driver/src/infra/config/file/load.rs
+++ b/crates/driver/src/infra/config/file/load.rs
@@ -58,13 +58,13 @@ pub async fn load(chain: Chain, path: &Path) -> infra::Config {
 
     // Shared by every solver, so it is borrowed instead of moved into the
     // per-solver futures.
-    let rwa = &config.rwa;
+    let token_groups = &config.token_groups;
 
     infra::Config {
         solvers: join_all(config.solvers.into_iter().map(|solver_config| async move {
             let tokens_supported = solver_config
                 .bad_order_detection
-                .canonicalize_token_support(rwa)
+                .canonicalize_token_support(token_groups)
                 .unwrap_or_else(|err| {
                     panic!(
                         "invalid token support for solver {}: {err:?}",

--- a/crates/driver/src/infra/config/file/load.rs
+++ b/crates/driver/src/infra/config/file/load.rs
@@ -31,7 +31,7 @@ pub async fn load(chain: Chain, path: &Path) -> infra::Config {
         .await
         .unwrap_or_else(|e| panic!("I/O error while reading {path:?}: {e:?}"));
 
-    let config: file::Config = toml::de::from_str(&data).unwrap_or_else(|err| {
+    let mut config: file::Config = toml::de::from_str(&data).unwrap_or_else(|err| {
         if std::env::var("TOML_TRACE_ERROR").is_ok_and(|v| v == "1") {
             panic!("failed to parse TOML config at {path:?}: {err:#?}")
         } else {
@@ -55,6 +55,17 @@ pub async fn load(chain: Chain, path: &Path) -> infra::Config {
         .balance_cache
         .validate()
         .unwrap_or_else(|err| panic!("invalid balance cache config: {err:?}"));
+
+    // The `[rwa]` groups are expanded into each solver's token support up
+    // front, so the rest of the loader only deals with resolved addresses.
+    let rwa = std::mem::take(&mut config.rwa);
+    for solver in &mut config.solvers {
+        let support = solver
+            .bad_order_detection
+            .token_support(&rwa)
+            .unwrap_or_else(|err| panic!("invalid rwa config for solver {}: {err:?}", solver.name));
+        solver.bad_order_detection.token_supported = support;
+    }
 
     infra::Config {
         solvers: join_all(config.solvers.into_iter().map(|solver_config| async move {

--- a/crates/driver/src/infra/config/file/load.rs
+++ b/crates/driver/src/infra/config/file/load.rs
@@ -31,7 +31,7 @@ pub async fn load(chain: Chain, path: &Path) -> infra::Config {
         .await
         .unwrap_or_else(|e| panic!("I/O error while reading {path:?}: {e:?}"));
 
-    let mut config: file::Config = toml::de::from_str(&data).unwrap_or_else(|err| {
+    let config: file::Config = toml::de::from_str(&data).unwrap_or_else(|err| {
         if std::env::var("TOML_TRACE_ERROR").is_ok_and(|v| v == "1") {
             panic!("failed to parse TOML config at {path:?}: {err:#?}")
         } else {
@@ -56,19 +56,21 @@ pub async fn load(chain: Chain, path: &Path) -> infra::Config {
         .validate()
         .unwrap_or_else(|err| panic!("invalid balance cache config: {err:?}"));
 
-    // The `[rwa]` groups are expanded into each solver's token support up
-    // front, so the rest of the loader only deals with resolved addresses.
-    let rwa = std::mem::take(&mut config.rwa);
-    for solver in &mut config.solvers {
-        let support = solver
-            .bad_order_detection
-            .token_support(&rwa)
-            .unwrap_or_else(|err| panic!("invalid rwa config for solver {}: {err:?}", solver.name));
-        solver.bad_order_detection.token_supported = support;
-    }
+    // Shared by every solver, so it is borrowed instead of moved into the
+    // per-solver futures.
+    let rwa = &config.rwa;
 
     infra::Config {
         solvers: join_all(config.solvers.into_iter().map(|solver_config| async move {
+            let tokens_supported = solver_config
+                .bad_order_detection
+                .canonicalize_token_support(rwa)
+                .unwrap_or_else(|err| {
+                    panic!(
+                        "invalid token support for solver {}: {err:?}",
+                        solver_config.name
+                    )
+                });
             let account = load_account(solver_config.account, config.chain_id).await;
             solver::Config {
                 endpoint: solver_config.endpoint,
@@ -108,13 +110,11 @@ pub async fn load(chain: Chain, path: &Path) -> infra::Config {
                 quote_tx_origin: solver_config.quote_tx_origin,
                 response_size_limit_max_bytes: solver_config.response_size_limit_max_bytes,
                 bad_order_detection: BadOrderDetection {
-                    tokens_supported: solver_config
-                        .bad_order_detection
-                        .token_supported
-                        .iter()
+                    tokens_supported: tokens_supported
+                        .into_iter()
                         .map(|(token, supported)| {
                             (
-                                eth::TokenAddress::from(*token),
+                                eth::TokenAddress::from(token),
                                 match supported {
                                     true => risk_detector::Quality::Supported,
                                     false => risk_detector::Quality::Unsupported,

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -842,8 +842,8 @@ fn default_simulation_bad_token_max_age() -> Duration {
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct BadOrderDetectionConfig {
     /// Which tokens are explicitly supported or unsupported by the solver.
-    /// A key is either a token address or the name of an `[rwa]` group, which
-    /// applies to all tokens of that group.
+    /// A key is either a token address or the name of a `[token-groups]`
+    /// entry, which applies to all tokens of that group.
     #[serde(default)]
     pub token_supported: HashMap<String, bool>,
 
@@ -911,15 +911,15 @@ pub struct BadOrderDetectionConfig {
 
 impl BadOrderDetectionConfig {
     /// Resolves the configured token support into addresses, expanding every
-    /// key that names an `[rwa]` group. Errors on a key that is neither an
-    /// address nor a configured group.
+    /// key that names a `[token-groups]` entry. Errors on a key that is
+    /// neither an address nor a configured group.
     pub fn canonicalize_token_support(
         &self,
         token_groups: &HashMap<String, Vec<eth::Address>>,
     ) -> anyhow::Result<HashMap<eth::Address, bool>> {
-        let n_rwa_tokens: usize = token_groups.values().map(|addresses| addresses.len()).sum();
+        let n_group_tokens: usize = token_groups.values().map(|addresses| addresses.len()).sum();
         let mut canonical_token_supported =
-            HashMap::with_capacity(self.token_supported.len() + n_rwa_tokens);
+            HashMap::with_capacity(self.token_supported.len() + n_group_tokens);
         let mut addresses = Vec::with_capacity(self.token_supported.len());
 
         for (token, supported) in &self.token_supported {
@@ -927,7 +927,7 @@ impl BadOrderDetectionConfig {
                 Ok(address) => addresses.push((address, *supported)),
                 Err(_) => {
                     let group = token_groups.get(token).with_context(|| {
-                        format!("{token} is neither a token address nor an rwa group")
+                        format!("{token} is neither a token address nor a token group")
                     })?;
                     canonical_token_supported
                         .extend(group.iter().map(|address| (*address, *supported)));
@@ -1218,12 +1218,12 @@ mod tests {
         assert_eq!(accounts.into_inner().len(), 1);
     }
 
-    /// Two RWA groups shared by all solvers, of which each solver supports a
-    /// different subset.
-    const RWA_CONFIG: &str = r#"
+    /// Two token groups shared by all solvers, of which each solver supports
+    /// a different subset.
+    const TOKEN_GROUPS_CONFIG: &str = r#"
         tx-gas-limit = "45000000"
 
-        [rwa]
+        [token-groups]
         ondo = [
             "0x0000000000000000000000000000000000000001",
             "0x0000000000000000000000000000000000000002",
@@ -1264,8 +1264,8 @@ mod tests {
     }
 
     #[test]
-    fn rwa_groups_are_resolved_per_solver() {
-        let config: Config = toml::from_str(RWA_CONFIG).unwrap();
+    fn token_groups_are_resolved_per_solver() {
+        let config: Config = toml::from_str(TOKEN_GROUPS_CONFIG).unwrap();
 
         assert_eq!(
             token_support(&config, 0),
@@ -1279,7 +1279,7 @@ mod tests {
     }
 
     #[test]
-    fn address_overrides_the_rwa_group_containing_it() {
+    fn address_overrides_the_token_group_containing_it() {
         let config: BadOrderDetectionConfig = toml::from_str(
             r#"
             [token-supported]
@@ -1320,7 +1320,7 @@ mod tests {
     }
 
     #[test]
-    fn without_rwa_groups_addresses_are_kept() {
+    fn without_token_groups_addresses_are_kept() {
         let config: BadOrderDetectionConfig = toml::from_str(
             r#"
             [token-supported]
@@ -1336,6 +1336,25 @@ mod tests {
             support,
             HashMap::from([(address(1), true), (address(2), false)])
         );
+    }
+
+    #[test]
+    fn address_keys_are_parsed_regardless_of_casing() {
+        // Existing configs write checksummed addresses, so they must not be
+        // mistaken for a group name.
+        let config: BadOrderDetectionConfig = toml::from_str(
+            r#"
+            [token-supported]
+            "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2" = true
+            "0x6b175474e89094c44da98b954eedeac495271d0f" = false
+            "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc3" = true
+            "#,
+        )
+        .unwrap();
+
+        let support = config.canonicalize_token_support(&HashMap::new()).unwrap();
+
+        assert_eq!(support.len(), 3);
     }
 
     #[test]

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -58,7 +58,7 @@ struct Config {
     /// name instead of by address. Shared by all solvers of this driver so
     /// the addresses only have to be listed once.
     #[serde(default)]
-    rwa: HashMap<String, Vec<eth::Address>>,
+    token_groups: HashMap<String, Vec<eth::Address>>,
 
     #[serde(default)]
     liquidity: LiquidityConfig,
@@ -915,9 +915,9 @@ impl BadOrderDetectionConfig {
     /// address nor a configured group.
     pub fn canonicalize_token_support(
         &self,
-        rwa: &HashMap<String, Vec<eth::Address>>,
+        token_groups: &HashMap<String, Vec<eth::Address>>,
     ) -> anyhow::Result<HashMap<eth::Address, bool>> {
-        let n_rwa_tokens: usize = rwa.values().map(|addresses| addresses.len()).sum();
+        let n_rwa_tokens: usize = token_groups.values().map(|addresses| addresses.len()).sum();
         let mut canonical_token_supported =
             HashMap::with_capacity(self.token_supported.len() + n_rwa_tokens);
         let mut addresses = Vec::with_capacity(self.token_supported.len());
@@ -926,7 +926,7 @@ impl BadOrderDetectionConfig {
             match eth::Address::from_str(token) {
                 Ok(address) => addresses.push((address, *supported)),
                 Err(_) => {
-                    let group = rwa.get(token).with_context(|| {
+                    let group = token_groups.get(token).with_context(|| {
                         format!("{token} is neither a token address nor an rwa group")
                     })?;
                     canonical_token_supported
@@ -1259,7 +1259,7 @@ mod tests {
     fn token_support(config: &Config, solver: usize) -> HashMap<eth::Address, bool> {
         config.solvers[solver]
             .bad_order_detection
-            .canonicalize_token_support(&config.rwa)
+            .canonicalize_token_support(&config.token_groups)
             .unwrap()
     }
 

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -843,7 +843,8 @@ fn default_simulation_bad_token_max_age() -> Duration {
 pub struct BadOrderDetectionConfig {
     /// Which tokens are explicitly supported or unsupported by the solver.
     /// A key is either a token address or the name of a `[token-groups]`
-    /// entry, which applies to all tokens of that group.
+    /// entry, which applies to all tokens of that group. An address overrides
+    /// the groups that contain it.
     #[serde(default)]
     pub token_supported: HashMap<String, bool>,
 
@@ -917,10 +918,8 @@ impl BadOrderDetectionConfig {
         &self,
         token_groups: &HashMap<String, Vec<eth::Address>>,
     ) -> anyhow::Result<HashMap<eth::Address, bool>> {
-        let n_group_tokens: usize = token_groups.values().map(|addresses| addresses.len()).sum();
-        let mut canonical_token_supported =
-            HashMap::with_capacity(self.token_supported.len() + n_group_tokens);
-        let mut addresses = Vec::with_capacity(self.token_supported.len());
+        let mut canonical_token_supported = HashMap::new();
+        let mut addresses = Vec::new();
 
         for (token, supported) in &self.token_supported {
             match eth::Address::from_str(token) {

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -2,6 +2,7 @@ pub use load::load;
 use {
     crate::infra,
     alloy::{eips::BlockNumberOrTag, primitives::Address},
+    anyhow::Context,
     configs::gas_price_estimation::{default_past_blocks, default_reward_percentile},
     eth_domain_types as eth,
     number::serialization::HexOrDecimalU256,
@@ -52,6 +53,13 @@ struct Config {
 
     #[serde(rename = "solver")]
     solvers: Vec<SolverConfig>,
+
+    /// Named groups of tokens that solvers opt into as a whole with
+    /// `rwa-support`. Shared by all solvers of this driver so the addresses
+    /// only have to be listed once. Declaring a group is not additive: it
+    /// marks its tokens as unsupported for every solver that does not opt in.
+    #[serde(default)]
+    rwa: HashMap<String, Vec<eth::Address>>,
 
     #[serde(default)]
     liquidity: LiquidityConfig,
@@ -835,8 +843,14 @@ fn default_simulation_bad_token_max_age() -> Duration {
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct BadOrderDetectionConfig {
     /// Which tokens are explicitly supported or unsupported by the solver.
+    /// Takes precedence over `rwa-support`.
     #[serde(default)]
     pub token_supported: HashMap<eth::Address, bool>,
+
+    /// Names of the `[rwa]` groups this solver supports. Tokens of the
+    /// remaining groups are marked as unsupported.
+    #[serde(default)]
+    pub rwa_support: Vec<String>,
 
     /// Whether the solver opted into detecting unsupported
     /// tokens with `trace_callMany` based simulation.
@@ -898,6 +912,33 @@ pub struct BadOrderDetectionConfig {
         with = "humantime_serde"
     )]
     pub metrics_strategy_gc_max_age: Duration,
+}
+
+impl BadOrderDetectionConfig {
+    /// Resolves which tokens the solver explicitly supports, expanding the
+    /// `[rwa]` groups: tokens of a group the solver did not opt into are
+    /// unsupported, and `token-supported` overrides both. Errors if the
+    /// solver opted into a group that is not configured.
+    pub fn token_support(
+        &self,
+        rwa: &HashMap<String, Vec<eth::Address>>,
+    ) -> anyhow::Result<HashMap<eth::Address, bool>> {
+        let mut support: HashMap<_, _> = rwa
+            .values()
+            .flatten()
+            .map(|token| (*token, false))
+            .collect();
+
+        for group in &self.rwa_support {
+            let tokens = rwa
+                .get(group)
+                .with_context(|| format!("unknown rwa group {group:?}"))?;
+            support.extend(tokens.iter().map(|token| (*token, true)));
+        }
+
+        support.extend(&self.token_supported);
+        Ok(support)
+    }
 }
 
 impl Default for BadOrderDetectionConfig {
@@ -1174,6 +1215,124 @@ mod tests {
         let accounts = SubmissionAccounts::new(vec![signer]).unwrap();
 
         assert_eq!(accounts.into_inner().len(), 1);
+    }
+
+    /// Two RWA groups shared by all solvers, of which each solver opts into a
+    /// different subset.
+    const RWA_CONFIG: &str = r#"
+        tx-gas-limit = "45000000"
+
+        [rwa]
+        ondo = [
+            "0x0000000000000000000000000000000000000001",
+            "0x0000000000000000000000000000000000000002",
+        ]
+        xstocks = ["0x0000000000000000000000000000000000000003"]
+
+        [[solver]]
+        name = "ondo-solver"
+        endpoint = "http://localhost:1234"
+        relative-slippage = "0.1"
+        account = "0x0000000000000000000000000000000000000000000000000000000000000001"
+        rwa-support = ["ondo"]
+
+        [[solver]]
+        name = "xstocks-solver"
+        endpoint = "http://localhost:1235"
+        relative-slippage = "0.1"
+        account = "0x0000000000000000000000000000000000000000000000000000000000000002"
+        rwa-support = ["xstocks"]
+    "#;
+
+    fn address(last_byte: u8) -> eth::Address {
+        let mut bytes = [0u8; 20];
+        bytes[19] = last_byte;
+        eth::Address::from(bytes)
+    }
+
+    fn token_support(config: &Config, solver: usize) -> HashMap<eth::Address, bool> {
+        config.solvers[solver]
+            .bad_order_detection
+            .token_support(&config.rwa)
+            .unwrap()
+    }
+
+    #[test]
+    fn rwa_groups_are_resolved_per_solver() {
+        let config: Config = toml::from_str(RWA_CONFIG).unwrap();
+
+        assert_eq!(
+            token_support(&config, 0),
+            HashMap::from([(address(1), true), (address(2), true), (address(3), false),])
+        );
+        assert_eq!(
+            token_support(&config, 1),
+            HashMap::from([(address(1), false), (address(2), false), (address(3), true),])
+        );
+    }
+
+    #[test]
+    fn explicit_token_support_overrides_rwa_group() {
+        let config: Config = toml::from_str(&format!(
+            r#"
+            {RWA_CONFIG}
+            [solver.token-supported]
+            "0x0000000000000000000000000000000000000001" = true
+            "0x0000000000000000000000000000000000000003" = false
+            "#
+        ))
+        .unwrap();
+
+        // The overrides win in both directions for `xstocks-solver`: a token of
+        // a group it did not opt into becomes supported, one of its own group
+        // becomes unsupported.
+        assert_eq!(
+            token_support(&config, 1),
+            HashMap::from([(address(1), true), (address(2), false), (address(3), false),])
+        );
+    }
+
+    #[test]
+    fn unknown_rwa_group_is_rejected() {
+        let config = BadOrderDetectionConfig {
+            rwa_support: vec!["ondu".to_owned()],
+            ..Default::default()
+        };
+
+        let err = config
+            .token_support(&HashMap::from([("ondo".to_owned(), vec![address(1)])]))
+            .unwrap_err();
+
+        assert!(err.to_string().contains("unknown rwa group"));
+    }
+
+    #[test]
+    fn token_supported_by_any_opted_in_group() {
+        let config = BadOrderDetectionConfig {
+            rwa_support: vec!["ondo".to_owned()],
+            ..Default::default()
+        };
+
+        let support = config
+            .token_support(&HashMap::from([
+                ("ondo".to_owned(), vec![address(1)]),
+                ("xstocks".to_owned(), vec![address(1)]),
+            ]))
+            .unwrap();
+
+        assert_eq!(support, HashMap::from([(address(1), true)]));
+    }
+
+    #[test]
+    fn without_rwa_groups_token_support_is_unchanged() {
+        let config = BadOrderDetectionConfig {
+            token_supported: HashMap::from([(address(1), true), (address(2), false)]),
+            ..Default::default()
+        };
+
+        let support = config.token_support(&HashMap::new()).unwrap();
+
+        assert_eq!(support, config.token_supported);
     }
 
     #[test]

--- a/crates/driver/src/infra/config/file/mod.rs
+++ b/crates/driver/src/infra/config/file/mod.rs
@@ -10,7 +10,7 @@ use {
     serde::{Deserialize, Deserializer, Serialize},
     serde_with::serde_as,
     solver::solver::Arn,
-    std::{collections::HashMap, num::NonZeroUsize, time::Duration},
+    std::{collections::HashMap, num::NonZeroUsize, str::FromStr, time::Duration},
 };
 
 mod load;
@@ -54,10 +54,9 @@ struct Config {
     #[serde(rename = "solver")]
     solvers: Vec<SolverConfig>,
 
-    /// Named groups of tokens that solvers opt into as a whole with
-    /// `rwa-support`. Shared by all solvers of this driver so the addresses
-    /// only have to be listed once. Declaring a group is not additive: it
-    /// marks its tokens as unsupported for every solver that does not opt in.
+    /// Named groups of tokens that a solver's `token-supported` refers to by
+    /// name instead of by address. Shared by all solvers of this driver so
+    /// the addresses only have to be listed once.
     #[serde(default)]
     rwa: HashMap<String, Vec<eth::Address>>,
 
@@ -843,14 +842,10 @@ fn default_simulation_bad_token_max_age() -> Duration {
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct BadOrderDetectionConfig {
     /// Which tokens are explicitly supported or unsupported by the solver.
-    /// Takes precedence over `rwa-support`.
+    /// A key is either a token address or the name of an `[rwa]` group, which
+    /// applies to all tokens of that group.
     #[serde(default)]
-    pub token_supported: HashMap<eth::Address, bool>,
-
-    /// Names of the `[rwa]` groups this solver supports. Tokens of the
-    /// remaining groups are marked as unsupported.
-    #[serde(default)]
-    pub rwa_support: Vec<String>,
+    pub token_supported: HashMap<String, bool>,
 
     /// Whether the solver opted into detecting unsupported
     /// tokens with `trace_callMany` based simulation.
@@ -915,29 +910,35 @@ pub struct BadOrderDetectionConfig {
 }
 
 impl BadOrderDetectionConfig {
-    /// Resolves which tokens the solver explicitly supports, expanding the
-    /// `[rwa]` groups: tokens of a group the solver did not opt into are
-    /// unsupported, and `token-supported` overrides both. Errors if the
-    /// solver opted into a group that is not configured.
-    pub fn token_support(
+    /// Resolves the configured token support into addresses, expanding every
+    /// key that names an `[rwa]` group. Errors on a key that is neither an
+    /// address nor a configured group.
+    pub fn canonicalize_token_support(
         &self,
         rwa: &HashMap<String, Vec<eth::Address>>,
     ) -> anyhow::Result<HashMap<eth::Address, bool>> {
-        let mut support: HashMap<_, _> = rwa
-            .values()
-            .flatten()
-            .map(|token| (*token, false))
-            .collect();
+        let n_rwa_tokens: usize = rwa.values().map(|addresses| addresses.len()).sum();
+        let mut canonical_token_supported =
+            HashMap::with_capacity(self.token_supported.len() + n_rwa_tokens);
+        let mut addresses = Vec::with_capacity(self.token_supported.len());
 
-        for group in &self.rwa_support {
-            let tokens = rwa
-                .get(group)
-                .with_context(|| format!("unknown rwa group {group:?}"))?;
-            support.extend(tokens.iter().map(|token| (*token, true)));
+        for (token, supported) in &self.token_supported {
+            match eth::Address::from_str(token) {
+                Ok(address) => addresses.push((address, *supported)),
+                Err(_) => {
+                    let group = rwa.get(token).with_context(|| {
+                        format!("{token} is neither a token address nor an rwa group")
+                    })?;
+                    canonical_token_supported
+                        .extend(group.iter().map(|address| (*address, *supported)));
+                }
+            }
         }
 
-        support.extend(&self.token_supported);
-        Ok(support)
+        // Applied last so that an address wins over the group containing it,
+        // independent of the iteration order.
+        canonical_token_supported.extend(addresses);
+        Ok(canonical_token_supported)
     }
 }
 
@@ -1217,7 +1218,7 @@ mod tests {
         assert_eq!(accounts.into_inner().len(), 1);
     }
 
-    /// Two RWA groups shared by all solvers, of which each solver opts into a
+    /// Two RWA groups shared by all solvers, of which each solver supports a
     /// different subset.
     const RWA_CONFIG: &str = r#"
         tx-gas-limit = "45000000"
@@ -1234,14 +1235,19 @@ mod tests {
         endpoint = "http://localhost:1234"
         relative-slippage = "0.1"
         account = "0x0000000000000000000000000000000000000000000000000000000000000001"
-        rwa-support = ["ondo"]
+
+        [solver.token-supported]
+        ondo = true
+        xstocks = false
 
         [[solver]]
         name = "xstocks-solver"
         endpoint = "http://localhost:1235"
         relative-slippage = "0.1"
         account = "0x0000000000000000000000000000000000000000000000000000000000000002"
-        rwa-support = ["xstocks"]
+
+        [solver.token-supported]
+        xstocks = true
     "#;
 
     fn address(last_byte: u8) -> eth::Address {
@@ -1253,7 +1259,7 @@ mod tests {
     fn token_support(config: &Config, solver: usize) -> HashMap<eth::Address, bool> {
         config.solvers[solver]
             .bad_order_detection
-            .token_support(&config.rwa)
+            .canonicalize_token_support(&config.rwa)
             .unwrap()
     }
 
@@ -1265,74 +1271,71 @@ mod tests {
             token_support(&config, 0),
             HashMap::from([(address(1), true), (address(2), true), (address(3), false),])
         );
+        // Groups the solver does not name stay unknown rather than unsupported.
         assert_eq!(
             token_support(&config, 1),
-            HashMap::from([(address(1), false), (address(2), false), (address(3), true),])
+            HashMap::from([(address(3), true)])
         );
     }
 
     #[test]
-    fn explicit_token_support_overrides_rwa_group() {
-        let config: Config = toml::from_str(&format!(
+    fn address_overrides_the_rwa_group_containing_it() {
+        let config: BadOrderDetectionConfig = toml::from_str(
             r#"
-            {RWA_CONFIG}
-            [solver.token-supported]
-            "0x0000000000000000000000000000000000000001" = true
-            "0x0000000000000000000000000000000000000003" = false
-            "#
-        ))
+            [token-supported]
+            ondo = false
+            "0x0000000000000000000000000000000000000002" = true
+            "#,
+        )
         .unwrap();
 
-        // The overrides win in both directions for `xstocks-solver`: a token of
-        // a group it did not opt into becomes supported, one of its own group
-        // becomes unsupported.
+        let support = config
+            .canonicalize_token_support(&HashMap::from([(
+                "ondo".to_owned(),
+                vec![address(1), address(2)],
+            )]))
+            .unwrap();
+
         assert_eq!(
-            token_support(&config, 1),
-            HashMap::from([(address(1), true), (address(2), false), (address(3), false),])
+            support,
+            HashMap::from([(address(1), false), (address(2), true)])
         );
     }
 
     #[test]
-    fn unknown_rwa_group_is_rejected() {
-        let config = BadOrderDetectionConfig {
-            rwa_support: vec!["ondu".to_owned()],
-            ..Default::default()
-        };
+    fn unknown_token_support_key_is_rejected() {
+        let config: BadOrderDetectionConfig = toml::from_str(
+            r#"
+            [token-supported]
+            ondu = true
+            "#,
+        )
+        .unwrap();
 
         let err = config
-            .token_support(&HashMap::from([("ondo".to_owned(), vec![address(1)])]))
+            .canonicalize_token_support(&HashMap::from([("ondo".to_owned(), vec![address(1)])]))
             .unwrap_err();
 
-        assert!(err.to_string().contains("unknown rwa group"));
+        assert!(err.to_string().contains("neither a token address"));
     }
 
     #[test]
-    fn token_supported_by_any_opted_in_group() {
-        let config = BadOrderDetectionConfig {
-            rwa_support: vec!["ondo".to_owned()],
-            ..Default::default()
-        };
+    fn without_rwa_groups_addresses_are_kept() {
+        let config: BadOrderDetectionConfig = toml::from_str(
+            r#"
+            [token-supported]
+            "0x0000000000000000000000000000000000000001" = true
+            "0x0000000000000000000000000000000000000002" = false
+            "#,
+        )
+        .unwrap();
 
-        let support = config
-            .token_support(&HashMap::from([
-                ("ondo".to_owned(), vec![address(1)]),
-                ("xstocks".to_owned(), vec![address(1)]),
-            ]))
-            .unwrap();
+        let support = config.canonicalize_token_support(&HashMap::new()).unwrap();
 
-        assert_eq!(support, HashMap::from([(address(1), true)]));
-    }
-
-    #[test]
-    fn without_rwa_groups_token_support_is_unchanged() {
-        let config = BadOrderDetectionConfig {
-            token_supported: HashMap::from([(address(1), true), (address(2), false)]),
-            ..Default::default()
-        };
-
-        let support = config.token_support(&HashMap::new()).unwrap();
-
-        assert_eq!(support, config.token_supported);
+        assert_eq!(
+            support,
+            HashMap::from([(address(1), true), (address(2), false)])
+        );
     }
 
     #[test]


### PR DESCRIPTION
# Description
Adds a new `[token-groups]` driver config section that acts like a YAML anchor to de-duplicate the RWA list from solvers. Internally it resolves the groups into token-supported

Example:
```
[token-groups]
stonks = [addr1, addr2]

token-supported = {
    "stonks" = false
}
```

# Changes

* New driver [token-groups] config

## How to test
Existing tests