### PR TITLE
Move the Solana trades endpoint to the paginated v2 contract

### DIFF
--- a/crates/solana-orderbook/openapi.yml
+++ b/crates/solana-orderbook/openapi.yml
@@ -77,10 +77,10 @@ paths:
     get:
       operationId: getTrades
       description: |
-        Trades of one order or one owner. Exactly one of `orderUid` and
-        `owner` must be set. To enumerate all trades start with `offset` 0
-        and keep increasing it by the number of returned results. A response
-        shorter than `limit` is the last page.
+        Trades of one order or one owner, newest first. Exactly one of
+        `orderUid` and `owner` must be set. To enumerate all trades start
+        with `offset` 0 and keep increasing it by the number of returned
+        results. A response shorter than `limit` is the last page.
       parameters:
         - name: orderUid
           in: query
@@ -103,10 +103,12 @@ paths:
           description: The pagination limit. Defaults to 10. Maximum 1000. Minimum 1.
           schema:
             type: integer
+            minimum: 1
+            maximum: 1000
           required: false
       responses:
         "200":
-          description: The trades, ordered by slot.
+          description: The trades, newest first.
           content:
             application/json:
               schema:

--- a/crates/solana-orderbook/openapi.yml
+++ b/crates/solana-orderbook/openapi.yml
@@ -117,7 +117,7 @@ paths:
           description: |
             Both or neither filter set (`InvalidTradeFilter`), a malformed
             filter value (`InvalidOrderUid`, `InvalidOwner`), or the limit
-            out of bounds (`LIMIT_OUT_OF_BOUNDS`).
+            out of bounds (`InvalidLimit`).
           content:
             application/json:
               schema:

--- a/crates/solana-orderbook/openapi.yml
+++ b/crates/solana-orderbook/openapi.yml
@@ -73,7 +73,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
-  /api/v1/trades:
+  /api/v2/trades:
     get:
       operationId: getTrades
       description: |

--- a/crates/solana-orderbook/openapi.yml
+++ b/crates/solana-orderbook/openapi.yml
@@ -78,7 +78,9 @@ paths:
       operationId: getTrades
       description: |
         Trades of one order or one owner. Exactly one of `orderUid` and
-        `owner` must be set.
+        `owner` must be set. To enumerate all trades start with `offset` 0
+        and keep increasing it by the number of returned results. A response
+        shorter than `limit` is the last page.
       parameters:
         - name: orderUid
           in: query
@@ -90,6 +92,18 @@ paths:
           required: false
           schema:
             $ref: "#/components/schemas/Pubkey"
+        - name: offset
+          in: query
+          description: The pagination offset. Defaults to 0.
+          schema:
+            type: integer
+          required: false
+        - name: limit
+          in: query
+          description: The pagination limit. Defaults to 10. Maximum 1000. Minimum 1.
+          schema:
+            type: integer
+          required: false
       responses:
         "200":
           description: The trades, ordered by slot.
@@ -101,8 +115,9 @@ paths:
                   $ref: "#/components/schemas/Trade"
         "400":
           description: |
-            Both or neither filter set (`InvalidTradeFilter`), or a malformed
-            filter value (`InvalidOrderUid`, `InvalidOwner`).
+            Both or neither filter set (`InvalidTradeFilter`), a malformed
+            filter value (`InvalidOrderUid`, `InvalidOwner`), or the limit
+            out of bounds (`LIMIT_OUT_OF_BOUNDS`).
           content:
             application/json:
               schema:

--- a/crates/solana-orderbook/src/infra/api/mod.rs
+++ b/crates/solana-orderbook/src/infra/api/mod.rs
@@ -101,7 +101,7 @@ impl Api {
             .route("/healthz", get(routes::healthz))
             .route("/api/v1/orders/{uid}", get(routes::order))
             .route("/api/v1/orders/{uid}/status", get(routes::order_status))
-            .route("/api/v1/trades", get(routes::trades))
+            .route("/api/v2/trades", get(routes::trades))
             .route("/api/v1/quote", post(routes::quote))
             .layer(cors)
             .layer(RequestDecompressionLayer::new())

--- a/crates/solana-orderbook/src/infra/api/routes/trades/mod.rs
+++ b/crates/solana-orderbook/src/infra/api/routes/trades/mod.rs
@@ -13,12 +13,21 @@ use {
     std::str::FromStr,
 };
 
-/// Query parameters. Exactly one of `orderUid` or `owner` must be set.
+const DEFAULT_OFFSET: u64 = 0;
+const DEFAULT_LIMIT: u64 = 10;
+const MIN_LIMIT: u64 = 1;
+const MAX_LIMIT: u64 = 1000;
+
+/// Query parameters. Exactly one of `orderUid` or `owner` must be set. The
+/// pagination defaults and bounds are the EVM orderbook's, and the unsigned
+/// types reject negative values at deserialization, as on EVM.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Params {
     pub order_uid: Option<String>,
     pub owner: Option<String>,
+    pub offset: Option<u64>,
+    pub limit: Option<u64>,
 }
 
 /// Handle `GET /api/v1/trades`.
@@ -59,7 +68,20 @@ pub async fn trades(
             ));
         }
     };
-    let rows = db::trades(state.pool(), order_uid, owner)
+    let offset = params.offset.unwrap_or(DEFAULT_OFFSET);
+    let limit = params.limit.unwrap_or(DEFAULT_LIMIT);
+    if !(MIN_LIMIT..=MAX_LIMIT).contains(&limit) {
+        return Err(error::reply(
+            StatusCode::BAD_REQUEST,
+            "LIMIT_OUT_OF_BOUNDS",
+            "The pagination limit is [1,1000].",
+        ));
+    }
+    // The limit is bounded above, and an offset past i64::MAX addresses no
+    // conceivable row.
+    let offset = i64::try_from(offset).unwrap_or(i64::MAX);
+    let limit = i64::try_from(limit).expect("limit is at most 1000");
+    let rows = db::trades(state.pool(), order_uid, owner, offset, limit)
         .await
         .map_err(|err| {
             tracing::error!(?err, "trades lookup failed");

--- a/crates/solana-orderbook/src/infra/api/routes/trades/mod.rs
+++ b/crates/solana-orderbook/src/infra/api/routes/trades/mod.rs
@@ -71,10 +71,11 @@ pub async fn trades(
     let offset = params.offset.unwrap_or(DEFAULT_OFFSET);
     let limit = params.limit.unwrap_or(DEFAULT_LIMIT);
     if !(MIN_LIMIT..=MAX_LIMIT).contains(&limit) {
+        // The EVM v2 trades error, verbatim.
         return Err(error::reply(
             StatusCode::BAD_REQUEST,
-            "LIMIT_OUT_OF_BOUNDS",
-            "The pagination limit is [1,1000].",
+            "InvalidLimit",
+            "limit must be between 1 and 1000",
         ));
     }
     // The limit is bounded above, and an offset past i64::MAX addresses no

--- a/crates/solana-orderbook/src/infra/api/routes/trades/mod.rs
+++ b/crates/solana-orderbook/src/infra/api/routes/trades/mod.rs
@@ -30,7 +30,7 @@ pub struct Params {
     pub limit: Option<u64>,
 }
 
-/// Handle `GET /api/v1/trades`.
+/// Handle `GET /api/v2/trades`.
 pub async fn trades(
     state: axum::extract::State<State>,
     Query(params): Query<Params>,

--- a/crates/solana-orderbook/src/infra/db.rs
+++ b/crates/solana-orderbook/src/infra/db.rs
@@ -68,10 +68,10 @@ pub struct TradeRow {
     pub slot: Option<i64>,
 }
 
-/// Trades filtered by order uid or owner, paged by `offset` and `limit`.
-/// The slot comes from any settlement row of the transaction because the
-/// slot is constant per transaction. A trade whose order row is not indexed
-/// yet is omitted until the order lands.
+/// Trades filtered by order uid or owner, newest first, paged by `offset`
+/// and `limit`. The slot comes from any settlement row of the transaction
+/// because the slot is constant per transaction. A trade whose order row is
+/// not indexed yet is omitted until the order lands.
 pub async fn trades(
     ex: impl PgExecutor<'_>,
     order_uid: Option<[u8; 32]>,
@@ -92,7 +92,8 @@ LEFT JOIN LATERAL (
 ) s ON true
 WHERE ($1::bytea IS NULL OR t.order_uid = $1)
   AND ($2::bytea IS NULL OR o.owner = $2)
-ORDER BY s.slot, t.tx_signature, t.instruction_index, t.order_uid
+ORDER BY s.slot DESC NULLS LAST, t.tx_signature DESC, t.instruction_index DESC,
+         t.order_uid DESC
 OFFSET $3 LIMIT $4
     "#;
     sqlx::query_as(QUERY)
@@ -280,8 +281,8 @@ VALUES ($1, $2, 400, CASE WHEN $3 THEN now() END)
                 .is_empty()
         );
 
-        // A second fill of the same order pages: one row per page, ordered
-        // by slot, and an offset past the result set is empty.
+        // A second fill of the same order pages: one row per page, newest
+        // first, and an offset past the result set is empty.
         sqlx::query(
             "INSERT INTO solana.trades (tx_signature, instruction_index, order_uid,              \
              sell_amount, buy_amount, fee_amount) VALUES ($1, 2, $2, 100, 50, 0)",
@@ -301,10 +302,10 @@ VALUES ($1, $2, 400, CASE WHEN $3 THEN now() END)
         .unwrap();
         let first = trades(&pool, Some(uid), None, 0, 1).await.unwrap();
         assert_eq!(first.len(), 1);
-        assert_eq!(first[0].slot, Some(42));
+        assert_eq!(first[0].slot, Some(43));
         let second = trades(&pool, Some(uid), None, 1, 1).await.unwrap();
         assert_eq!(second.len(), 1);
-        assert_eq!(second[0].slot, Some(43));
+        assert_eq!(second[0].slot, Some(42));
         assert!(
             trades(&pool, Some(uid), None, 2, 1)
                 .await

--- a/crates/solana-orderbook/src/infra/db.rs
+++ b/crates/solana-orderbook/src/infra/db.rs
@@ -68,14 +68,16 @@ pub struct TradeRow {
     pub slot: Option<i64>,
 }
 
-/// Trades filtered by order uid or owner. The slot comes from any settlement
-/// row of the transaction because the slot is constant per transaction. A
-/// trade whose order row is not indexed yet is omitted until the order
-/// lands.
+/// Trades filtered by order uid or owner, paged by `offset` and `limit`.
+/// The slot comes from any settlement row of the transaction because the
+/// slot is constant per transaction. A trade whose order row is not indexed
+/// yet is omitted until the order lands.
 pub async fn trades(
     ex: impl PgExecutor<'_>,
     order_uid: Option<[u8; 32]>,
     owner: Option<[u8; 32]>,
+    offset: i64,
+    limit: i64,
 ) -> Result<Vec<TradeRow>> {
     const QUERY: &str = r#"
 SELECT t.order_uid, o.owner, o.sell_token, o.buy_token,
@@ -91,10 +93,13 @@ LEFT JOIN LATERAL (
 WHERE ($1::bytea IS NULL OR t.order_uid = $1)
   AND ($2::bytea IS NULL OR o.owner = $2)
 ORDER BY s.slot, t.tx_signature, t.instruction_index, t.order_uid
+OFFSET $3 LIMIT $4
     "#;
     sqlx::query_as(QUERY)
         .bind(order_uid.map(ByteArray))
         .bind(owner.map(ByteArray))
+        .bind(offset)
+        .bind(limit)
         .fetch_all(ex)
         .await
         .context("read solana.trades")
@@ -259,17 +264,49 @@ VALUES ($1, $2, 400, CASE WHEN $3 THEN now() END)
         .await
         .unwrap();
 
-        let by_uid = trades(&pool, Some(uid), None).await.unwrap();
+        let by_uid = trades(&pool, Some(uid), None, 0, 10).await.unwrap();
         assert_eq!(by_uid.len(), 1);
         assert_eq!(by_uid[0].slot, Some(42));
         assert_eq!(by_uid[0].instruction_index, 1);
         assert_eq!(by_uid[0].sell_amount, BigDecimal::from(400));
 
-        let by_owner = trades(&pool, None, Some([0xAA; 32])).await.unwrap();
+        let by_owner = trades(&pool, None, Some([0xAA; 32]), 0, 10).await.unwrap();
         assert_eq!(by_owner.len(), 1);
 
         assert!(
-            trades(&pool, Some([0x99; 32]), None)
+            trades(&pool, Some([0x99; 32]), None, 0, 10)
+                .await
+                .unwrap()
+                .is_empty()
+        );
+
+        // A second fill of the same order pages: one row per page, ordered
+        // by slot, and an offset past the result set is empty.
+        sqlx::query(
+            "INSERT INTO solana.trades (tx_signature, instruction_index, order_uid,              \
+             sell_amount, buy_amount, fee_amount) VALUES ($1, 2, $2, 100, 50, 0)",
+        )
+        .bind(ByteArray([8u8; 64]))
+        .bind(ByteArray(uid))
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO solana.settlements (slot, tx_signature, instruction_index, solver,              auction_id) VALUES (43, $1, 2, $2, 8)",
+        )
+        .bind(ByteArray([8u8; 64]))
+        .bind(ByteArray([0xCC; 32]))
+        .execute(&pool)
+        .await
+        .unwrap();
+        let first = trades(&pool, Some(uid), None, 0, 1).await.unwrap();
+        assert_eq!(first.len(), 1);
+        assert_eq!(first[0].slot, Some(42));
+        let second = trades(&pool, Some(uid), None, 1, 1).await.unwrap();
+        assert_eq!(second.len(), 1);
+        assert_eq!(second[0].slot, Some(43));
+        assert!(
+            trades(&pool, Some(uid), None, 2, 1)
                 .await
                 .unwrap()
                 .is_empty()

--- a/crates/solana-orderbook/tests/api.rs
+++ b/crates/solana-orderbook/tests/api.rs
@@ -283,3 +283,23 @@ async fn quote_without_a_route_is_no_liquidity() {
         (reqwest::StatusCode::NOT_FOUND, "NoLiquidity")
     );
 }
+
+/// Parameter validation of the trades endpoint short-circuits before any
+/// database access.
+#[tokio::test]
+async fn trades_rejects_a_limit_out_of_bounds() {
+    let addr = spawn_server().await;
+    let uid = "11".repeat(32);
+    for limit in ["0", "1001"] {
+        let response = reqwest::Client::new()
+            .get(format!(
+                "http://{addr}/api/v1/trades?orderUid={uid}&limit={limit}"
+            ))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(response.status(), reqwest::StatusCode::BAD_REQUEST);
+        let json: serde_json::Value = response.json().await.unwrap();
+        assert_eq!(json["errorType"], "LIMIT_OUT_OF_BOUNDS");
+    }
+}

--- a/crates/solana-orderbook/tests/api.rs
+++ b/crates/solana-orderbook/tests/api.rs
@@ -287,7 +287,7 @@ async fn quote_without_a_route_is_no_liquidity() {
 /// Parameter validation of the trades endpoint short-circuits before any
 /// database access.
 #[tokio::test]
-async fn trades_rejects_a_limit_out_of_bounds() {
+async fn trades_rejects_an_invalid_limit() {
     let addr = spawn_server().await;
     let uid = "11".repeat(32);
     for limit in ["0", "1001"] {
@@ -300,6 +300,6 @@ async fn trades_rejects_a_limit_out_of_bounds() {
             .unwrap();
         assert_eq!(response.status(), reqwest::StatusCode::BAD_REQUEST);
         let json: serde_json::Value = response.json().await.unwrap();
-        assert_eq!(json["errorType"], "LIMIT_OUT_OF_BOUNDS");
+        assert_eq!(json["errorType"], "InvalidLimit");
     }
 }

--- a/crates/solana-orderbook/tests/api.rs
+++ b/crates/solana-orderbook/tests/api.rs
@@ -293,7 +293,7 @@ async fn trades_rejects_an_invalid_limit() {
     for limit in ["0", "1001"] {
         let response = reqwest::Client::new()
             .get(format!(
-                "http://{addr}/api/v1/trades?orderUid={uid}&limit={limit}"
+                "http://{addr}/api/v2/trades?orderUid={uid}&limit={limit}"
             ))
             .send()
             .await


### PR DESCRIPTION
# Description
EVM deprecated `/api/v1/trades` in favor of the paginated `/api/v2/trades`. The Solana trades route mirrored the deprecated shape: unpaginated, every fill of a busy owner in one response. Nobody has integrated it yet, so it moves straight to the v2 contract, `/api/v2/trades` with `offset` and `limit`, matching the EVM path and semantics.

# Changes
- The trades route moves to `GET /api/v2/trades` and accepts `offset` and `limit` with the EVM defaults and bounds (0 and 10, limit 1 to 1000), rejecting a bad limit with `InvalidLimit`
- The trades query pages in SQL and returns newest first, like EVM v2
- The openapi spec documents the new path and parameters

# How to test
Updated unit and database tests.