### PR TITLE
Adjust Rust caches in build job

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -93,9 +93,9 @@ jobs:
         with:
           cache-all-crates: true
           cache-workspace-crates: true
-          # Always use whatever cache was last build for main
+          # Always use whatever cache was last written for main
           shared-key: main
-          # Only update the cache if on main
+          # Only write to the cache if running on main
           save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build release binaries

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -93,10 +93,10 @@ jobs:
         with:
           cache-all-crates: true
           cache-workspace-crates: true
-          # shared-key is included in restore-key prefix matching, so it produces a
-          # branch-scoped fallback before falling back to any-branch caches.
-          # Restore order: same branch (most recent) → any branch (same Cargo.lock) → any branch.
-          shared-key: ${{ github.ref_name }}
+          # Always use whatever cache was last build for main
+          shared-key: main
+          # Only update the cache if on main
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Build release binaries
         run: |


### PR DESCRIPTION
# Description
Adjusts the build caching, using a central read-only (r/w only for main) cache instead of one per PR.

The previous caching behavior was wrong, the comment said `Restore order: same branch (most recent) → any branch (same Cargo.lock) → any branch.` but that's not/no longer true, at least not based on the pinned version of the cache job.

Right now, the caching appears to be prefix-based, and has no fallback, so the shared key means that we are actually only caching per branch.

With this change, we now cache only on main, but every branch can pull from main.

The `save-if` is also more important than it seems, because sure we could use some magic and create a prefix and get it to pull dynamically but the caches are so large and the artifact storage so small that we are often deleting the main cache just by running out of available storage (on GitHub).

"How bad is it", you may ask? Well, when I last checked the caches, the oldest was 12 minutes old, so caching was effectively useless unless you're iterating in <10m.

# Changes
* Switch to using a single shared-key
* Only save cache if running on main

## How to test
Run CI and see if it improves, very little impact other than potentially longer (but ideally shorter) workflow runs.