### PR TITLE
Log order uids through the solana auction and settle lifecycle

### DIFF
--- a/crates/autopilot-svm/src/infra/competition.rs
+++ b/crates/autopilot-svm/src/infra/competition.rs
@@ -89,25 +89,24 @@ impl SolverCompetition<SolanaCycle> for DriverCompetition {
                 }
                 match convert(driver_index, dto_solution, &by_uid) {
                     Ok(solution) => {
-                        for order in solution.inner.orders() {
-                            tracing::debug!(
-                                driver = %driver.name,
-                                solution = solution.inner.id(),
-                                order = %order.uid,
-                                "proposed solution"
-                            );
-                        }
+                        tracing::debug!(
+                            driver = %driver.name,
+                            solution = solution.inner.id(),
+                            orders = ?solution
+                                .inner
+                                .orders()
+                                .iter()
+                                .map(|order| order.uid.to_string())
+                                .collect::<Vec<_>>(),
+                            "proposed solution"
+                        );
                         solutions.push(solution);
                     }
-                    Err(uids) => {
-                        for uid in uids {
-                            tracing::warn!(
-                                driver = %driver.name,
-                                order = %uid,
-                                "solution names an order outside the auction, dropped"
-                            );
-                        }
-                    }
+                    Err(uids) => tracing::warn!(
+                        driver = %driver.name,
+                        orders = ?uids.iter().map(ToString::to_string).collect::<Vec<_>>(),
+                        "solution names orders outside the auction, dropped"
+                    ),
                 }
             }
         }

--- a/crates/autopilot-svm/src/infra/competition.rs
+++ b/crates/autopilot-svm/src/infra/competition.rs
@@ -89,24 +89,25 @@ impl SolverCompetition<SolanaCycle> for DriverCompetition {
                 }
                 match convert(driver_index, dto_solution, &by_uid) {
                     Ok(solution) => {
-                        tracing::debug!(
-                            driver = %driver.name,
-                            solution = solution.inner.id(),
-                            orders = ?solution
-                                .inner
-                                .orders()
-                                .iter()
-                                .map(|order| order.uid.to_string())
-                                .collect::<Vec<_>>(),
-                            "proposed solution"
-                        );
+                        for order in solution.inner.orders() {
+                            tracing::debug!(
+                                driver = %driver.name,
+                                solution = solution.inner.id(),
+                                order = %order.uid,
+                                "proposed solution"
+                            );
+                        }
                         solutions.push(solution);
                     }
-                    Err(uids) => tracing::warn!(
-                        driver = %driver.name,
-                        orders = ?uids.iter().map(ToString::to_string).collect::<Vec<_>>(),
-                        "solution names orders outside the auction, dropped"
-                    ),
+                    Err(uids) => {
+                        for uid in uids {
+                            tracing::warn!(
+                                driver = %driver.name,
+                                order = %uid,
+                                "solution names an order outside the auction, dropped"
+                            );
+                        }
+                    }
                 }
             }
         }

--- a/crates/autopilot-svm/src/infra/competition.rs
+++ b/crates/autopilot-svm/src/infra/competition.rs
@@ -88,9 +88,10 @@ impl SolverCompetition<SolanaCycle> for DriverCompetition {
                     continue;
                 }
                 match convert(driver_index, dto_solution, &by_uid) {
-                    Some(solution) => solutions.push(solution),
-                    None => tracing::warn!(
+                    Ok(solution) => solutions.push(solution),
+                    Err(uid) => tracing::warn!(
                         driver = %driver.name,
+                        order = %uid,
                         "solution names an order outside the auction, dropped"
                     ),
                 }
@@ -108,13 +109,13 @@ fn convert(
     driver_index: usize,
     dto_solution: dto::Solution,
     by_uid: &HashMap<IntentHash, &Order>,
-) -> Option<Solution> {
+) -> Result<Solution, IntentHash> {
     let orders = dto_solution
         .orders
         .iter()
         .map(|(uid, amounts)| {
-            let order = by_uid.get(uid)?;
-            Some(solution::Order::<Solana> {
+            let order = by_uid.get(uid).ok_or(*uid)?;
+            Ok(solution::Order::<Solana> {
                 uid: *uid,
                 sell_token: order.sell_token,
                 buy_token: order.buy_token,
@@ -128,8 +129,8 @@ fn convert(
                 },
             })
         })
-        .collect::<Option<Vec<_>>>()?;
-    Some(Solution {
+        .collect::<Result<Vec<_>, IntentHash>>()?;
+    Ok(Solution {
         driver_index,
         inner: solution::Solution::new(dto_solution.solution_id, dto_solution.solver, orders),
     })

--- a/crates/autopilot-svm/src/infra/competition.rs
+++ b/crates/autopilot-svm/src/infra/competition.rs
@@ -88,11 +88,24 @@ impl SolverCompetition<SolanaCycle> for DriverCompetition {
                     continue;
                 }
                 match convert(driver_index, dto_solution, &by_uid) {
-                    Ok(solution) => solutions.push(solution),
-                    Err(uid) => tracing::warn!(
+                    Ok(solution) => {
+                        tracing::debug!(
+                            driver = %driver.name,
+                            solution = solution.inner.id(),
+                            orders = ?solution
+                                .inner
+                                .orders()
+                                .iter()
+                                .map(|order| order.uid.to_string())
+                                .collect::<Vec<_>>(),
+                            "proposed solution"
+                        );
+                        solutions.push(solution);
+                    }
+                    Err(uids) => tracing::warn!(
                         driver = %driver.name,
-                        order = %uid,
-                        "solution names an order outside the auction, dropped"
+                        orders = ?uids.iter().map(ToString::to_string).collect::<Vec<_>>(),
+                        "solution names orders outside the auction, dropped"
                     ),
                 }
             }
@@ -109,13 +122,17 @@ fn convert(
     driver_index: usize,
     dto_solution: dto::Solution,
     by_uid: &HashMap<IntentHash, &Order>,
-) -> Result<Solution, IntentHash> {
-    let orders = dto_solution
+) -> Result<Solution, Vec<IntentHash>> {
+    let mut missing = Vec::new();
+    let orders: Vec<_> = dto_solution
         .orders
         .iter()
-        .map(|(uid, amounts)| {
-            let order = by_uid.get(uid).ok_or(*uid)?;
-            Ok(solution::Order::<Solana> {
+        .filter_map(|(uid, amounts)| {
+            let Some(order) = by_uid.get(uid) else {
+                missing.push(*uid);
+                return None;
+            };
+            Some(solution::Order::<Solana> {
                 uid: *uid,
                 sell_token: order.sell_token,
                 buy_token: order.buy_token,
@@ -129,7 +146,10 @@ fn convert(
                 },
             })
         })
-        .collect::<Result<Vec<_>, IntentHash>>()?;
+        .collect();
+    if !missing.is_empty() {
+        return Err(missing);
+    }
     Ok(Solution {
         driver_index,
         inner: solution::Solution::new(dto_solution.solution_id, dto_solution.solver, orders),

--- a/crates/autopilot-svm/src/infra/executor.rs
+++ b/crates/autopilot-svm/src/infra/executor.rs
@@ -42,6 +42,7 @@ impl SettlementExecutor<SolanaCycle> for DriverExecutor {
                 continue;
             };
             let driver = Arc::clone(driver);
+            tracing::info!(driver = %driver.name, solution = winner.id(), "winner");
             let request = dto::SettleRequest {
                 auction_id,
                 solution_id: winner.id(),

--- a/crates/autopilot-svm/src/infra/observer.rs
+++ b/crates/autopilot-svm/src/infra/observer.rs
@@ -77,6 +77,34 @@ impl SettlementObserver<crate::domain::cycle::SolanaCycle> for CompetitionObserv
             filtered_out = ranking.inner.filtered_out.len(),
             "competition ranked"
         );
+        for solution in ranking.inner.winners() {
+            let orders: Vec<String> = solution
+                .orders()
+                .iter()
+                .map(|o| o.uid.to_string())
+                .collect();
+            tracing::debug!(solution_id = solution.id(), ?orders, "winning solution");
+        }
+        for solution in ranking.inner.non_winners() {
+            let orders: Vec<String> = solution
+                .orders()
+                .iter()
+                .map(|o| o.uid.to_string())
+                .collect();
+            tracing::debug!(solution_id = solution.id(), ?orders, "non-winning solution");
+        }
+        for solution in &ranking.inner.filtered_out {
+            let orders: Vec<String> = solution
+                .orders()
+                .iter()
+                .map(|o| o.uid.to_string())
+                .collect();
+            tracing::debug!(
+                solution_id = solution.id(),
+                ?orders,
+                "filtered-out solution"
+            );
+        }
         Ok(())
     }
 

--- a/crates/autopilot-svm/src/infra/observer.rs
+++ b/crates/autopilot-svm/src/infra/observer.rs
@@ -77,34 +77,6 @@ impl SettlementObserver<crate::domain::cycle::SolanaCycle> for CompetitionObserv
             filtered_out = ranking.inner.filtered_out.len(),
             "competition ranked"
         );
-        for solution in ranking.inner.winners() {
-            let orders: Vec<String> = solution
-                .orders()
-                .iter()
-                .map(|o| o.uid.to_string())
-                .collect();
-            tracing::debug!(solution_id = solution.id(), ?orders, "winning solution");
-        }
-        for solution in ranking.inner.non_winners() {
-            let orders: Vec<String> = solution
-                .orders()
-                .iter()
-                .map(|o| o.uid.to_string())
-                .collect();
-            tracing::debug!(solution_id = solution.id(), ?orders, "non-winning solution");
-        }
-        for solution in &ranking.inner.filtered_out {
-            let orders: Vec<String> = solution
-                .orders()
-                .iter()
-                .map(|o| o.uid.to_string())
-                .collect();
-            tracing::debug!(
-                solution_id = solution.id(),
-                ?orders,
-                "filtered-out solution"
-            );
-        }
         Ok(())
     }
 

--- a/crates/autopilot-svm/src/infra/observer.rs
+++ b/crates/autopilot-svm/src/infra/observer.rs
@@ -46,12 +46,15 @@ impl CompetitionObserver {
 #[async_trait]
 impl SettlementObserver<crate::domain::cycle::SolanaCycle> for CompetitionObserver {
     fn on_orders_ready(&self, auction: &Auction) {
-        let uids: Vec<_> = auction.orders.iter().map(|order| order.uid).collect();
-        tracing::debug!(
-            orders = ?uids.iter().map(ToString::to_string).collect::<Vec<_>>(),
-            "auction entered competition"
+        tracing::info!(
+            auction_id = auction.id,
+            orders = auction.orders.len(),
+            "solving"
         );
-        self.store_events(uids, OrderEventLabel::Ready);
+        self.store_events(
+            auction.orders.iter().map(|order| order.uid).collect(),
+            OrderEventLabel::Ready,
+        );
     }
 
     async fn persist_competition_ranking(
@@ -79,8 +82,8 @@ impl SettlementObserver<crate::domain::cycle::SolanaCycle> for CompetitionObserv
 
     fn on_orders_matched(&self, executing: HashSet<IntentHash>, considered: HashSet<IntentHash>) {
         tracing::debug!(
-            executing = ?executing.iter().map(ToString::to_string).collect::<Vec<_>>(),
-            considered = ?considered.iter().map(ToString::to_string).collect::<Vec<_>>(),
+            executing = executing.len(),
+            considered = considered.len(),
             "orders matched"
         );
         self.store_events(executing.into_iter().collect(), OrderEventLabel::Executing);

--- a/crates/autopilot-svm/src/infra/observer.rs
+++ b/crates/autopilot-svm/src/infra/observer.rs
@@ -46,11 +46,12 @@ impl CompetitionObserver {
 #[async_trait]
 impl SettlementObserver<crate::domain::cycle::SolanaCycle> for CompetitionObserver {
     fn on_orders_ready(&self, auction: &Auction) {
-        tracing::debug!(orders = auction.orders.len(), "auction entered competition");
-        self.store_events(
-            auction.orders.iter().map(|order| order.uid).collect(),
-            OrderEventLabel::Ready,
+        let uids: Vec<_> = auction.orders.iter().map(|order| order.uid).collect();
+        tracing::debug!(
+            orders = ?uids.iter().map(ToString::to_string).collect::<Vec<_>>(),
+            "auction entered competition"
         );
+        self.store_events(uids, OrderEventLabel::Ready);
     }
 
     async fn persist_competition_ranking(
@@ -78,8 +79,8 @@ impl SettlementObserver<crate::domain::cycle::SolanaCycle> for CompetitionObserv
 
     fn on_orders_matched(&self, executing: HashSet<IntentHash>, considered: HashSet<IntentHash>) {
         tracing::debug!(
-            executing = executing.len(),
-            considered = considered.len(),
+            executing = ?executing.iter().map(ToString::to_string).collect::<Vec<_>>(),
+            considered = ?considered.iter().map(ToString::to_string).collect::<Vec<_>>(),
             "orders matched"
         );
         self.store_events(executing.into_iter().collect(), OrderEventLabel::Executing);

--- a/crates/autopilot-svm/src/infra/observer.rs
+++ b/crates/autopilot-svm/src/infra/observer.rs
@@ -51,6 +51,9 @@ impl SettlementObserver<crate::domain::cycle::SolanaCycle> for CompetitionObserv
             orders = auction.orders.len(),
             "solving"
         );
+        for order in &auction.orders {
+            tracing::debug!(auction_id = auction.id, order = %order.uid, "order in auction");
+        }
         self.store_events(
             auction.orders.iter().map(|order| order.uid).collect(),
             OrderEventLabel::Ready,

--- a/crates/solana-driver/src/domain/competition.rs
+++ b/crates/solana-driver/src/domain/competition.rs
@@ -183,6 +183,10 @@ impl Competition {
         let program_id = self.blockchain.program_id();
 
         let orders = orders_with_trades(auction.orders.clone(), &solution);
+        tracing::debug!(
+            orders = ?orders.iter().map(|order| order.uid.to_string()).collect::<Vec<_>>(),
+            "settling orders"
+        );
 
         let settlement = super::Settlement::new(program_id, auction_id, orders, solution)?;
 

--- a/crates/solana-driver/src/domain/competition.rs
+++ b/crates/solana-driver/src/domain/competition.rs
@@ -135,12 +135,7 @@ impl Competition {
                 }
                 result
             }
-            .instrument(tracing::info_span!(
-                "settle",
-                ?auction_id,
-                solution_id,
-                orders = tracing::field::Empty
-            )),
+            .instrument(tracing::info_span!("settle", ?auction_id, solution_id)),
         );
         task.await.unwrap_or_else(|error| {
             tracing::error!(?error, "settle task panicked");
@@ -188,15 +183,9 @@ impl Competition {
         let program_id = self.blockchain.program_id();
 
         let orders = orders_with_trades(auction.orders.clone(), &solution);
-        tracing::Span::current().record(
-            "orders",
-            tracing::field::debug(
-                orders
-                    .iter()
-                    .map(|order| order.uid.to_string())
-                    .collect::<Vec<_>>(),
-            ),
-        );
+        for order in &orders {
+            tracing::debug!(order = %order.uid, "settling order");
+        }
 
         let settlement = super::Settlement::new(program_id, auction_id, orders, solution)?;
 

--- a/crates/solana-driver/src/domain/competition.rs
+++ b/crates/solana-driver/src/domain/competition.rs
@@ -135,7 +135,12 @@ impl Competition {
                 }
                 result
             }
-            .instrument(tracing::Span::current()),
+            .instrument(tracing::info_span!(
+                "settle",
+                ?auction_id,
+                solution_id,
+                orders = tracing::field::Empty
+            )),
         );
         task.await.unwrap_or_else(|error| {
             tracing::error!(?error, "settle task panicked");
@@ -183,9 +188,14 @@ impl Competition {
         let program_id = self.blockchain.program_id();
 
         let orders = orders_with_trades(auction.orders.clone(), &solution);
-        tracing::debug!(
-            orders = ?orders.iter().map(|order| order.uid.to_string()).collect::<Vec<_>>(),
-            "settling orders"
+        tracing::Span::current().record(
+            "orders",
+            tracing::field::debug(
+                orders
+                    .iter()
+                    .map(|order| order.uid.to_string())
+                    .collect::<Vec<_>>(),
+            ),
         );
 
         let settlement = super::Settlement::new(program_id, auction_id, orders, solution)?;

--- a/crates/solana-driver/src/domain/competition.rs
+++ b/crates/solana-driver/src/domain/competition.rs
@@ -183,9 +183,10 @@ impl Competition {
         let program_id = self.blockchain.program_id();
 
         let orders = orders_with_trades(auction.orders.clone(), &solution);
-        for order in &orders {
-            tracing::debug!(order = %order.uid, "settling order");
-        }
+        tracing::debug!(
+            orders = ?orders.iter().map(|order| order.uid.to_string()).collect::<Vec<_>>(),
+            "settling orders"
+        );
 
         let settlement = super::Settlement::new(program_id, auction_id, orders, solution)?;
 

--- a/crates/solana-indexer/src/persistence.rs
+++ b/crates/solana-indexer/src/persistence.rs
@@ -147,6 +147,7 @@ ON CONFLICT (uid) DO NOTHING
         .await?
         .rows_affected();
         if inserted > 0 {
+            tracing::debug!(order_uid = %order.order_uid, "indexed order");
             Self::insert_order_event(tx, order.order_uid.0, OrderEventLabel::Created).await?;
         }
         Ok(())

--- a/crates/solana-solvers/src/domain/solver/mod.rs
+++ b/crates/solana-solvers/src/domain/solver/mod.rs
@@ -58,7 +58,7 @@ pub async fn solve<Q: Quote>(quoter: &Q, auction: &Auction) -> Vec<Solution> {
             tracing::debug!("solved");
             Some(solution)
         }
-        .instrument(tracing::info_span!("solve", order = %order.uid))
+        .instrument(tracing::info_span!("solve", auction_id = ?auction.id, order = %order.uid))
     });
     join_all(candidates).await.into_iter().flatten().collect()
 }

--- a/crates/solana-solvers/src/domain/solver/mod.rs
+++ b/crates/solana-solvers/src/domain/solver/mod.rs
@@ -41,7 +41,6 @@ impl Quote for Dex {
 /// TODO: Enforce `auction.deadline` with a timeout, like the EVM dex solver
 /// does (`crates/solvers/src/domain/solver/dex/mod.rs`).
 pub async fn solve<Q: Quote>(quoter: &Q, auction: &Auction) -> Vec<Solution> {
-    tracing::debug!(auction_id = ?auction.id, orders = auction.orders.len(), "solving auction");
     let candidates = auction.orders.iter().enumerate().map(|(index, order)| {
         let dex_order = order.to_dex_order();
         async move {
@@ -50,20 +49,18 @@ pub async fn solve<Q: Quote>(quoter: &Q, auction: &Auction) -> Vec<Solution> {
                 .await
                 .inspect_err(|err| match err {
                     dex::jupiter::Error::NotFound | dex::jupiter::Error::OrderNotSupported => {
-                        tracing::debug!(%err, "no swap for order")
+                        tracing::debug!("no solution for swap")
                     }
                     _ => tracing::warn!(%err, "quote failed"),
                 })
                 .ok()?;
             let solution = Solution::new(index as u64, order.uid, &dex_order, swap).ok()?;
-            tracing::debug!("solved order");
+            tracing::debug!("solved");
             Some(solution)
         }
         .instrument(tracing::info_span!("solve", order = %order.uid))
     });
-    let solutions: Vec<Solution> = join_all(candidates).await.into_iter().flatten().collect();
-    tracing::debug!(auction_id = ?auction.id, solved = solutions.len(), "solved auction");
-    solutions
+    join_all(candidates).await.into_iter().flatten().collect()
 }
 
 #[cfg(test)]

--- a/crates/solana-solvers/src/domain/solver/mod.rs
+++ b/crates/solana-solvers/src/domain/solver/mod.rs
@@ -8,6 +8,7 @@ use {
     futures::future::join_all,
     solana_sdk::pubkey::Pubkey,
     std::future::Future,
+    tracing::Instrument,
 };
 
 /// Quotes one order into a swap. A seam over [`Dex`] so the loop is testable
@@ -40,6 +41,7 @@ impl Quote for Dex {
 /// TODO: Enforce `auction.deadline` with a timeout, like the EVM dex solver
 /// does (`crates/solvers/src/domain/solver/dex/mod.rs`).
 pub async fn solve<Q: Quote>(quoter: &Q, auction: &Auction) -> Vec<Solution> {
+    tracing::debug!(auction_id = ?auction.id, orders = auction.orders.len(), "solving auction");
     let candidates = auction.orders.iter().enumerate().map(|(index, order)| {
         let dex_order = order.to_dex_order();
         async move {
@@ -48,15 +50,20 @@ pub async fn solve<Q: Quote>(quoter: &Q, auction: &Auction) -> Vec<Solution> {
                 .await
                 .inspect_err(|err| match err {
                     dex::jupiter::Error::NotFound | dex::jupiter::Error::OrderNotSupported => {
-                        tracing::debug!(order = %order.uid, %err, "no swap for order")
+                        tracing::debug!(%err, "no swap for order")
                     }
-                    _ => tracing::warn!(order = %order.uid, %err, "quote failed"),
+                    _ => tracing::warn!(%err, "quote failed"),
                 })
                 .ok()?;
-            Solution::new(index as u64, order.uid, &dex_order, swap).ok()
+            let solution = Solution::new(index as u64, order.uid, &dex_order, swap).ok()?;
+            tracing::debug!("solved order");
+            Some(solution)
         }
+        .instrument(tracing::info_span!("solve", order = %order.uid))
     });
-    join_all(candidates).await.into_iter().flatten().collect()
+    let solutions: Vec<Solution> = join_all(candidates).await.into_iter().flatten().collect();
+    tracing::debug!(auction_id = ?auction.id, solved = solutions.len(), "solved auction");
+    solutions
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Description
Right now the solana services log order UIDs only when something fails (a swallowed quote, a dead-letter), and the driver logs none at all. A normally-flowing order, or one stuck at settlement, leaves no UID trace, so you cannot follow an order through the logs by its UID the way you can on EVM. A partner hit this recently: they searched their order UID and found only the ingress request.

# Changes
- Autopilot logs the order UIDs when an auction enters competition and when orders are matched
- Driver logs the order UIDs it is about to settle

# How to test
Existing tests. On staging, grep an order UID and confirm it appears at "auction entered competition", "orders matched", and "settling orders".

# Related issues
BE-266