### PR TITLE
solana-driver: temporary per-solver auction participation stride

### DIFF
--- a/crates/solana-driver/example.toml
+++ b/crates/solana-driver/example.toml
@@ -23,4 +23,8 @@ endpoint = "http://localhost:8001"
 # identity for this solver is derived from this keypair.
 # TODO: plaintext keypair paths are temporary; KMS is planned.
 signer-keypair = "/path/to/keypair.json"
+# Temporary staging knob: solve only auctions whose id is a multiple of this
+# value, sitting the rest out so other solvers win settlements to test
+# against. Omit to participate in every auction.
+# solve-every-nth-auction = 5
 max-in-flight = 1

--- a/crates/solana-driver/src/infra/api/mod.rs
+++ b/crates/solana-driver/src/infra/api/mod.rs
@@ -7,7 +7,7 @@ use {
     },
     axum::{Router, extract::DefaultBodyLimit, routing::get},
     observe::tracing::distributed::axum::{make_span, record_trace_id},
-    std::{net::SocketAddr, sync::Arc},
+    std::{net::SocketAddr, num::NonZero, sync::Arc},
     tokio_util::sync::CancellationToken,
     tower::ServiceBuilder,
     tower_http::{decompression::RequestDecompressionLayer, trace::TraceLayer},
@@ -60,8 +60,9 @@ impl Api {
         // Mount one router per solver engine under `/{solver_name}`.
         for solver in self.solvers {
             let solver_name = solver.name().to_owned();
+            let solve_every_nth_auction = solver.solve_every_nth_auction();
             let competition = domain::Competition::new(solver, self.blockchain.clone());
-            let state = State::new(competition);
+            let state = State::new(competition, solve_every_nth_auction);
 
             let router = Router::new()
                 .route("/quote", axum::routing::post(routes::quote))
@@ -93,9 +94,13 @@ pub(crate) struct State(Arc<Inner>);
 
 impl State {
     /// Build the shared state the handlers operate on.
-    fn new(competition: domain::Competition) -> Self {
+    fn new(
+        competition: domain::Competition,
+        solve_every_nth_auction: Option<NonZero<u64>>,
+    ) -> Self {
         Self(Arc::new(Inner {
             competition: Arc::new(competition),
+            solve_every_nth_auction,
         }))
     }
 
@@ -103,9 +108,16 @@ impl State {
     fn competition(&self) -> &Arc<domain::Competition> {
         &self.0.competition
     }
+
+    /// The auction-id stride this solver participates at, when throttled.
+    pub(crate) fn solve_every_nth_auction(&self) -> Option<NonZero<u64>> {
+        self.0.solve_every_nth_auction
+    }
 }
 
 struct Inner {
     /// The competition that runs auctions for this solver engine.
     competition: Arc<domain::Competition>,
+    /// The auction-id stride this solver participates at, when throttled.
+    solve_every_nth_auction: Option<NonZero<u64>>,
 }

--- a/crates/solana-driver/src/infra/api/routes/solve/mod.rs
+++ b/crates/solana-driver/src/infra/api/routes/solve/mod.rs
@@ -15,6 +15,15 @@ pub(crate) async fn solve(
 ) -> Result<Json<dto::SolveResponse>, (StatusCode, Json<ApiError>)> {
     let auction = request.into_domain()?;
     let auction_id = auction.id.ok_or(dto::AuctionError::InvalidAuctionId)?;
+    // Temporary staging knob: sit out auctions off the configured stride so
+    // other solvers win settlements to test against.
+    if let Some(stride) = state.solve_every_nth_auction() {
+        let id = u64::try_from(auction_id.get()).expect("auction ids are positive");
+        if id % stride.get() != 0 {
+            tracing::debug!(%auction_id, %stride, "sitting out the auction");
+            return Ok(Json(dto::SolveResponse::new(Vec::new())));
+        }
+    }
     let solutions = state
         .competition()
         .solve(auction_id, &auction)

--- a/crates/solana-driver/src/infra/config.rs
+++ b/crates/solana-driver/src/infra/config.rs
@@ -126,6 +126,11 @@ pub struct Solver {
     pub signer_keypair: PathBuf,
     /// Maximum number of concurrent solve requests kept in flight per solver.
     pub max_in_flight: NonZero<usize>,
+    /// Temporary staging knob: solve only auctions whose id is a multiple of
+    /// this value and sit the rest out, so other solvers win settlements to
+    /// test against. Absent means every auction.
+    #[serde(default)]
+    pub solve_every_nth_auction: Option<NonZero<u64>>,
 }
 
 #[cfg(test)]

--- a/crates/solana-driver/src/infra/solver/mod.rs
+++ b/crates/solana-driver/src/infra/solver/mod.rs
@@ -13,7 +13,7 @@ use {
         pubkey::Pubkey,
         signer::{Signer, keypair::Keypair},
     },
-    std::sync::Arc,
+    std::{num::NonZero, sync::Arc},
     thiserror::Error,
     tokio::sync::Semaphore,
 };
@@ -28,6 +28,7 @@ pub struct Solver {
     client: reqwest::Client,
     base_url: reqwest::Url,
     in_flight: Arc<Semaphore>,
+    solve_every_nth_auction: Option<NonZero<u64>>,
 }
 
 impl Solver {
@@ -44,6 +45,11 @@ impl Solver {
     /// The solver's settlement signer keypair.
     pub(crate) fn keypair(&self) -> &Keypair {
         &self.keypair
+    }
+
+    /// The auction-id stride this solver participates at, when throttled.
+    pub fn solve_every_nth_auction(&self) -> Option<NonZero<u64>> {
+        self.solve_every_nth_auction
     }
 
     /// Build a solver client from its configuration.
@@ -68,6 +74,7 @@ impl Solver {
             client: reqwest::Client::new(),
             base_url: config.endpoint.clone(),
             in_flight: Arc::new(Semaphore::new(config.max_in_flight.get())),
+            solve_every_nth_auction: config.solve_every_nth_auction,
         })
     }
 
@@ -181,6 +188,7 @@ mod tests {
             endpoint: "http://127.0.0.1:1".parse().unwrap(),
             signer_keypair: keypair_path,
             max_in_flight: NonZero::new(1).unwrap(),
+            solve_every_nth_auction: None,
         })
         .expect("solver construction should succeed");
         let auction = domain::Auction {

--- a/crates/solana-driver/tests/api.rs
+++ b/crates/solana-driver/tests/api.rs
@@ -98,6 +98,7 @@ fn solver_with_keypair(addr: SocketAddr) -> (Solver, Pubkey) {
         endpoint: format!("http://{addr}").parse().unwrap(),
         signer_keypair: keypair_path,
         max_in_flight: NonZero::new(1).unwrap(),
+        solve_every_nth_auction: None,
     })
     .expect("solver construction should succeed");
     let account = solver.pubkey();
@@ -107,6 +108,19 @@ fn solver_with_keypair(addr: SocketAddr) -> (Solver, Pubkey) {
 /// A solver client pointing at a dead endpoint (no listener).
 fn dead_solver() -> (Solver, Pubkey) {
     solver_with_keypair("127.0.0.1:1".parse().unwrap())
+}
+
+/// A dead-endpoint solver throttled to the given auction-id stride.
+fn throttled_dead_solver(stride: u64) -> Solver {
+    let keypair_file = temp_keypair();
+    Solver::new(&config::Solver {
+        name: "mock".to_owned(),
+        endpoint: "http://127.0.0.1:1".parse().unwrap(),
+        signer_keypair: keypair_file.path().to_path_buf(),
+        max_in_flight: NonZero::new(1).unwrap(),
+        solve_every_nth_auction: NonZero::new(stride),
+    })
+    .expect("solver construction should succeed")
 }
 
 fn order_pda() -> Pubkey {
@@ -564,4 +578,28 @@ async fn quoting_does_not_populate_the_settle_cache() {
     assert_eq!(response.status(), reqwest::StatusCode::BAD_REQUEST);
     let json: serde_json::Value = response.json().await.unwrap();
     assert_eq!(json["kind"], "SolutionNotAvailable");
+}
+
+/// A throttled solver only participates in auctions on its id stride: off
+/// the stride the driver answers an empty solution set without asking the
+/// engine, on the stride the request reaches the (dead) engine.
+#[tokio::test]
+async fn solve_sits_out_auctions_off_the_participation_stride() {
+    // Auction id 7 with stride 2: sat out, the dead engine is never asked.
+    let addr = spawn_server(vec![throttled_dead_solver(2)]).await;
+    let body = call_solve(addr).await;
+    assert_eq!(body["solutions"].as_array().unwrap().len(), 0);
+
+    // Stride 7 matches auction id 7: the request reaches the dead engine
+    // and fails, proving participation.
+    let addr = spawn_server(vec![throttled_dead_solver(7)]).await;
+    let response = reqwest::Client::new()
+        .post(format!("http://{addr}/mock/solve"))
+        .json(&solve_request())
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), reqwest::StatusCode::BAD_REQUEST);
+    let body: serde_json::Value = response.json().await.unwrap();
+    assert_eq!(body["kind"], "SolverFailed");
 }

--- a/crates/solana-driver/tests/jupiter_live.rs
+++ b/crates/solana-driver/tests/jupiter_live.rs
@@ -124,6 +124,7 @@ async fn driver_solves_against_live_jupiter_engine() {
         endpoint: format!("http://{addr}").parse().unwrap(),
         signer_keypair: keypair_path,
         max_in_flight: std::num::NonZero::new(1).unwrap(),
+        solve_every_nth_auction: None,
     })
     .expect("solver construction should succeed");
 

--- a/crates/solana-driver/tests/settle_devnet.rs
+++ b/crates/solana-driver/tests/settle_devnet.rs
@@ -371,6 +371,7 @@ async fn spawn_driver(
                 endpoint,
                 signer_keypair: s.signer_keypair,
                 max_in_flight: s.max_in_flight,
+                solve_every_nth_auction: None,
             })
         })
         .collect::<Result<_, _>>()

--- a/crates/solana-driver/tests/settle_mainnet.rs
+++ b/crates/solana-driver/tests/settle_mainnet.rs
@@ -266,6 +266,7 @@ async fn spawn_driver(
                 endpoint,
                 signer_keypair: s.signer_keypair,
                 max_in_flight: s.max_in_flight,
+                solve_every_nth_auction: None,
             })
         })
         .collect::<Result<_, _>>()


### PR DESCRIPTION
# Description
On staging one engine wins nearly every auction, so other solver teams cannot exercise their settlement paths. This adds a temporary per-solver knob to the Solana driver: with `solve-every-nth-auction = N` the engine participates only in auctions whose id is a multiple of N, and the driver answers every other auction with an empty solution set before the engine is asked. The knob lives in the driver so whichever engine starts dominating next can be throttled by config alone.

# Changes
- `solve-every-nth-auction` on each `[[solvers]]` entry, absent means every auction
- The solve route answers off-stride auctions with an empty solution set, quoting and settling stay untouched

# How to test
New driver API test.
